### PR TITLE
Added missing System.Core reference to the projects.

### DIFF
--- a/src/FSharp.Data.DesignTime.fsproj
+++ b/src/FSharp.Data.DesignTime.fsproj
@@ -83,6 +83,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>

--- a/src/FSharp.Data.Experimental.DesignTime.fsproj
+++ b/src/FSharp.Data.Experimental.DesignTime.fsproj
@@ -71,6 +71,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Core" />
   </ItemGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>

--- a/src/FSharp.Data.Experimental.fsproj
+++ b/src/FSharp.Data.Experimental.fsproj
@@ -54,6 +54,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Core" />
   </ItemGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>

--- a/src/FSharp.Data.fsproj
+++ b/src/FSharp.Data.fsproj
@@ -62,6 +62,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>


### PR DESCRIPTION
These references are necessary in order to correctly build FSharp.Data on Mono/Xamarin Studio.

Fixes issue #127.
