### PR TITLE
Performance Improvement

### DIFF
--- a/src/CsvProvider/CsvInference.fs
+++ b/src/CsvProvider/CsvInference.fs
@@ -25,7 +25,7 @@ let headerRegex = new Regex(@"(?<field>.+) \((?<unit>.+)\)", regexOptions)
 let inferFields (csv:CsvFile) count culture =
   
   // Infer the units and names from the headers
-  let headers = csv.Headers |> Seq.map (fun header ->
+  let headers = csv.Headers |> Array.map (fun header ->
     let m = headerRegex.Match(header)
     if m.Success then
       let headerName = m.Groups.["field"].Value


### PR DESCRIPTION
Seq.zip will enumerate the headers for each row, which will repeat the regex matching. Freeze the computation by using Array.map instead of Seq.map

PS: the change is only to change Seq.map to Array.map on line 28, for some reason github is showing line ending differences on the whole file
