### PR TITLE
Be more conservative when recognizing dates

### DIFF
--- a/src/Providers/StructureInference.fs
+++ b/src/Providers/StructureInference.fs
@@ -230,5 +230,7 @@ let inferPrimitiveType culture (value : string) unit =
         | Parse Operations.AsInteger64 _ -> Primitive(typeof<int64>, unit)
         | Parse Operations.AsDecimal _ -> Primitive(typeof<decimal>, unit)
         | Parse Operations.AsFloat _ -> Primitive(typeof<float>, unit)
-        | Parse Operations.AsDateTime _ -> Primitive(typeof<DateTime>, unit)
+        | Parse Operations.AsDateTime _ 
+            // if this can be considered a decimal under the invariant culture, it's a safer bet to consider it a string than a datetime
+            when Operations.AsDecimal CultureInfo.InvariantCulture value = None -> Primitive(typeof<DateTime>, unit)
         | _ -> Primitive(typeof<string>, unit)


### PR DESCRIPTION
Only in the inference, if AsDateTime is called explicitely on a JsonValue, still allow the cast
Minimizes the weirdness of #49
