### PR TITLE
Support for DateTime in CsvProvider

### DIFF
--- a/samples/CsvProvider.fsx
+++ b/samples/CsvProvider.fsx
@@ -54,6 +54,11 @@ let wc = new WebClient()
 let data = wc.DownloadString("http://ichart.finance.yahoo.com/table.csv?s=MSFT")
 let msft = Stocks.Parse(data)
 
+
+let firstRow = msft.Data |> Seq.head
+// Note that the return type is DateTime
+let quoteDate = firstRow.Date
+
 // Print the prices in the HLOC format
 for row in msft.Data do
   printfn "HLOC: (%A, %A, %A, %A)" row.High row.Low row.Open row.Close
@@ -78,7 +83,7 @@ open System
 open Samples.FSharp.Charting
 
 // Visualize the stock prices
-[ for row in msft.Data -> DateTime.Parse(row.Date), row.Open ]
+[ for row in msft.Data -> row.Date, row.Open ]
 |> Chart.FastLine
 
 (**
@@ -89,9 +94,8 @@ data over the last month:
 // Get last months' prices in HLOC format 
 let recent = 
   [ for row in msft.Data do
-      let dt = DateTime.Parse(row.Date)
-      if dt > DateTime.Now.AddDays(-30.0) then
-        yield dt, row.High, row.Low, row.Open, row.Close ]
+      if row.Date > DateTime.Now.AddDays(-30.0) then
+        yield row.Date, row.High, row.Low, row.Open, row.Close ]
 
 // Visualize prices using Candlestick chart
 Chart.Candlestick(recent).AndYAxis(Max = 30.0, Min = 25.0)
@@ -103,7 +107,7 @@ Another interesting feature of the CSV type provider is that it supports F# unit
 If the header includes the name of one of the standard SI units, then the generated type
 returns values annotated with the appropriate unit. 
 
-In this section, we use a simple file [`docs/SimpleTest.csv`](docs/SimpleTest.csv) which
+In this section, we use a simple file [`docs/SmallTest.csv`](docs/SmallTest.csv) which
 looks as follows:
 
     Name,  Distance (metre), Time (second)
@@ -111,7 +115,7 @@ looks as follows:
 
 As you can see, the second and third columns are annotated with `metre` and `second`,
 respectively. To use units of measure in our code, we need to open the namespace with
-standard unit names. Then we pass the `SampleTesxt.csv` file to the type provider as
+standard unit names. Then we pass the `SmallTest.csv` file to the type provider as
 a static argument and load the same file (at runtime):
 *)
 open Microsoft.FSharp.Data.UnitSystems.SI.UnitNames
@@ -133,7 +137,7 @@ for row in small.Data do
 
 (**
 The numerical values of `Distance` and `Time` are both inferred as `decimal` (because they
-are small enough). Thus the type of `speed` becmes `decimal<meter/second>`. The compiler
+are small enough). Thus the type of `speed` becomes `decimal<meter/second>`. The compiler
 can then statically check that we're not comparing incompatible values - e.g. number in
 meters per second against a value in kilometers per hour.
 

--- a/src/Providers/Helpers.fs
+++ b/src/Providers/Helpers.fs
@@ -135,6 +135,8 @@ module Conversions =
   type Operations =
     // Operations that convert string to supported primitive types
     static member ConvertString = Option.map (fun (s:string) -> s)
+    static member ConvertDateTime = Option.bind (fun s -> 
+      DateTime.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.None) |> asOption)
     static member ConvertInteger = Option.bind (fun s -> 
       Int32.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture) |> asOption)
     static member ConvertInteger64 = Option.bind (fun s -> 
@@ -154,6 +156,7 @@ module Conversions =
       match opt with 
       | Some v -> v
       | None when typeof<'T> = typeof<string> -> Unchecked.defaultof<'T>
+      | None when typeof<'T> = typeof<DateTime> -> Unchecked.defaultof<'T>
       | _ -> failwithf "Mismatch: %s is missing" name
 
   /// Creates a function that takes Expr<string option> and converts it to 
@@ -168,6 +171,7 @@ module Conversions =
         elif typ = typeof<float> then <@@ Operations.ConvertFloat(%%e) @@>
         elif typ = typeof<string> then <@@ Operations.ConvertString(%%e) @@>
         elif typ = typeof<bool> then <@@ Operations.ConvertBoolean(%%e) @@>
+        elif typ = typeof<DateTime> then <@@ Operations.ConvertDateTime(%%e) @@>
         else failwith "convertValue: Unsupported primitive type"
       if not optional then 
         ReflectionHelpers.makeMethodCall typeof<Operations> "GetNonOptionalAttribute"

--- a/src/Providers/StructureInference.fs
+++ b/src/Providers/StructureInference.fs
@@ -35,6 +35,7 @@ and [<RequireQualifiedAccess>] InferedTypeTag =
   | Number 
   | Boolean
   | String
+  | DateTime
   // Collections and sum types
   | Collection 
   | Heterogeneous
@@ -73,6 +74,7 @@ type InferedTypeTag with
     | Number -> "Number"
     | Boolean -> "Boolean"
     | String -> "String"
+    | DateTime -> "DateTime"
     | Collection -> "Array"
     | Heterogeneous -> "Choice"
     | Record None -> "Record"
@@ -91,6 +93,7 @@ type InferedTypeTag with
     | "Number" -> Number 
     | "Boolean" -> Boolean
     | "String" -> String 
+    | "DateTime" -> DateTime
     | "Array" -> Collection
     | "Choice" -> Heterogeneous
     | _ -> failwith "Invalid InferredTypeTag code"
@@ -101,11 +104,11 @@ type InferedTypeTag with
 /// (with names that are returned for heterogeneous types)
 let primitiveTypes =
   [ typeof<int>; typeof<int64>; typeof<float>; 
-    typeof<decimal>; typeof<bool>; typeof<string> ]
+    typeof<decimal>; typeof<bool>; typeof<string> ; typeof<DateTime>]
 
 /// Checks whether a value is a value type (and cannot have null as a value)
 let isValueType = function
-  | Primitive(typ, _) -> typ <> typeof<string>
+  | Primitive(typ, _) -> typ <> typeof<string> || typ <> typeof<DateTime>
   | _ -> true
 
 /// Returns a tag of a type - a tag represents a 'kind' of type 
@@ -120,6 +123,7 @@ let typeTag = function
         then InferedTypeTag.Number
       elif typ = typeof<bool> then InferedTypeTag.Boolean
       elif typ = typeof<string> then InferedTypeTag.String
+      elif typ = typeof<DateTime> then InferedTypeTag.DateTime
       else failwith "inferCollectionType: Unknown primitive type"
 
 /// Find common subtype of two primitive types or `Bottom` if there is no such type.
@@ -270,4 +274,5 @@ let inferPrimitiveType value unit =
   | Parse Int64.TryParse _ -> Primitive(typeof<int64>, unit)
   | Parse Decimal.TryParse _ -> Primitive(typeof<decimal>, unit)
   | Parse Double.TryParse _ -> Primitive(typeof<float>, unit)
+  | Parse DateTime.TryParse _ -> Primitive(typeof<DateTime>, unit)
   | _ -> Primitive(typeof<string>, unit)

--- a/tests/Providers.Inference.fs
+++ b/tests/Providers.Inference.fs
@@ -8,6 +8,7 @@ namespace FSharp.Data.Tests
 #r "../bin/FSharp.Data.dll"
 #endif
 
+open System
 open FSharp.Data.Json
 open NUnit.Framework
 open ProviderImplementation
@@ -153,3 +154,28 @@ module ProviderInference =
       |> Map.ofSeq |> Collection
     let actual = JsonInference.inferType source
     Assert.AreEqual(expected, actual)
+
+  [<Test>]
+  let ``Inference of DateTime``() = 
+      let source = CsvFile.Parse "date,int,float\n2012-12-19,2,3.0\n2012-12-12,4,5.0\n2012-12-1,6,10.0"
+      let actual = CsvInference.inferType source Int32.MaxValue
+      let propDate = { Name = "date"; Optional = false; Type = Primitive(typeof<DateTime>, None) }
+      let propInt = { Name = "int"; Optional = false; Type = Primitive(typeof<int>, None) }
+      let propFloat = { Name = "float"; Optional = false; Type = Primitive(typeof<Decimal>, None) }
+      let expected = 
+        [ InferedTypeTag.Record None, 
+          (Multiple, Record(None, [ propDate ; propInt ; propFloat ])) ]
+        |> Map.ofSeq |> Collection
+      Assert.AreEqual(expected, actual)
+
+  [<Test>]
+  let ``Inference of DateTime with timestamp``() = 
+      let source = CsvFile.Parse "date,timestamp\n2012-12-19,2012-12-19 12:00\n2012-12-12,2012-12-12 00:00\n2012-12-1,2012-12-1 07:00"
+      let actual = CsvInference.inferType source Int32.MaxValue
+      let propDate = { Name = "date"; Optional = false; Type = Primitive(typeof<DateTime>, None) }
+      let propTimestamp = { Name = "timestamp"; Optional = false; Type = Primitive(typeof<DateTime>, None) }
+      let expected = 
+        [ InferedTypeTag.Record None, 
+          (Multiple, Record(None, [ propDate ; propTimestamp ])) ]
+        |> Map.ofSeq |> Collection
+      Assert.AreEqual(expected, actual)


### PR DESCRIPTION
The CsvProvider now supports parsing data with dates to native type
DateTime. Test cases added.
