### PR TITLE
Small improvement to JsonValue api

### DIFF
--- a/src/Common/Json.fs
+++ b/src/Common/Json.fs
@@ -338,6 +338,9 @@ module Extensions =
     member x.Item
       with get(index) = (JsonValue.asArray x).[index]
 
+    member x.Item
+      with get(propertName) = JsonValue.getProperty propertName x
+
     /// Get all elements of a JSON object (assuming that the value is an array)
     member x.GetEnumerator() = (JsonValue.asArray x :> seq<_>).GetEnumerator()
 

--- a/src/WorldBankProvider/WorldBankRuntime.fs
+++ b/src/WorldBankProvider/WorldBankRuntime.fs
@@ -135,12 +135,12 @@ module Implementation =
                                 yield ind?code.AsString,
                                       ind?name.AsString ] }
 
-        let getData funcs args key = 
+        let getData funcs args (key:string) = 
             async { let! docs = getDocuments funcs args 1 1
                     return
                         [ for doc in docs do
                             for ind in doc.[1] do
-                                yield ind |> JsonValue.getProperty key |> JsonValue.asString,
+                                yield ind.[key].AsString,
                                       ind?value.AsString ] }
 
         /// At compile time, download the schema


### PR DESCRIPTION
Adds a new indexer `jsonValue.[propertName]` for the cases where `?` does not apply because the propertyName is not a constant.
Allows to change `ind |> JsonValue.getProperty key |> JsonValue.asString` to `ind.[key].AsString` in WorldBankRuntime.fs
