### PR TITLE
Http.Request Improvements

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,3 +14,4 @@
 * 1.1.1 - Update WorldBank internals to support more efficient implementation and FunScript.
 * 1.1.2 - Update NuGet package links and icon reference.
 * 1.1.3 - Improve Units of Measure support and allow to override the type inference in the CSV Provider.
+* 1.1.4 - Improvements to FSharp.Net.Http to support cookies and binary files.

--- a/samples/library/Http.fsx
+++ b/samples/library/Http.fsx
@@ -42,15 +42,13 @@ the use of `AsyncRequest` is exactly the same.
 
 ## Query parameters and headers
 
-If you use the GET method, you can specify query parameters either by constructing
+You can specify query parameters either by constructing
 a URL that includes the parameters (e.g. `http://...?test=foo&more=bar`) or you
 can pass them using the optional parameter `query`. The following example also explicitly
-specifies the GET method (which is the default option):
+specifies the GET method, but it will be set automatically for you if you omit it:
 *)
 
-Http.Request
-  ( "http://httpbin.org/get", 
-    query = ["test", "foo"], meth="GET")
+Http.Request("http://httpbin.org/get", query=["test", "foo"], meth="GET")
 
 (** 
 Additional headers are specified similarly - using an optional parameter `headers`.
@@ -74,13 +72,12 @@ Http.Request
 ## Sending request data
 
 If you want to create a POST request with HTTP POST data, you can specify the
-additional data using the `body` parameter. The following example uses the 
+additional data in a string using the `body` parameter, or you can specify a set
+of name-value pairs using the `bodyValues` parameter. The following example uses the 
 [httpbin.org](http://httpbin.org) service which returns the request details:
 *)
 
-Http.Request
-  ( "http://httpbin.org/post", 
-    meth="POST", body="test=foo")
+Http.Request("http://httpbin.org/post", bodyValues=["test", "foo"])
 
 (**
 By default, the Content-Type header is set to `application/x-www-form-urlencoded`,
@@ -91,5 +88,52 @@ using the optional argument `headers`:
 Http.Request
   ( "http://httpbin.org/post", 
     headers = ["content-type", "application/json"],
-    meth="POST", body=""" {"test": 42} """)
+    body = """ {"test": 42} """)
 
+(**
+## Maintaing cookies across requests
+
+If you want to maintain cookies between requests, you can specify the `cookieContainer` parameter.
+The following example will request the MSDN documentation for the `HttpRequest` class. It will return
+the code snippets in C# and not F#:
+*)
+
+let msdn className = 
+    sprintf "http://msdn.microsoft.com/en-gb/library/%s.aspx" className
+
+Http.Request(msdn "system.web.httprequest").Contains "<a>F#</a>"
+
+(**
+
+If we now go to another MSDN page and click on a F# code sample, and then go back to the `HttpRequest` class docs,
+while maintaining the same `cookieContainer`, we will be presented with the F# code snippets:
+*)
+
+open System.Net
+let cc = CookieContainer()
+
+Http.Request(msdn "system.datetime", 
+             query=["cs-save-lang", "1"
+                    "cs-lang","fsharp"], 
+             cookieContainer = cc) |> ignore
+
+Http.Request(msdn "system.web.httprequest", 
+             cookieContainer = cc).Contains "<a>F#</a>"
+
+(**
+If you want to see more information about the response, including the response headers, the returned cookies, and the response url
+(which might be different to the url you passed when there are redirects), you can use the `RequestEx` method:
+*)
+
+Http.RequestEx(msdn "system.web.httprequest")
+
+(**
+## Requesting binary data
+
+The `Request` method will always return the response as a `string`, but if you use the `RequestEx` method, it will
+return a `HttpResponseBody.Text` or a `HttpResponseBody.Binary` depending on the response `content-type` header:
+*)
+
+match Http.RequestEx("https://raw.github.com/fsharp/FSharp.Data/master/misc/logo.png").Body with
+| HttpResponseBody.Text text -> printfn "Got text content: %s" text
+| HttpResponseBody.Binary bytes -> printfn "Got %d bytes of binary content" bytes.Length

--- a/src/ApiaryProvider/ApiarySchema.fs
+++ b/src/ApiaryProvider/ApiarySchema.fs
@@ -22,11 +22,10 @@ type RestApi<'T> =
   | Function of string * 'T
   | Entity of string * list<'T> * list<RestApi<'T>>
 
-
 module ApiarySchema =
   let download = 
     // Cache for storing downloaded specifications
-    let cache = createInMemoryCache()
+    let cache, _ = createInternetFileCache "ApiarySchema" (TimeSpan.FromMinutes 30.0)
     fun uri ->
       match cache.TryRetrieve(uri) with
       | Some html -> html

--- a/src/Common/ProviderFileSystem.fs
+++ b/src/Common/ProviderFileSystem.fs
@@ -26,6 +26,8 @@ let private watchForChanges invalidate (fileName:string) =
   watcher.EnableRaisingEvents <- true
 #endif
 
+let internal isWeb (uri:Uri) = uri.IsAbsoluteUri && not uri.IsUnc
+
 /// Resolve the absolute location of a file (or web URL) according to the rules
 /// used by standard F# type providers as described here:
 /// https://github.com/fsharp/fsharpx/issues/195#issuecomment-12141785
@@ -50,15 +52,13 @@ let private resolveUri
     (designTime:bool) (isHosted:bool, defaultResolutionFolder:string) (resolutionFolder:string) (uri:Uri) =
 
 #if FX_NO_LOCAL_FILESYSTEM
-  let isWeb = uri.IsAbsoluteUri && not uri.IsUnc
-  if isWeb then
+  if isWeb uri then
       uri, true
   else
       failwith "Only web locations are supported"
 #else
-  let isWeb = uri.IsAbsoluteUri && (not uri.IsUnc && not uri.IsFile)
   match uri with
-  | url when isWeb -> url, true
+  | url when isWeb url -> url, true
   | fullPath when uri.IsAbsoluteUri -> fullPath, false
   | relative ->
       let root = 

--- a/src/DefineConstants.targets
+++ b/src/DefineConstants.targets
@@ -1,15 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Condition=" '$(SilverlightVersion)' == 'v5.0' ">
+  <PropertyGroup Condition=" '$(TargetFrameworkIdentifier)' == 'Silverlight' ">
     <DefineConstants>$(DefineConstants);FX_NO_LOCAL_FILESYSTEM</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_CONCURRENT</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_CUSTOMTYPEDESCRIPTOR</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_CUSTOMATTRIBUTEDATA</DefineConstants>
-    <DefineConstants>$(DefineConstants);FX_NO_WEBHEADERS_ADD</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_REGEX_COMPILATION</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_URI_WORKAROUND</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_GET_ENUM_UNDERLYING_TYPE</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_SECURITY_ELEMENT_ESCAPE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_WEBREQUEST_REFERER</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_WEBREQUEST_HOST</DefineConstants>
     <DefineConstants>$(DefineConstants);SILVERLIGHT</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFrameworkProfile)' == 'Profile47' ">
@@ -18,7 +19,9 @@
     <DefineConstants>$(DefineConstants);FX_NO_CUSTOMTYPEDESCRIPTOR</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_CUSTOMATTRIBUTEDATA</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_WEBREQUEST_CONTENTLENGTH</DefineConstants>
-    <DefineConstants>$(DefineConstants);FX_NO_WEBHEADERS_ADD</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_WEBREQUEST_USERAGENT</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_WEBREQUEST_REFERER</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_WEBREQUEST_HOST</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_REGEX_COMPILATION</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_URI_WORKAROUND</DefineConstants>
   </PropertyGroup>

--- a/src/Library/Http.fs
+++ b/src/Library/Http.fs
@@ -1,4 +1,4 @@
-// --------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------
 // Utilities for working with network, downloading resources with specified headers etc.
 // --------------------------------------------------------------------------------------
 
@@ -11,13 +11,27 @@ open System.Text
 open System.Reflection
 open System.Collections.Generic
 
+[<RequireQualifiedAccess>]
+type HttpResponseBody =
+    | Text of string
+    | Binary of byte[]
+
+type HttpResponse =
+  { Body : HttpResponseBody
+    Headers : Map<string,string> 
+    ResponseUrl : string
+    Cookies : Map<string,string> }
+
 /// Utilities for working with network via HTTP. Includes methods for downloading 
 /// resources with specified headers, query parameters and HTTP body
 type Http private() = 
 
+#if FX_NO_URI_WORKAROUND
+#else
   /// Are we currently running on Mono?
   /// (Mono does not have the issue with encoding slashes in URLs, so we do not need workaround)
   static let runningOnMono = Type.GetType("Mono.Runtime") <> null
+#endif
 
   /// Returns a clone of a System.Uri object that allows URL encoded slashes.
   /// (This is an ugly hack using Reflection, but it is the best way to do this
@@ -39,7 +53,7 @@ type Http private() =
     uri
 
   /// Read the contents of a stream asynchronously and return it as a string
-  static let asyncReadToEnd (stream:Stream) = async {
+  static let asyncReadToEnd (stream:Stream) isText = async {
     // Allocate 4kb buffer for downloading dat
     let buffer = Array.zeroCreate (4 * 1024)
     use output = new MemoryStream()
@@ -53,60 +67,91 @@ type Http private() =
 
     // Read all data into a string
     output.Seek(0L, SeekOrigin.Begin) |> ignore
-    use sr = new StreamReader(output)
-    return sr.ReadToEnd() }
+    return 
+        if isText then
+            use sr = new StreamReader(output)
+            sr.ReadToEnd() |> HttpResponseBody.Text
+        else
+            output.ToArray() |> HttpResponseBody.Binary }
 
-  /// Download an HTTP web resource from the specified URL asynchronously
-  static member AsyncRequest(url:string) = async {
+  static member inline internal reraisePreserveStackTrace (e:Exception) =
+    let remoteStackTraceString = typeof<exn>.GetField("_remoteStackTraceString", BindingFlags.Instance ||| BindingFlags.NonPublic)
+    if remoteStackTraceString <> null then
+        remoteStackTraceString.SetValue(e, e.StackTrace + Environment.NewLine)
+    raise e
+
+  static member private InnerRequest(url:string, forceText, ?query, ?headers, ?meth, ?body, ?bodyValues, ?cookies, ?cookieContainer) = async {
+
+    // Format query parameters
+    let url = 
+      match query with
+      | None -> url
+      | Some query ->
+          url + (if url.Contains "?" then "&" else "?") + (String.concat "&" [ for k, v in query -> k + "=" + v ])
+    let uri = Uri url |> enableUriSlashes
+
     // do not use WebRequest.CreateHttp otherwise the silverlight proxy won't work
-    let req = WebRequest.Create(enableUriSlashes(Uri(url)))
-    let! resp = req.AsyncGetResponse() 
-    use stream = resp.GetResponseStream()
-    return! asyncReadToEnd(stream) }
+    let req = WebRequest.Create(uri) :?> HttpWebRequest
 
-  /// Download an HTTP web resource from the specified URL
-  static member Request(url:string) = 
-    Http.AsyncRequest(url) |> Async.RunSynchronously
+    // set method
+    let defaultMethod =
+      match body, bodyValues with
+      | None, None -> "GET"
+      | Some _, Some _ -> failwith "Only one of 'body' or 'bodyValues' may be specified, not both"
+      | _ -> "POST"
+    req.Method <- (defaultArg meth defaultMethod).ToUpperInvariant()   
 
-  /// Download an HTTP web resource from the specified URL asynchronously
-  /// (allows specifying query string parameters and HTTP headers including
-  /// headers that have to be handled specially - such as Accept)
-  static member AsyncRequest(url:string, ?query, ?headers, ?meth, ?body) = async {
-    let query = defaultArg query []
-    let headers = defaultArg headers []
-    let meth = (defaultArg meth "GET").ToUpperInvariant()
+    let (|StringEquals|_|) (s1:string) s2 = 
+      if s1.Equals(s2, StringComparison.OrdinalIgnoreCase) 
+      then Some () else None
 
-    // Format query parameters & send HTTP request
-    let query = 
-      [ for (k, v) in query -> k + "=" + v ]
-      |> String.concat "&"
-    let url = if query = "" then url else url + "?" + query
-    // do not use WebRequest.CreateHttp otherwise the silverlight proxy won't work
-    let req = WebRequest.Create(enableUriSlashes(Uri url)) 
-    let req = req :?> HttpWebRequest
-    req.Method <- meth
-    
-    // Set headers, but look for special headers like Accept
-    for header, value in headers do
-      if String.Compare(header, "accept", StringComparison.OrdinalIgnoreCase) = 0 then
-        req.Accept <- value
-      elif String.Compare(header, "content-type", StringComparison.OrdinalIgnoreCase) = 0 then
-        req.ContentType <- value
-      else
-#if FX_NO_WEBHEADERS_ADD
-        req.Headers.[header] <- value
+    // set headers, but look for special headers like Accept
+    let hasContentType = ref false
+    headers |> Option.iter (fun headers ->
+      for header, value in headers do
+        match header with
+        | StringEquals "accept" -> req.Accept <- value
+        | StringEquals "content-type" -> hasContentType := true; req.ContentType <- value
+#if FX_NO_WEBREQUEST_USERAGENT
+        | StringEquals "user-agent" -> req.Headers.[HttpRequestHeader.UserAgent] <- value
 #else
-        req.Headers.Add(header, value) 
+        | StringEquals "user-agent" -> req.UserAgent <- value
 #endif
+#if FX_NO_WEBREQUEST_REFERER
+        | StringEquals "referer" -> req.Headers.[HttpRequestHeader.Referer] <- value
+#else
+        | StringEquals "referer" -> req.Referer <- value
+#endif
+#if FX_NO_WEBREQUEST_HOST
+        | StringEquals "host" -> req.Headers.[HttpRequestHeader.Host] <- value
+#else
+        | StringEquals "host" -> req.Host <- value
+#endif       
+        | _ -> req.Headers.[header] <- value)
+
+    // set cookies    
+    let cookieContainer = defaultArg cookieContainer (new CookieContainer())
+    match cookies with
+    | None -> ()
+    | Some cookies ->
+        for name, value in cookies do
+          cookieContainer.Add(req.RequestUri, Cookie(name, value))
+    req.CookieContainer <- cookieContainer
 
     // If we want to set some body, encode it with POST data as array of bytes
-    match body with 
+    let body = 
+        match body, bodyValues with 
+        | Some _, Some _ -> failwithf "Only body or bodyValues can be specified"
+        | _, Some bodyValues ->
+            [ for k, v in bodyValues -> Uri.EscapeDataString k + "=" + Uri.EscapeDataString v ]
+            |> String.concat "&"
+            |> Some
+        | body, _ -> body
+
+    match body with
     | Some (text:string) ->
         // Set default content type if it is not specified by the user
-        let hasContentType = 
-          headers |> Seq.exists (fun (header, _) -> 
-            String.Compare(header, "content-type", StringComparison.OrdinalIgnoreCase) = 0)
-        if not hasContentType then
+        if not !hasContentType then
           req.ContentType <- "application/x-www-form-urlencoded"
 
         // Write the body 
@@ -120,14 +165,82 @@ type Http private() =
         output.Flush()
     | _ -> ()
     
+    let isText (mimeType:string) =
+        mimeType.StartsWith "text/" || 
+        mimeType = "application/json" || 
+        mimeType = "application/xml" ||
+        mimeType = "application/javascript" ||
+        mimeType = "application/ecmascript" ||
+        mimeType = "application/xml-dtd" ||
+        mimeType.StartsWith "application/" && mimeType.EndsWith "+xml"
+
     // Send the request and get the response       
-    use! resp = req.AsyncGetResponse()
-    use stream = resp.GetResponseStream()
-    return! asyncReadToEnd stream }
+    try
+      use! resp = Async.FromBeginEnd(req.BeginGetResponse, req.EndGetResponse)
+      use stream = resp.GetResponseStream()
+      let! respBody = asyncReadToEnd stream (forceText || (isText resp.ContentType))
+      let cookies = Map.ofList [ for cookie in cookieContainer.GetCookies uri |> Seq.cast<Cookie> -> cookie.Name, cookie.Value ]  
+      let headers = Map.ofList [ for header in resp.Headers.AllKeys -> header, resp.Headers.[header] ]
+      return { Body = respBody
+               Headers = headers
+               ResponseUrl = resp.ResponseUri.OriginalString
+               Cookies = cookies }
+    with 
+      // If an exception happens, augment the message with the response
+      | :? WebException as exn -> 
+        if exn.Response = null then Http.reraisePreserveStackTrace exn
+        let responseExn =
+            try
+              use responseStream = exn.Response.GetResponseStream()
+              use streamReader = new StreamReader(responseStream)
+              let response = streamReader.ReadToEnd()
+              if String.IsNullOrEmpty response then None
+              else Some(WebException(sprintf "%s\n%s" exn.Message response, exn, exn.Status, exn.Response))
+            with _ -> None
+        match responseExn with
+        | Some e -> raise e
+        | None -> Http.reraisePreserveStackTrace exn
+        return { Body = HttpResponseBody.Text ""
+                 Headers = Map.empty
+                 ResponseUrl = uri.OriginalString
+                 Cookies = Map.empty }
+  }
+
+  /// Download an HTTP web resource from the specified URL asynchronously
+  /// (allows specifying query string parameters and HTTP headers including
+  /// headers that have to be handled specially - such as Accept, Content-Type & Referer)
+  /// The body for POST request can be specified either as text or as a list of parameters
+  /// that will be encoded, and the method will automatically be set if not specified
+  static member AsyncRequestEx(url, ?query, ?headers, ?meth, ?body, ?bodyValues, ?cookies, ?cookieContainer) = 
+    Http.InnerRequest(url, false, ?headers=headers, ?query=query, ?meth=meth, ?body=body, ?bodyValues=bodyValues, ?cookies=cookies, ?cookieContainer=cookieContainer)
+
+  /// Download an HTTP web resource from the specified URL asynchronously
+  /// (allows specifying query string parameters and HTTP headers including
+  /// headers that have to be handled specially - such as Accept, Content-Type & Referer)
+  /// The body for POST request can be specified either as text or as a list of parameters
+  /// that will be encoded, and the method will automatically be set if not specified
+  static member AsyncRequest(url, ?query, ?headers, ?meth, ?body, ?bodyValues, ?cookies, ?cookieContainer) = async {
+    let! response = Http.InnerRequest(url, true, ?headers=headers, ?query=query, ?meth=meth, ?body=body, ?bodyValues=bodyValues, ?cookies=cookies, ?cookieContainer=cookieContainer)
+    return
+        match response.Body with
+        | HttpResponseBody.Text text -> text
+        | HttpResponseBody.Binary binary -> failwithf "Expecting text, but got a binary response (%d bytes)" binary.Length
+  }
 
   /// Download an HTTP web resource from the specified URL synchronously
   /// (allows specifying query string parameters and HTTP headers including
-  /// headers that have to be handled specially - such as Accept)
-  static member Request(url:string, ?query, ?headers, ?meth, ?body) = 
-    Http.AsyncRequest(url, ?headers=headers, ?query=query, ?meth=meth, ?body=body)
+  /// headers that have to be handled specially - such as Accept, Content-Type & Referer)
+  /// The body for POST request can be specified either as text or as a list of parameters
+  /// that will be encoded, and the method will automatically be set if not specified
+  static member RequestEx(url, ?query, ?headers, ?meth, ?body, ?bodyValues, ?cookies, ?cookieContainer) = 
+    Http.AsyncRequestEx(url, ?headers=headers, ?query=query, ?meth=meth, ?body=body, ?bodyValues=bodyValues, ?cookies=cookies, ?cookieContainer=cookieContainer)
+    |> Async.RunSynchronously
+
+  /// Download an HTTP web resource from the specified URL synchronously
+  /// (allows specifying query string parameters and HTTP headers including
+  /// headers that have to be handled specially - such as Accept, Content-Type & Referer)
+  /// The body for POST request can be specified either as text or as a list of parameters
+  /// that will be encoded, and the method will automatically be set if not specified
+  static member Request(url, ?query, ?headers, ?meth, ?body, ?bodyValues, ?cookies, ?cookieContainer) = 
+    Http.AsyncRequest(url, ?query=query, ?headers=headers, ?meth=meth, ?body=body, ?bodyValues=bodyValues, ?cookies=cookies, ?cookieContainer=cookieContainer)
     |> Async.RunSynchronously

--- a/src/WorldBankProvider/WorldBankProvider.fs
+++ b/src/WorldBankProvider/WorldBankProvider.fs
@@ -23,7 +23,7 @@ type public WorldBankProvider(cfg:TypeProviderConfig) as this =
     let ns = "FSharp.Data" 
 
     let defaultServiceUrl = "http://api.worldbank.org"
-    let restCache, _ = createInternetFileCache "WorldBankSchema"
+    let restCache, _ = createInternetFileCache "WorldBankSchema" (TimeSpan.FromDays 30.0)
 
     let createTypesForSources(sources, worldBankTypeName, asynchronous) = 
 

--- a/src/WorldBankProvider/WorldBankRuntime.fs
+++ b/src/WorldBankProvider/WorldBankRuntime.fs
@@ -346,7 +346,7 @@ type IWorldBankData =
 
 type WorldBankData(serviceUrl:string, sources:string) = 
     let sources = sources.Split([| ';' |], StringSplitOptions.RemoveEmptyEntries) |> Array.toList
-    let restCache, _ = createInternetFileCache "WorldBankRuntime"
+    let restCache, _ = createInternetFileCache "WorldBankRuntime" (TimeSpan.FromDays 30.0)
     let connection = new ServiceConnection(restCache, serviceUrl, sources)
     interface IWorldBankData with
         member x.GetCountries() = CountryCollection(connection, None) :> seq<_>

--- a/tools/build.fsx
+++ b/tools/build.fsx
@@ -17,7 +17,7 @@ let output   = __SOURCE_DIRECTORY__ ++ "../docs"
 let root = "http://fsharp.github.com/FSharp.Data"
 
 // When running locally, you can use your path
-// let root = "file://C:\Tomas\Projects\FSharp.Data\docs"
+//let root = @"file://C:\Tomas\Projects\FSharp.Data\docs"
 
 
 // Copy all sample documents to the "docs" directory


### PR DESCRIPTION
- Improvements to exception messages thrown inside Http.Request
- Allow to specify the body as a set of form name-value pairs in addition to content
- Auto-set method to GET or POST if not specified depending on whether we pass body as param or not
- Support for cookies
- Support for user-agent, host & referer headers
- Support for downloading binary files
- Support for knowing the actual url the response came from
- Change caches that were previously indefinite to 30 days, and cache all designtime urls for 30 minutes (fixes #90)
