### PR TITLE
Async loading for XmlProvider and JsonProvider

### DIFF
--- a/FSharp.Data.ExtraPlatforms.sln
+++ b/FSharp.Data.ExtraPlatforms.sln
@@ -1,8 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.20827.3
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 2012
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharp.Data.Portable", "src\FSharp.Data.Portable.fsproj", "{993A6EEF-6E82-4964-8F91-BE72CC63D000}"
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharp.Data.DesignTime.Silverlight", "src\FSharp.Data.DesignTime.Silverlight.fsproj", "{AD03F725-3AE4-4369-907F-58D8563B4AB4}"

--- a/FSharp.Data.Tests.sln
+++ b/FSharp.Data.Tests.sln
@@ -1,8 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.20827.3
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 2012
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{7E48C05A-8C42-4871-A618-180BEEF696AA}"
 	ProjectSection(SolutionItems) = preProject
 		samples\contributing.md = samples\contributing.md
@@ -48,13 +46,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Experimental", "Experimental", "{34171948-6CCE-448B-AA7D-A76FCE32A08E}"
 	ProjectSection(SolutionItems) = preProject
 		samples\experimental\ApiaryProvider.fsx = samples\experimental\ApiaryProvider.fsx
-	EndProjectSection
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{CE160A87-FDF5-4F73-A4FB-F5A0E15986E8}"
-	ProjectSection(SolutionItems) = preProject
-		.nuget\NuGet.Config = .nuget\NuGet.Config
-		.nuget\NuGet.exe = .nuget\NuGet.exe
-		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharp.Data.Tests", "tests\FSharp.Data.Tests\FSharp.Data.Tests.fsproj", "{5EF9FF95-1C75-458A-983A-168E43945913}"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,4 +21,4 @@
 * 1.1.8 - Fixed problem with portable version of FSharp.Net.Http.
 * 1.1.9 - Infer booleans for ints that only manifest 0 and 1. Support for partially overriding the Schema in CsvProvider. PreferOptionals and SafeMode parameters for CsvProvider.
 * 1.1.10 - Support for heterogeneous XML attributes. Make CsvFile re-entrant. Support for compressed HTTP responses. Fix JSON conversion of 0 and 1 to booleans. Fix XmlProvider problems with nested elements and elements with same name in different namespaces.
-* 1.2.0 - Support for sending HTTP requests with a binary body. Allow currency symbols on decimals. Remove .AsTuple member from CsvProvider.
+* 1.2.0 - Support for sending HTTP requests with a binary body. Allow currency symbols on decimals. Remove .AsTuple member from CsvProvider. CsvProvider now uses GetSample instead of constructor like the other providers. Renamed SampleList to SampleIsList. Renamed Separator to Separators. Add AsyncLoad(string uri) to CsvProvider, JsonProvider and XmlProvider

--- a/samples/library/CsvFile.fsx
+++ b/samples/library/CsvFile.fsx
@@ -20,8 +20,9 @@ open FSharp.Data.Csv
 (**
 The `FSharp.Data.Csv` namespace contains the `CsvFile` type that provides two static methods
 for loading data. The `Parse` method can be used if we have the data in a `string` value.
-The `Load` method allows reading the data from a file or from a web resource. The following 
-sample calls it with a URL that points to a live CSV file on the Yahoo finance web site:
+The `Load` method allows reading the data from a file or from a web resource (and there's
+also an asynchronous `AsyncLoad` version). The following sample calls `Load` with a URL that
+points to a live CSV file on the Yahoo finance web site:
 *)
  
 // Download the stock prices

--- a/samples/library/CsvProvider.fsx
+++ b/samples/library/CsvProvider.fsx
@@ -41,8 +41,9 @@ type Stocks = CsvProvider<"../docs/MSFT.csv">
 (**
 The generated type provides two static methods for loading data. The `Parse` method can be
 used if we have the data in a `string` value. The `Load` method allows reading the data from
-a file or from a web resource. The following sample calls it with a URL that points to 
-a live CSV file on the Yahoo finance web site:
+a file or from a web resource (and there's also an asynchronous `AsyncLoad` version). We could also
+have used a web url instead of a local file in the sample parameter of the type provider.
+The following sample calls the `Load` method with an URL that points to a live CSV file on the Yahoo finance web site:
 *)
  
 // Download the stock prices
@@ -114,10 +115,10 @@ As you can see, the second and third columns are annotated with `metre` and `s`,
 respectively. To use units of measure in our code, we need to open the namespace with
 standard unit names. Then we pass the `SmallTest.csv` file to the type provider as
 a static argument. Also note that in this case we're using the same data at runtime,
-so there's no need to use the Load method, we can just call the default constructor.
+so we use the `GetSample` method instead of calling `Load` and passing the same parameter again.
 *)
 
-let small = new CsvProvider<"../docs/SmallTest.csv">()
+let small = CsvProvider<"../docs/SmallTest.csv">.GetSample()
 
 (**
 As in the previous example, the `small` value exposes the rows using the `Data` property.
@@ -148,7 +149,7 @@ where you can specify what to use as separator. This means that you can consume
 any textual tabular format. Here is an example using `;` as a separator:
 *)
 
-let airQuality = new CsvProvider<"../docs/AirQuality.csv", ";">()
+let airQuality = CsvProvider<"../docs/AirQuality.csv", ";">.GetSample()
 
 for row in airQuality.Data do
   if row.Month > 6 then 
@@ -166,7 +167,7 @@ we also set `IgnoreErrors` static parameter to `true` so that lines with incorre
 are automatically skipped (the sample file ([`docs/MortalityNY.csv`](../docs/MortalityNY.tsv)) contains additional unstructured data at the end):
 *)
 
-let mortalityNy = new CsvProvider<"../docs/MortalityNY.tsv", IgnoreErrors=true>()
+let mortalityNy = CsvProvider<"../docs/MortalityNY.tsv", IgnoreErrors=true>.GetSample()
 
 // Find the name of a cause based on code
 // (Pedal cyclist injured in an accident)
@@ -274,7 +275,7 @@ names are overridden using the `Schema` parameter. Note that you can override on
 and still have the provider infer the type for you. Example:
 *)
 
-let csv = new CsvProvider<"1,2,3", HasHeaders = false, Schema = "Duration (float<second>),foo,float option">()
+let csv = CsvProvider<"1,2,3", HasHeaders = false, Schema = "Duration (float<second>),foo,float option">.GetSample()
 for row in csv.Data do
   printfn "%f %d %f" (row.Duration/1.0<second>) row.foo (defaultArg row.Column3 1.0)
 
@@ -288,7 +289,7 @@ the other columns blank in the schema (you also don't need to add all the traili
 
 *)
 
-let titanic1 = new CsvProvider<"../docs/Titanic.csv", Schema=",,Passenger Class,,,float">()
+let titanic1 = CsvProvider<"../docs/Titanic.csv", Schema=",,Passenger Class,,,float">.GetSample()
 for row in titanic1.Data do
   printfn "%s Class = %d Fare = %g" row.Name row.``Passenger Class`` row.Fare
 
@@ -298,7 +299,7 @@ Alternatively, you can rename and override the type of any column by name instea
 
 *)
 
-let titanic2 = new CsvProvider<"../docs/Titanic.csv", Schema="Fare=float,PClass->Passenger Class">()
+let titanic2 = CsvProvider<"../docs/Titanic.csv", Schema="Fare=float,PClass->Passenger Class">.GetSample()
 for row in titanic2.Data do
   printfn "%s Class = %d Fare = %g" row.Name row.``Passenger Class`` row.Fare
 
@@ -333,7 +334,7 @@ You can still cache the data at some point by using the `Cache` method, but only
 transformed the dataset to be smaller:
 *)
 
-let stocks = new CsvProvider<"http://ichart.finance.yahoo.com/table.csv?s=MSFT", CacheRows=false>()
+let stocks = CsvProvider<"http://ichart.finance.yahoo.com/table.csv?s=MSFT", CacheRows=false>.GetSample()
 stocks.Take(10).Cache()
 
 (**

--- a/samples/library/JsonProvider.fsx
+++ b/samples/library/JsonProvider.fsx
@@ -81,12 +81,12 @@ Now, let's look at a sample JSON document that contains a list of records. The
 following example uses two records - one with `name` and `age` and the second with just
 `name`. If a property is missing, then the provider infers it as optional.
 
-If we want to just use the same text used for the schema at runtime, we can use the `GetSample` method:
+If we want to just use the same text used for the schema at runtime, we can use the `GetSamples` method:
 *)
 
 type People = JsonProvider<""" [{ "name":"John", "age":94 }, { "name":"Tomas" }] """>
 
-for item in People.GetSample() do 
+for item in People.GetSamples() do 
   printf "%s " item.Name 
   item.Age |> Option.iter (printf "(%d)")
   printfn ""
@@ -105,7 +105,7 @@ as follows:
 
 type Values = JsonProvider<""" [{"value":94 }, {"value":"Tomas" }] """>
 
-for item in Values.GetSample() do 
+for item in Values.GetSamples() do 
   match item.Value.Number, item.Value.String with
   | Some num, _ -> printfn "Numeric: %d" num
   | _, Some str -> printfn "Text: %s" str
@@ -116,6 +116,9 @@ Here, the `Value` property is either a number or a string, The type provider gen
 a type that has an optional property for each possible option, so we can use 
 simple pattern matching on `option<int>` and `option<string>` values to distinguish
 between the two options. This is similar to the handling of heterogeneous arrays.
+
+Note that we have a `GetSamples` method because the sample is a json list. If it was a json
+object, we would have a `GetSample` method instead.
 
 ## Loading WorldBank data
 
@@ -143,6 +146,11 @@ file and loads it:
 
 type WorldBank = JsonProvider<"../docs/WorldBank.json">
 let doc = WorldBank.Load("../docs/WorldBank.json")
+
+(** Note that we can also load the data directly from the web both in the `Load` method and in
+the type provider sample parameter, and there's an asynchronous `AsyncLoad` method available too: **)
+
+let docAsync = WorldBank.AsyncLoad("http://api.worldbank.org/country/cz/indicator/GC.DOD.TOTL.GD.ZS?format=json")
 
 (**
 The `doc` is an array of heterogeneous types, so the provider generates a type
@@ -175,12 +183,12 @@ it to print the result only when the data point is available.
 In our last example, we look how to parse tweets returned by the [Twitter API](http://dev.twitter.com/).
 Tweets are quite heterogeneous, so we infer the structure from a _list_ of inputs rather than from 
 just a single input. To do that, we use the file [`docs/TwitterStream.json`](../docs/TwitterStream.json) 
-(containing a list of tweets) and pass an optional parameter `SampleList=true` which tells the 
+(containing a list of tweets) and pass an optional parameter `SampleIsList=true` which tells the 
 provider that the sample is actually a _list of samples_:
 
 *)
 
-type Tweet = JsonProvider<"../docs/TwitterStream.json", SampleList=true>
+type Tweet = JsonProvider<"../docs/TwitterStream.json", SampleIsList=true>
 let text = (*[omit:(omitted)]*)""" {"in_reply_to_status_id_str":null,"text":"\u5927\u91d1\u6255\u3063\u3066\u904a\u3070\u3057\u3066\u3082\u3089\u3046\u3002\u3082\u3046\u3053\u306e\u4e0a\u306a\u3044\u8d05\u6ca2\u3002\u3067\u3082\uff0c\u5b9f\u969b\u306b\u306f\u305d\u306e\u8d05\u6ca2\u306e\u672c\u8cea\u3092\u6e80\u55ab\u3067\u304d\u308b\u4eba\u306f\u9650\u3089\u308c\u3066\u308b\u3002\u305d\u3053\u306b\u76ee\u306b\u898b\u3048\u306a\u3044\u968e\u5c64\u304c\u3042\u308b\u3068\u304a\u3082\u3046\u3002","in_reply_to_user_id_str":null,"retweet_count":0,"geo":null,"source":"web","retweeted":false,"truncated":false,"id_str":"263290764686155776","entities":{"user_mentions":[],"hashtags":[],"urls":[]},"in_reply_to_user_id":null,"in_reply_to_status_id":null,"place":null,"coordinates":null,"in_reply_to_screen_name":null,"created_at":"Tue Oct 30 14:46:24 +0000 2012","user":{"notifications":null,"contributors_enabled":false,"time_zone":"Tokyo","profile_background_color":"FFFFFF","location":"Kodaira Tokyo Japan","profile_background_tile":false,"profile_image_url_https":"https:\/\/si0.twimg.com\/profile_images\/1172376796\/70768_100000537851636_3599485_q_normal.jpg","default_profile_image":false,"follow_request_sent":null,"profile_sidebar_fill_color":"17451B","description":"KS(Green62)\/WasedaUniv.(Schl Adv Sci\/Eng)\/SynBio\/ChronoBio\/iGEM2010-2012\/Travel\/Airplane\/ \u5bfa\u30fb\u5ead\u3081\u3050\u308a","favourites_count":17,"screen_name":"Merlin_wand","profile_sidebar_border_color":"000000","id_str":"94788486","verified":false,"lang":"ja","statuses_count":8641,"profile_use_background_image":true,"protected":false,"profile_image_url":"http:\/\/a0.twimg.com\/profile_images\/1172376796\/70768_100000537851636_3599485_q_normal.jpg","listed_count":31,"geo_enabled":true,"created_at":"Sat Dec 05 13:07:32 +0000 2009","profile_text_color":"000000","name":"Marin","profile_background_image_url":"http:\/\/a0.twimg.com\/profile_background_images\/612807391\/twitter_free1.br.jpg","friends_count":629,"url":null,"id":94788486,"is_translator":false,"default_profile":false,"following":null,"profile_background_image_url_https":"https:\/\/si0.twimg.com\/profile_background_images\/612807391\/twitter_free1.br.jpg","utc_offset":32400,"profile_link_color":"ADADAD","followers_count":426},"id":263290764686155776,"contributors":null,"favorited":false} """(*[/omit]*)
 let tweet = Tweet.Parse(text)
 

--- a/samples/library/JsonValue.fsx
+++ b/samples/library/JsonValue.fsx
@@ -105,10 +105,14 @@ and a collection of data points as the second element. The following code
 reads the document and parses it:
 *)
 
-let value = JsonValue.Load(__SOURCE_DIRECTORY__ + "/docs/WorldBank.json")
+let value = JsonValue.Load(__SOURCE_DIRECTORY__ + "../docs/WorldBank.json")
 
-(** 
-To split the top-level array into the first record (with overall information) 
+(** Note that we can also load the data directly from the web, and there's an
+asynchronous version available too: **)
+
+let valueAsync = JsonValue.AsyncLoad("http://api.worldbank.org/country/cz/indicator/GC.DOD.TOTL.GD.ZS?format=json")
+
+(** To split the top-level array into the first record (with overall information) 
 and the collection of data points, we use pattern matching and match the `value`
 against the `JsonValue.Array` constructor:
 *)

--- a/samples/library/XmlProvider.fsx
+++ b/samples/library/XmlProvider.fsx
@@ -122,7 +122,7 @@ let authors = """
 
 (**
 When initializing the `XmlProvider`, we can pass it a file name or a web url.
-The `Load` method allows reading the data from a file or from a web resource. The
+The `Load` and `AsyncLoad` methods allows reading the data from a file or from a web resource. The
 `Parse` method takes the data as a string, so we can now print the information as follows:
 *)
 
@@ -206,7 +206,7 @@ type Rss = XmlProvider<"http://tomasp.net/blog/rss.aspx">
 
 (**
 This code builds a type `Rss` that represents RSS feeds (with the features that are used
-on `http://tomasp.net`). The type `Rss` provides static methods `Parse` and `Load`
+on `http://tomasp.net`). The type `Rss` provides static methods `Parse`, `Load` and `AsyncLoad`
 to construct it - here, we just want to reuse the same uri of the schema, so we
 use the `GetSample` static method:
 *)

--- a/src/CsvProvider/CsvProvider.fs
+++ b/src/CsvProvider/CsvProvider.fs
@@ -1,21 +1,16 @@
 ﻿// --------------------------------------------------------------------------------------
-// CSV type provider (inference engine and code generator)
+// CSV type provider
 // --------------------------------------------------------------------------------------
-
 namespace ProviderImplementation
 
 open System
-open System.Collections.Generic
-open System.IO
-open System.Reflection
 open Microsoft.FSharp.Core.CompilerServices
 open Microsoft.FSharp.Quotations
-open ProviderImplementation
 open ProviderImplementation.ProvidedTypes
-open ProviderImplementation.QuotationBuilder
+open ProviderImplementation.ProviderHelpers
 open FSharp.Data.Csv
 open FSharp.Data.RuntimeImplementation
-open FSharp.Data.RuntimeImplementation.ProviderFileSystem
+open ProviderImplementation.QuotationBuilder
 
 // --------------------------------------------------------------------------------------
 
@@ -26,12 +21,12 @@ type public CsvProvider(cfg:TypeProviderConfig) as this =
   // Generate namespace and type 'FSharp.Data.CsvProvider'
   let asm, replacer = AssemblyResolver.init cfg
   let ns = "FSharp.Data"
-  let csvProvTy = ProvidedTypeDefinition(asm, ns, "CsvProvider", Some(typeof<obj>))
+  let csvProvTy = ProvidedTypeDefinition(asm, ns, "CsvProvider", Some typeof<obj>)
 
   let buildTypes (typeName:string) (args:obj[]) =
 
     let sample = args.[0] :?> string
-    let separator = args.[1] :?> string
+    let separators = args.[1] :?> string
     let culture = args.[2] :?> string
     let cultureInfo = Operations.GetCulture culture
     let inferRows = args.[3] :?> int
@@ -45,86 +40,46 @@ type public CsvProvider(cfg:TypeProviderConfig) as this =
     let missingValuesList = missingValues.Split([| ',' |], StringSplitOptions.RemoveEmptyEntries)
     let cacheRows = args.[11] :?> bool
     let resolutionFolder = args.[12] :?> string
-    let isHostedExecution = cfg.IsHostedExecution
-    let defaultResolutionFolder = cfg.ResolutionFolder
-
-    // Infer the schema from a specified uri or inline text
-    let sampleCsv, sampleIsUri, separator = 
-      try
-        match ProviderHelpers.tryGetUri sample with
-        | Some uri ->
-            let separator = 
-              if String.IsNullOrEmpty separator &&
-                 (uri.IsAbsoluteUri && uri.AbsolutePath.EndsWith(".tsv", StringComparison.OrdinalIgnoreCase) || uri.OriginalString.EndsWith(".tsv", StringComparison.OrdinalIgnoreCase)) then
-                "\t"
-              else
-                separator
-            let reader = ProviderHelpers.readTextAtDesignTime defaultResolutionFolder this.Invalidate resolutionFolder uri
-            CsvFile.Load(reader, separator, quote, hasHeaders, ignoreErrors), true, separator
-        | None ->
-            CsvFile.Parse(sample, separator, quote, hasHeaders, ignoreErrors), false, separator
-      with e ->
-        failwithf "Specified argument is neither a file, nor well-formed CSV: %s" e.Message
     
-    use sampleCsv = sampleCsv
+    let parse (extension:string) value =
+      let separators = 
+        if String.IsNullOrEmpty separators && extension.ToLowerInvariant() = ".tsv"
+        then "\t" else separators
+      CsvFile.Parse(value, separators, quote, hasHeaders, ignoreErrors)
 
-    let inferredFields = 
-      CsvInference.inferType sampleCsv inferRows (missingValuesList, cultureInfo) schema safeMode preferOptionals
-      ||> CsvInference.getFields preferOptionals
+    let getSpecFromSamples samples = 
+      
+      use sampleCsv : CsvFile = Seq.head samples
+      let separators = sampleCsv.Separators
+  
+      let inferredFields = 
+        CsvInference.inferType sampleCsv inferRows (missingValuesList, cultureInfo) schema safeMode preferOptionals
+        ||> CsvInference.getFields preferOptionals
+  
+      let csvType, csvErasedType, stringArrayToRow, rowToStringArray = 
+        inferredFields 
+        |> CsvTypeBuilder.generateTypes asm ns typeName (missingValues, culture) replacer 
+  
+      { GeneratedType = csvType
+        RepresentationType = csvType
+        CreateFromTextReader = fun reader ->
+          csvErasedType?CreateNonReentrant () (stringArrayToRow, rowToStringArray, replacer.ToRuntime reader, 
+                                               separators, quote, hasHeaders, ignoreErrors, cacheRows)
+        AsyncCreateFromTextReader = fun readerAsync ->
+          csvErasedType?AsyncCreateNonReentrant () (stringArrayToRow, rowToStringArray, replacer.ToRuntime readerAsync, 
+                                                    separators, quote, hasHeaders, ignoreErrors, cacheRows)
+        CreateFromTextReaderForSampleList = fun _ -> failwith "Not Applicable"
+        AsyncCreateFromTextReaderForSampleList = fun _ -> failwith "Not Applicable" }
 
-    let csvType, csvErasedType, stringArrayToRow, rowToStringArray = 
-      inferredFields 
-      |> CsvTypeBuilder.generateTypes asm ns typeName (missingValues, culture) replacer 
-
-    let csvConstructor (reader:Expr) =
-      let uncachedCsv = csvErasedType?CreateNonReentrant () (stringArrayToRow, rowToStringArray, replacer.ToRuntime reader, separator, quote, hasHeaders, ignoreErrors) :> Expr
-      if cacheRows then csvErasedType?Cache () uncachedCsv else uncachedCsv
-
-    // Generate default constructor
-    let c = ProvidedConstructor []
-    c.InvokeCode <- 
-      if sampleIsUri then
-        fun _ -> csvConstructor <@@ readTextAtRunTimeWithDesignTimeOptions defaultResolutionFolder resolutionFolder sample @@>
-      else
-        fun _ -> csvConstructor <@@ new StringReader(sample) @@>
-    csvType.AddMember c
-
-    // Generate static Parse method
-    let args = [ ProvidedParameter("text", typeof<string>) ]
-    let m = ProvidedMethod("Parse", args, csvType, IsStaticMethod = true)
-    m.InvokeCode <- fun (Singleton text) -> csvConstructor <@@ new StringReader(%%text:string) @@>
-    m.AddXmlDoc "Parses the specified CSV content"
-    csvType.AddMember m
-
-    // Generate static Load stream method
-    let args = [ ProvidedParameter("stream", typeof<Stream>) ]
-    let m = ProvidedMethod("Load", args, csvType, IsStaticMethod = true)
-    m.InvokeCode <- fun (Singleton stream) -> csvConstructor <@@ new StreamReader(%%stream:Stream) @@>
-    m.AddXmlDoc "Loads CSV from the specified stream"
-    csvType.AddMember m
-
-    // Generate static Load reader method
-    let args = [ ProvidedParameter("reader", typeof<TextReader>) ]
-    let m = ProvidedMethod("Load", args, csvType, IsStaticMethod = true)
-    m.InvokeCode <- fun (Singleton reader) -> csvConstructor reader
-    m.AddXmlDoc "Loads CSV from the specified reader"
-    csvType.AddMember m
-
-    // Generate static Load uri method
-    let args = [ ProvidedParameter("uri", typeof<string>) ]
-    let m = ProvidedMethod("Load", args, csvType, IsStaticMethod = true)
-    m.InvokeCode <- fun (Singleton uri) -> csvConstructor <@@ readTextAtRunTime isHostedExecution defaultResolutionFolder resolutionFolder %%uri @@>
-    m.AddXmlDoc "Loads CSV from the specified uri"
-    csvType.AddMember m
-
-    // Return the generated type
-    csvType
+    generateConstructors "CSV" sample (*sampleIsList*)false 
+                         parse (fun _ _ -> failwith "Not Applicable") getSpecFromSamples
+                         this cfg replacer resolutionFolder
 
   let defaultMissingValues = String.Join(",", Operations.DefaultMissingValues)
   // Add static parameter that specifies the API we want to get (compile-time) 
   let parameters = 
     [ ProvidedStaticParameter("Sample", typeof<string>) 
-      ProvidedStaticParameter("Separator", typeof<string>, parameterDefaultValue = "") 
+      ProvidedStaticParameter("Separators", typeof<string>, parameterDefaultValue = "") 
       ProvidedStaticParameter("Culture", typeof<string>, parameterDefaultValue = "")
       ProvidedStaticParameter("InferRows", typeof<int>, parameterDefaultValue = 1000)
       ProvidedStaticParameter("Schema", typeof<string>, parameterDefaultValue = "")
@@ -140,7 +95,7 @@ type public CsvProvider(cfg:TypeProviderConfig) as this =
   let helpText = 
     """<summary>Typed representation of a CSV file</summary>
        <param name='Sample'>Location of a CSV sample file or a string containing a sample CSV document</param>
-       <param name='Separator'>Column delimiter. Defaults to ","</param>
+       <param name='Separators'>Column delimiter(s). Defaults to ","</param>
        <param name='Culture'>The culture used for parsing numbers and dates. Defaults to the invariant culture</param>
        <param name='InferRows'>Number of rows to use for inference. Defaults to 1000. If this is zero, all rows are used</param>
        <param name='Schema'>Optional column types, in a comma separated list. Valid types are "int", "int64", "bool", "float", "decimal", "date", "guid", "string", "int?", "int64?", "bool?", "float?", "decimal?", "date?", "guid?", "int option", "int64 option", "bool option", "float option", "decimal option", "date option", "guid option" and "string option". You can also specify a unit and the name of the column like this: Name (type&lt;unit&gt;). You can also override only the name. If you don't want to specify all the columns, you can specify by name like this: 'ColumnName=type'</param>
@@ -158,3 +113,4 @@ type public CsvProvider(cfg:TypeProviderConfig) as this =
 
   // Register the main type with F# compiler
   do this.AddNamespace(ns, [ csvProvTy ])
+  

--- a/src/FSharp.Data.DesignTime.Silverlight.fsproj
+++ b/src/FSharp.Data.DesignTime.Silverlight.fsproj
@@ -66,6 +66,7 @@
     <Compile Include="Providers\AssemblyReplacer.fs" />
     <Compile Include="Providers\StructureInference.fs" />
     <Compile Include="Providers\Helpers.fs" />
+    <Compile Include="Providers\AssemblyResolver.fs" />
     <Compile Include="Providers\Debug.fs" />
     <Compile Include="JsonProvider\JsonRuntime.fs" />
     <Compile Include="JsonProvider\JsonInference.fs" />
@@ -101,19 +102,7 @@
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
   </PropertyGroup>
   <Import Project="DefineConstants.targets" />
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '11.0'">
-      <PropertyGroup>
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
+  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets" Condition=" Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Silverlight\$(SilverlightVersion)\Microsoft.Silverlight.Common.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/FSharp.Data.DesignTime.fsproj
+++ b/src/FSharp.Data.DesignTime.fsproj
@@ -56,6 +56,7 @@
     <Compile Include="Providers\AssemblyReplacer.fs" />
     <Compile Include="Providers\StructureInference.fs" />
     <Compile Include="Providers\Helpers.fs" />
+    <Compile Include="Providers\AssemblyResolver.fs" />
     <Compile Include="Providers\Debug.fs" />
     <Compile Include="JsonProvider\JsonRuntime.fs" />
     <Compile Include="JsonProvider\JsonInference.fs" />

--- a/src/FSharp.Data.Experimental.DesignTime.Silverlight.fsproj
+++ b/src/FSharp.Data.Experimental.DesignTime.Silverlight.fsproj
@@ -63,6 +63,7 @@
     <Compile Include="Providers\AssemblyReplacer.fs" />
     <Compile Include="Providers\StructureInference.fs" />
     <Compile Include="Providers\Helpers.fs" />
+    <Compile Include="Providers\AssemblyResolver.fs" />
     <Compile Include="Providers\Debug.fs" />
     <Compile Include="JsonProvider\JsonRuntime.fs" />
     <Compile Include="JsonProvider\JsonInference.fs" />
@@ -93,19 +94,7 @@
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
   </PropertyGroup>
   <Import Project="DefineConstants.targets" />
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '11.0'">
-      <PropertyGroup>
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
+  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets" Condition=" Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Silverlight\$(SilverlightVersion)\Microsoft.Silverlight.Common.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/FSharp.Data.Experimental.DesignTime.fsproj
+++ b/src/FSharp.Data.Experimental.DesignTime.fsproj
@@ -53,6 +53,7 @@
     <Compile Include="Providers\AssemblyReplacer.fs" />
     <Compile Include="Providers\StructureInference.fs" />
     <Compile Include="Providers\Helpers.fs" />
+    <Compile Include="Providers\AssemblyResolver.fs" />
     <Compile Include="Providers\Debug.fs" />
     <Compile Include="JsonProvider\JsonRuntime.fs" />
     <Compile Include="JsonProvider\JsonInference.fs" />

--- a/src/FSharp.Data.Experimental.Portable.fsproj
+++ b/src/FSharp.Data.Experimental.Portable.fsproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <BaseOutputPath>bin\portable\</BaseOutputPath>
     <BaseIntermediateOutputPath>obj\portable\</BaseIntermediateOutputPath>
-    <TargetFSharpCoreVersion>2.3.5.0</TargetFSharpCoreVersion>
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -50,28 +49,15 @@
     <Compile Include="AssemblyInfo.Experimental.fs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="FSharp.Core">
-      <HintPath>$(MSBuildExtensionsPath32)\..\Reference Assemblies\Microsoft\FSharp\.NETPortable\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FSharp.Core, Version=2.3.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>$(MSBuildExtensionsPath32)\..\Reference Assemblies\Microsoft\FSharp\3.0\Runtime\.NETPortable\FSharp.Core.dll</HintPath>
     </Reference>
   </ItemGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
   </PropertyGroup>
   <Import Project="DefineConstants.targets" />
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '11.0'">
-      <PropertyGroup>
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.Portable.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.Portable.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
+  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets" Condition=" Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/FSharp.Data.Portable.fsproj
+++ b/src/FSharp.Data.Portable.fsproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <BaseOutputPath>bin\portable\</BaseOutputPath>
     <BaseIntermediateOutputPath>obj\portable\</BaseIntermediateOutputPath>
-    <TargetFSharpCoreVersion>2.3.5.0</TargetFSharpCoreVersion>
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -58,28 +57,15 @@
     <Compile Include="AssemblyInfo.fs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="FSharp.Core">
-      <HintPath>$(MSBuildExtensionsPath32)\..\Reference Assemblies\Microsoft\FSharp\.NETPortable\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FSharp.Core, Version=2.3.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>$(MSBuildExtensionsPath32)\..\Reference Assemblies\Microsoft\FSharp\3.0\Runtime\.NETPortable\FSharp.Core.dll</HintPath>
     </Reference>
   </ItemGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
   </PropertyGroup>
   <Import Project="DefineConstants.targets" />
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '11.0'">
-      <PropertyGroup>
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.Portable.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.Portable.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
+  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets" Condition=" Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/FSharp.Data.Silverlight.fsproj
+++ b/src/FSharp.Data.Silverlight.fsproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <BaseOutputPath>bin\sl5\</BaseOutputPath>
     <BaseIntermediateOutputPath>obj\sl5\</BaseIntermediateOutputPath>
-    <TargetFSharpCoreVersion>2.3.5.0</TargetFSharpCoreVersion>
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -68,9 +67,8 @@
     <Compile Include="AssemblyInfo.fs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="FSharp.Core">
-      <HintPath>$(MSBuildExtensionsPath32)\..\Reference Assemblies\Microsoft\FSharp\.NETPortable\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FSharp.Core, Version=2.3.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>$(MSBuildExtensionsPath32)\..\Reference Assemblies\Microsoft\FSharp\3.0\Runtime\.NETPortable\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
@@ -84,19 +82,7 @@
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
   </PropertyGroup>
   <Import Project="DefineConstants.targets" />
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '11.0'">
-      <PropertyGroup>
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
+  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets" Condition=" Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Silverlight\$(SilverlightVersion)\Microsoft.Silverlight.Common.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/FSharp.Data.WindowsPhone7.fsproj
+++ b/src/FSharp.Data.WindowsPhone7.fsproj
@@ -78,19 +78,7 @@
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
   </PropertyGroup>
   <Import Project="DefineConstants.targets" />
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '11.0'">
-      <PropertyGroup>
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
+  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets" Condition=" Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\Silverlight for Phone\$(TargetFrameworkVersion)\Microsoft.Silverlight.$(TargetFrameworkProfile).Overrides.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\Silverlight for Phone\$(TargetFrameworkVersion)\Microsoft.Silverlight.Common.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/JsonProvider/JsonProvider.fs
+++ b/src/JsonProvider/JsonProvider.fs
@@ -1,17 +1,16 @@
 ﻿namespace ProviderImplementation
 
-open System
 open System.IO
 open Microsoft.FSharp.Core.CompilerServices
 open ProviderImplementation.ProvidedTypes
-open ProviderImplementation.StructureInference
+open ProviderImplementation.ProviderHelpers
 open FSharp.Data.Json
 open FSharp.Data.Json.Extensions
 open FSharp.Data.RuntimeImplementation
-open FSharp.Data.RuntimeImplementation.ProviderFileSystem
-open FSharp.Data.RuntimeImplementation.StructuralTypes
 
 // ----------------------------------------------------------------------------------------------
+
+#nowarn "10001"
 
 [<TypeProvider>]
 type public JsonProvider(cfg:TypeProviderConfig) as this =
@@ -20,124 +19,65 @@ type public JsonProvider(cfg:TypeProviderConfig) as this =
   // Generate namespace and type 'FSharp.Data.JsonProvider'
   let asm, replacer = AssemblyResolver.init cfg
   let ns = "FSharp.Data"
-  let jsonProvTy = ProvidedTypeDefinition(asm, ns, "JsonProvider", Some(typeof<obj>))
+  let jsonProvTy = ProvidedTypeDefinition(asm, ns, "JsonProvider", Some typeof<obj>)
 
   let buildTypes (typeName:string) (args:obj[]) =
 
-    // Generate the required type with empty constructor
-    let resTy = ProvidedTypeDefinition(asm, ns, typeName, Some(typeof<obj>))
-    ProvidedConstructor([], InvokeCode = fun _ -> <@@ new obj() @@>)
-    |> resTy.AddMember
+    // Generate the required type
+    let tpType = ProvidedTypeDefinition(asm, ns, typeName, Some typeof<obj>)
 
     // A type that is used to hide all generated domain types
-    let domainTy = ProvidedTypeDefinition("DomainTypes", Some(typeof<obj>))
-    resTy.AddMember(domainTy)
+    let domainTy = ProvidedTypeDefinition("DomainTypes", Some typeof<obj>)
+    tpType.AddMember(domainTy)
 
     let sample = args.[0] :?> string
-    let sampleList = args.[1] :?> bool
-    let culture = args.[2] :?> string
-    let cultureInfo = Operations.GetCulture culture
-    let rootName = args.[3] :?> string
+    let sampleIsList = args.[1] :?> bool
+    let rootName = args.[2] :?> string
+    let culture = args.[3] :?> string
     let resolutionFolder = args.[4] :?> string
-    let isHostedExecution = cfg.IsHostedExecution
-    let defaultResolutionFolder = cfg.ResolutionFolder
 
-    let parse value = 
-      if sampleList then
-        try
-          JsonValue.Parse(value, cultureInfo).AsArray() :> seq<_>
-        with _  ->
-          value.Split('\n', '\r')
-          |> Seq.filter (not << String.IsNullOrWhiteSpace)
-          |> Seq.map (fun value -> JsonValue.Parse(value, cultureInfo))
-      else
-        JsonValue.Parse(value, cultureInfo) |> Seq.singleton
+    let cultureInfo = Operations.GetCulture culture
+    let parseSingle _ value = JsonValue.Parse(value, cultureInfo)
+    let parseList _ value = JsonValue.Parse(value, cultureInfo).AsArray() :> seq<_>
+    
+    let getSpecFromSamples samples = 
 
-    // Infer the schema from a specified uri or inline text
-    let sampleJson, sampleIsUri = 
-      try
-        match ProviderHelpers.tryGetUri sample with
-        | Some uri ->
-            use reader = ProviderHelpers.readTextAtDesignTime defaultResolutionFolder this.Invalidate resolutionFolder uri
-            parse (reader.ReadToEnd()), true
-        | None ->
-            parse sample, false
-      with e ->
-        failwithf "Specified argument is neither a file, nor well-formed JSON: %s" e.Message
+      let inferedType = 
+        [ for sampleJson in samples -> JsonInference.inferType cultureInfo (*allowNulls*)true sampleJson ]
+        |> Seq.fold (StructureInference.subtypeInfered (*allowNulls*)true) StructuralTypes.Top
+  
+      let ctx = JsonGenerationContext.Create(domainTy, replacer)
+      let resTy, resTypConv = JsonTypeBuilder.generateJsonType culture ctx (NameUtils.singularize rootName) inferedType
 
-    let inferedType = 
-      [ for item in sampleJson -> JsonInference.inferType cultureInfo (*allowNulls*)true item ]
-      |> Seq.fold (subtypeInfered (*allowNulls*)true) Top
+      { GeneratedType = tpType
+        RepresentationType = resTy
+        CreateFromTextReader = fun reader -> 
+          resTypConv <@@ JsonDocument.Create(%reader, culture) @@>
+        AsyncCreateFromTextReader = fun readerAsync -> 
+          resTypConv <@@ JsonDocument.AsyncCreate(%readerAsync, culture) @@>
+        CreateFromTextReaderForSampleList = fun reader -> 
+          resTypConv <@@ JsonDocument.CreateList(%reader, culture) @@>
+        AsyncCreateFromTextReaderForSampleList = fun readerAsync -> 
+          resTypConv <@@ JsonDocument.AsyncCreateList(%readerAsync, culture) @@> }
 
-    let ctx = JsonGenerationContext.Create(domainTy, replacer)
-    let methResTy, methResConv = JsonTypeBuilder.generateJsonType culture ctx (NameUtils.singularize rootName) inferedType
-
-    // Generate static Parse method
-    let args = [ ProvidedParameter("text", typeof<string>) ]
-    let m = ProvidedMethod("Parse", args, methResTy, IsStaticMethod = true)
-    m.InvokeCode <- fun (Singleton text) -> 
-      <@@ JsonDocument.Create(JsonValue.Parse(%%text, Operations.GetCulture(culture))) @@>
-      |> methResConv
-    m.AddXmlDoc "Parses the specified JSON string"
-    resTy.AddMember m
-
-    // Generate static Load stream method
-    let args = [ ProvidedParameter("stream", typeof<Stream>) ]
-    let m = ProvidedMethod("Load", args, methResTy, IsStaticMethod = true)
-    m.InvokeCode <- fun (Singleton stream) -> 
-      <@@ JsonDocument.Create(JsonValue.Load((%%stream:Stream), Operations.GetCulture(culture))) @@>
-      |> methResConv
-    m.AddXmlDoc "Loads JSON from the specified stream"
-    resTy.AddMember m
-
-    // Generate static Load reader method
-    let args = [ ProvidedParameter("reader", typeof<TextReader>) ]
-    let m = ProvidedMethod("Load", args, methResTy, IsStaticMethod = true)
-    m.InvokeCode <- fun (Singleton reader) -> 
-      <@@ JsonDocument.Create(JsonValue.Load((%%reader:TextReader), Operations.GetCulture(culture))) @@>
-      |> methResConv
-    m.AddXmlDoc "Loads JSON from the specified reader"
-    resTy.AddMember m
-
-    // Generate static Load uri method
-    let args = [ ProvidedParameter("uri", typeof<string>) ]
-    let m = ProvidedMethod("Load", args, methResTy, IsStaticMethod = true)
-    m.InvokeCode <- fun (Singleton uri) -> 
-      <@@ use reader = readTextAtRunTime isHostedExecution defaultResolutionFolder resolutionFolder %%uri
-          JsonDocument.Create(JsonValue.Parse(reader.ReadToEnd(), Operations.GetCulture(culture))) @@>
-      |> methResConv 
-    m.AddXmlDoc "Loads JSON from the specified uri"
-    resTy.AddMember m
-
-    if not sampleList then
-      // Generate static GetSample method
-      let m = ProvidedMethod("GetSample", [], methResTy, IsStaticMethod = true)
-      m.InvokeCode <- fun _ -> 
-        (if sampleIsUri then
-          <@@ use reader = readTextAtRunTimeWithDesignTimeOptions defaultResolutionFolder resolutionFolder sample
-              JsonDocument.Create(JsonValue.Parse(reader.ReadToEnd(), Operations.GetCulture(culture))) @@>
-         else
-          <@@ JsonDocument.Create(JsonValue.Parse(sample, Operations.GetCulture(culture))) @@>)
-        |> methResConv
-      resTy.AddMember m
-
-    // Return the generated type
-    resTy
+    generateConstructors "JSON" sample sampleIsList
+                         parseSingle parseList getSpecFromSamples 
+                         this cfg replacer resolutionFolder
 
   // Add static parameter that specifies the API we want to get (compile-time) 
   let parameters = 
     [ ProvidedStaticParameter("Sample", typeof<string>)
-      ProvidedStaticParameter("SampleList", typeof<bool>, parameterDefaultValue = false) 
-      ProvidedStaticParameter("Culture", typeof<string>, parameterDefaultValue = "") 
+      ProvidedStaticParameter("SampleIsList", typeof<bool>, parameterDefaultValue = false) 
       ProvidedStaticParameter("RootName", typeof<string>, parameterDefaultValue = "") 
+      ProvidedStaticParameter("Culture", typeof<string>, parameterDefaultValue = "") 
       ProvidedStaticParameter("ResolutionFolder", typeof<string>, parameterDefaultValue = "") ]
 
   let helpText = 
     """<summary>Typed representation of a JSON document</summary>
        <param name='Sample'>Location of a JSON sample file or a string containing a sample JSON document</param>
-       <param name='SampleList'>If true, sample should be a list of individual samples for the inference.</param>
-       <param name='Culture'>The culture used for parsing numbers and dates.</param>
+       <param name='SampleIsList'>If true, sample should be a list of individual samples for the inference.</param>
        <param name='RootName'>The name to be used to the root type. Defaults to 'Entity'.</param>
+       <param name='Culture'>The culture used for parsing numbers and dates.</param>
        <param name='ResolutionFolder'>A directory that is used when resolving relative file references (at design time and in hosted execution)</param>"""
 
   do jsonProvTy.AddXmlDoc helpText

--- a/src/Library/CsvRuntime.fs
+++ b/src/Library/CsvRuntime.fs
@@ -120,8 +120,17 @@ type CsvFile<'RowType> private (rowToStringArray:Func<'RowType,string[]>, dispos
 
   [<EditorBrowsableAttribute(EditorBrowsableState.Never)>]
   [<CompilerMessageAttribute("This method is not intended for use from F#.", 10001, IsHidden=true, IsError=false)>]
-  static member CreateNonReentrant (stringArrayToRow, rowToStringArray, reader:TextReader, separators, quote, hasHeaders, ignoreErrors) =
-    new CsvFile<'RowType>(stringArrayToRow, rowToStringArray, Func<_>(fun _ -> reader), separators, quote, hasHeaders, ignoreErrors)
+  static member CreateNonReentrant (stringArrayToRow, rowToStringArray, reader:TextReader, separators, quote, hasHeaders, ignoreErrors, cacheRows) =    
+    let uncachedCsv = new CsvFile<'RowType>(stringArrayToRow, rowToStringArray, Func<_>(fun _ -> reader), separators, quote, hasHeaders, ignoreErrors)
+    if cacheRows then uncachedCsv.Cache() else uncachedCsv
+
+  [<EditorBrowsableAttribute(EditorBrowsableState.Never)>]
+  [<CompilerMessageAttribute("This method is not intended for use from F#.", 10001, IsHidden=true, IsError=false)>]
+  static member AsyncCreateNonReentrant (stringArrayToRow, rowToStringArray, asyncReader:Async<TextReader>, separators, quote, hasHeaders, ignoreErrors, cacheRows) = async {
+    let! reader = asyncReader
+    let uncachedCsv = new CsvFile<'RowType>(stringArrayToRow, rowToStringArray, Func<_>(fun _ -> reader), separators, quote, hasHeaders, ignoreErrors)
+    return if cacheRows then uncachedCsv.Cache() else uncachedCsv
+  }
 
   new (stringArrayToRow, rowToStringArray, readerFunc:Func<TextReader>, separators, quote, hasHeaders, ignoreErrors) as this =
   

--- a/src/Library/Json.fs
+++ b/src/Library/Json.fs
@@ -212,21 +212,31 @@ type private JsonParser(jsonText:string, culture:CultureInfo option) =
 type JsonValue with
 
   /// Parses the specified JSON string
-  static member Parse(text, ?culture) = JsonParser(text, culture).Parse()
+  static member Parse(text, ?culture) = 
+    JsonParser(text, culture).Parse()
 
   /// Loads JSON from the specified stream
   static member Load(stream:Stream, ?culture) = 
     use reader = new StreamReader(stream)
-    JsonParser(reader.ReadToEnd(), culture).Parse()
+    let text = reader.ReadToEnd()
+    JsonParser(text, culture).Parse()
 
   /// Loads JSON from the specified reader
   static member Load(reader:TextReader, ?culture) = 
-    JsonParser(reader.ReadToEnd(), culture).Parse()
+    let text = reader.ReadToEnd()
+    JsonParser(text, culture).Parse()
+
+  /// Loads JSON from the specified uri  asynchronously
+  static member AsyncLoad(uri:string, ?culture) = async {
+    let! reader = asyncReadTextAtRuntime false "" "" uri
+    let text = reader.ReadToEnd()
+    return JsonParser(text, culture).Parse()
+  }
 
   /// Loads JSON from the specified uri
-  static member Load(uri, ?culture) = 
-    use reader = readTextAtRunTime false "" "" uri
-    JsonParser(reader.ReadToEnd(), culture).Parse()
+  static member Load(uri:string, ?culture) =
+    JsonValue.AsyncLoad(uri, ?culture=culture)
+    |> Async.RunSynchronously
 
 // --------------------------------------------------------------------------------------
 // Unsafe extensions for simple JSON processing

--- a/src/Providers/AssemblyReplacer.fs
+++ b/src/Providers/AssemblyReplacer.fs
@@ -126,7 +126,8 @@ module AssemblyReplacer =
   // there might be multiple assemblies involved in generic types
   and private getAssemblies t =
     let rec innerGetAssemblies (t:Type) = seq {
-      yield t.Assembly
+      if not <| t :? ProvidedSymbolType then
+        yield t.Assembly
       if t.IsGenericType && not t.IsGenericTypeDefinition then
         for t in t.GetGenericArguments() do
           yield! innerGetAssemblies t

--- a/src/Providers/AssemblyResolver.fs
+++ b/src/Providers/AssemblyResolver.fs
@@ -1,0 +1,165 @@
+﻿module ProviderImplementation.AssemblyResolver
+
+open System
+open System.IO
+open System.Reflection
+open Microsoft.FSharp.Core.CompilerServices
+
+#if SILVERLIGHT
+
+let onUiThread f = 
+    if System.Windows.Deployment.Current.Dispatcher.CheckAccess() then 
+        f() 
+    else
+        let resultTask = System.Threading.Tasks.TaskCompletionSource<'T>()
+        System.Windows.Deployment.Current.Dispatcher.BeginInvoke(Action(fun () -> try resultTask.SetResult (f()) with err -> resultTask.SetException err)) |> ignore
+        resultTask.Task.Result
+
+let init (cfg : TypeProviderConfig) = 
+
+    let runtimeAssembly = 
+        onUiThread (fun () ->
+            let assemblyPart = System.Windows.AssemblyPart()
+            let FileStreamReadShim(fileName) = 
+                match System.Windows.Application.GetResourceStream(System.Uri(fileName,System.UriKind.Relative)) with 
+                | null -> System.IO.IsolatedStorage.IsolatedStorageFile.GetUserStoreForApplication().OpenFile(fileName, System.IO.FileMode.Open) :> System.IO.Stream 
+                | resStream -> resStream.Stream
+            let assemblyStream = FileStreamReadShim cfg.RuntimeAssembly
+        
+            assemblyPart.Load(assemblyStream))
+
+    runtimeAssembly, AssemblyReplacer.create []
+
+#else
+
+let private (++) a b = Path.Combine(a,b)
+
+let private referenceAssembliesPath = 
+    Environment.GetFolderPath Environment.SpecialFolder.ProgramFilesX86 
+    ++ "Reference Assemblies" 
+    ++ "Microsoft" 
+
+let private fsharp30PortableAssembliesPath = 
+    referenceAssembliesPath
+    ++ "FSharp" 
+    ++ "3.0" 
+    ++ "Runtime" 
+    ++ ".NETPortable"
+
+let private fsharp30Net40AssembliesPath = 
+    referenceAssembliesPath
+    ++ "FSharp" 
+    ++ "3.0" 
+    ++ "Runtime" 
+    ++ "v4.0"
+
+let private net40AssembliesPath = 
+    referenceAssembliesPath
+    ++ "Framework" 
+    ++ ".NETFramework" 
+    ++ "v4.0" 
+
+let private portable40AssembliesPath = 
+    referenceAssembliesPath
+    ++ "Framework" 
+    ++ ".NETPortable" 
+    ++ "v4.0" 
+    ++ "Profile" 
+    ++ "Profile47" 
+
+let private silverlight5AssembliesPath = 
+    referenceAssembliesPath
+    ++ "Framework" 
+    ++ "Silverlight" 
+    ++ "v5.0" 
+
+let private silverlight5SdkAssembliesPath = 
+    Environment.GetFolderPath Environment.SpecialFolder.ProgramFilesX86 
+    ++ "Microsoft SDKs" 
+    ++ "Silverlight" 
+    ++ "v5.0" 
+    ++ "Libraries"
+    ++ "Client"
+
+let private designTimeAssemblies = 
+    AppDomain.CurrentDomain.GetAssemblies()
+    |> Seq.map (fun asm -> asm.GetName().Name, asm)
+    // If there are dups, Map.ofSeq will take the last one. When the portable version
+    // is already loaded, it will be the last one and replace the full version on the
+    // map. We don't want that, so we use distinct to only keep the first version of
+    // each assembly (assumes CurrentDomain.GetAssemblies() returns assemblies in
+    // load order, must check if that's also true for Mono)
+    |> Seq.distinctBy fst 
+    |> Map.ofSeq
+
+let private getAssembly (asmName:AssemblyName) reflectionOnly = 
+    let folder = 
+        let version = 
+            if asmName.Version = null // version is null when trying to load the log4net assembly when running tests inside NUnit
+            then "" else asmName.Version.ToString()
+        match asmName.Name, version with
+        | "FSharp.Core", "4.3.0.0" -> fsharp30Net40AssembliesPath
+        | "FSharp.Core", "2.3.5.0" -> fsharp30PortableAssembliesPath
+        | _, "4.0.0.0" -> net40AssembliesPath
+        | _, "2.0.5.0" -> portable40AssembliesPath
+        | "System.Xml.Linq", "5.0.5.0" -> silverlight5SdkAssembliesPath
+        | _, "5.0.5.0" -> silverlight5AssembliesPath
+        | _, _ -> null
+    if folder = null then 
+        null
+    else
+        let assemblyPath = folder ++ (asmName.Name + ".dll")
+        if File.Exists assemblyPath then
+            if reflectionOnly then Assembly.ReflectionOnlyLoadFrom assemblyPath
+            else Assembly.LoadFrom assemblyPath 
+        else null
+
+let mutable private initialized = false    
+
+let init (cfg : TypeProviderConfig) = 
+
+    if not initialized then
+        initialized <- true
+        AppDomain.CurrentDomain.add_AssemblyResolve(fun _ args -> getAssembly (AssemblyName args.Name) false)
+        AppDomain.CurrentDomain.add_ReflectionOnlyAssemblyResolve(fun _ args -> getAssembly (AssemblyName args.Name) true)
+    
+    let isPortable = cfg.SystemRuntimeAssemblyVersion = new Version(2, 0, 5, 0)
+    let isSilverlight = cfg.SystemRuntimeAssemblyVersion = new Version(5, 0, 5, 0)
+    let isFSharp31 = typedefof<option<_>>.Assembly.GetName().Version = new Version(4, 3, 1, 0)
+
+    let differentFramework = isPortable || isSilverlight || isFSharp31
+    let useReflectionOnly =
+        differentFramework &&
+        // Ideally we would always use reflectionOnly, but that creates problems in Windows 8
+        // apps with the System.Core.dll version, so we set to false for portable
+        (not isPortable || isFSharp31)
+
+    let runtimeAssembly = 
+        if useReflectionOnly then Assembly.ReflectionOnlyLoadFrom cfg.RuntimeAssembly
+        else Assembly.LoadFrom cfg.RuntimeAssembly
+
+    let mainRuntimeAssemblyPair = Assembly.GetExecutingAssembly(), runtimeAssembly
+
+    let asmMappings = 
+        if differentFramework then
+            let runtimeAsmsPairs = 
+                runtimeAssembly.GetReferencedAssemblies()
+                |> Seq.filter (fun asmName -> asmName.Name <> "mscorlib")
+                |> Seq.choose (fun asmName -> 
+                    designTimeAssemblies.TryFind asmName.Name
+                    |> Option.bind (fun designTimeAsm ->
+                        let targetAsm = getAssembly asmName useReflectionOnly
+                        if targetAsm <> null && (targetAsm.FullName <> designTimeAsm.FullName ||
+                                                 targetAsm.ReflectionOnly <> designTimeAsm.ReflectionOnly) then 
+                          Some (designTimeAsm, targetAsm)
+                        else None))
+                |> Seq.toList
+            if runtimeAsmsPairs = [] then
+                failwithf "Something went wrong when creating the assembly mappings"
+            mainRuntimeAssemblyPair::runtimeAsmsPairs
+        else
+            [mainRuntimeAssemblyPair]
+
+    runtimeAssembly, AssemblyReplacer.create asmMappings
+
+#endif

--- a/src/Providers/Helpers.fs
+++ b/src/Providers/Helpers.fs
@@ -7,6 +7,7 @@ namespace ProviderImplementation
 open System
 open System.IO
 open Microsoft.FSharp.Core.CompilerServices
+open Microsoft.FSharp.Quotations
 open FSharp.Data.RuntimeImplementation.StructuralTypes
 open ProviderImplementation.ProvidedTypes
 open ProviderImplementation.StructureInference
@@ -85,38 +86,207 @@ module ProviderHelpers =
   open System.IO
   open FSharp.Data.RuntimeImplementation.Caching
   open FSharp.Data.RuntimeImplementation.ProviderFileSystem
-  open FSharp.Net
 
-  let private webUrisCache, _ = createInternetFileCache "DesignTimeURLs" (TimeSpan.FromMinutes 30.0)
+  let private invalidChars = [ for c in "\"|<>{}[]," -> c ] @ [ for i in 0..31 -> char i ] |> set
+  let private webUrisCache, _ = createInternetFileCache "DesignTimeURIs" (TimeSpan.FromMinutes 30.0)
+  
+  /// Reads a sample parameter for a type provider, detecting if it is a uri and fetching it if needed
+  /// Samples from the web are cached for 30 minutes
+  /// Samples from the filesystem are read using shared read, so it works when the file is locked by Excel or similar tools,
+  /// and a filesystem watcher that calls the invalidate function whenever the file changes is setup
+  /// 
+  /// Parameters:
+  /// * sampleOrSampleUri - the text which can be a sample or an uri for a sample
+  /// * parseFunc - receives the file/url extension (or ""  if not applicable) and the text value 
+  /// * formatName - the description of what is being parsed (for the error message)
+  /// * tp -> the type provider
+  /// * cfg -> the type provider config
+  /// * resolutionFolder -> if the type provider allows to override the resolutionFolder pass it here
+  let parseTextAtDesignTime sampleOrSampleUri parseFunc formatName
+                            (tp:TypeProviderForNamespaces) (cfg:TypeProviderConfig) resolutionFolder =
+  
+      let tryGetUri str =
+          match Uri.TryCreate(str, UriKind.RelativeOrAbsolute) with
+          | false, _ -> None
+          | true, uri ->
+              if not uri.IsAbsoluteUri && (str |> Seq.exists (fun c -> invalidChars.Contains c)) 
+              then None else Some uri
+  
+      try
+        match tryGetUri sampleOrSampleUri with
+        | None -> parseFunc "" sampleOrSampleUri, false
+        | Some uri ->
 
-  /// Resolve a location of a file (or a web location) and open it for shared
-  /// read, and trigger the specified function whenever the file changes
-  let readTextAtDesignTime defaultResolutionFolder invalidate resolutionFolder uri = 
-    if isWeb uri then
-      let value = 
-        match webUrisCache.TryRetrieve uri.OriginalString with
-        | Some value -> value
-        | None ->
-            let value = Http.RequestString(uri.OriginalString)
-            webUrisCache.Set(uri.OriginalString, value)
-            value
-      new StringReader(value) :> TextReader
-    else
-      let stream = 
-        asyncOpenStreamInProvider true (false, defaultResolutionFolder) (Some invalidate) resolutionFolder uri
-        |> Async.RunSynchronously
-      new StreamReader(stream) :> TextReader
+            let resolver = 
+              { ResolutionType = DesignTime
+                DefaultResolutionFolder = cfg.ResolutionFolder
+                ResolutionFolder = resolutionFolder }
+            
+            let readText() = 
+              Async.RunSynchronously <| async {
+                  use! stream = asyncOpenStream (Some tp.Invalidate) resolver uri
+                  use reader = new StreamReader(stream)
+                  return reader.ReadToEnd()
+              } 
+            
+            let sample = 
+              if isWeb uri then
+                  match webUrisCache.TryRetrieve uri.OriginalString with
+                  | Some value -> value
+                  | None ->
+                      let value = readText()
+                      webUrisCache.Set(uri.OriginalString, value)
+                      value
+              else readText()
+                
+            parseFunc (Path.GetExtension uri.OriginalString) sample, true
+        
+      with e ->
+        failwithf "Specified argument is neither a file, nor well-formed %s: %s" formatName e.Message
 
-  let invalidChars = [ for c in "\"|<>{}[]," -> c ] @ [ for i in 0..31 -> char i ] |> set
+  // carries part of the information needed by generateConstructors
+  type TypeProviderSpec = 
+    { //the generated type
+      GeneratedType : ProvidedTypeDefinition 
+      //the representation type (what's returned from the constructors, may or may not be the same as Type)
+      RepresentationType : Type 
+      // the constructor from a text reader to the representation
+      CreateFromTextReader : Expr<TextReader> -> Expr
+      // async version of the constructor from a text reader to the representation
+      AsyncCreateFromTextReader : Expr<Async<TextReader>> -> Expr
+      // the constructor from a text reader to an array of the representation
+      CreateFromTextReaderForSampleList : Expr<TextReader> -> Expr
+      // async version of the constructor from a text reader to an array of the representation
+      AsyncCreateFromTextReaderForSampleList : Expr<Async<TextReader>> -> Expr }
 
-  let tryGetUri str =
-    match Uri.TryCreate(str, UriKind.RelativeOrAbsolute) with
-    | false, _ -> None
-    | true, uri ->
-        if not uri.IsAbsoluteUri && (str |> Seq.exists (fun c -> invalidChars.Contains c)) then
-          None
-        else
-          Some uri
+  /// Creates all the constructors for a type provider: (Async)Parse, (Async)Load, (Async)GetSample(s)
+  /// * sampleOrSampleUri - the text which can be a sample or an uri for a sample
+  /// * sampleIsList - true if the sample consists of several samples put together
+  /// * parseSingle - receives the file/url extension (or ""  if not applicable) and the text value 
+  /// * parseList - receives the file/url extension (or ""  if not applicable) and the text value 
+  /// * getSpecFromSamples - receives a seq of parsed samples and returns a TypeProviderSpec
+  /// * tp -> the type provider
+  /// * cfg -> the type provider config
+  /// * replaceer -> the assemblyReplacer
+  /// * resolutionFolder -> if the type provider allows to override the resolutionFolder pass it here
+  let generateConstructors formatName sampleOrSampleUri sampleIsList parseSingle parseList getSpecFromSamples
+                           (tp:TypeProviderForNamespaces) (cfg:TypeProviderConfig) (replacer:AssemblyReplacer) resolutionFolder =
+
+    let isRunningInFSI = cfg.IsHostedExecution
+    let defaultResolutionFolder = cfg.ResolutionFolder
+
+    let parse extension (value:string) = 
+      if sampleIsList then
+        try
+          parseList extension value
+        with _  ->
+          value.Split('\n', '\r')
+          |> Seq.filter (not << String.IsNullOrWhiteSpace)
+          |> Seq.map (parseSingle extension)
+      else
+        parseSingle extension value |> Seq.singleton
+
+    // Infer the schema from a specified uri or inline text
+    let typedSamples, sampleIsUri = parseTextAtDesignTime sampleOrSampleUri parse formatName tp cfg resolutionFolder
+
+    let spec = getSpecFromSamples typedSamples
+    
+    let resultType = spec.RepresentationType
+    let resultTypeAsync = typedefof<Async<_>>.MakeGenericType [| spec.RepresentationType |] |> replacer.ToRuntime
+
+    [ // Generate static Parse method
+      let args = [ ProvidedParameter("text", typeof<string>) ]
+      let m = ProvidedMethod("Parse", args, resultType, IsStaticMethod = true)
+      m.InvokeCode <- fun (Singleton text) -> 
+        <@ new StringReader(%%text) :> TextReader @>
+        |> spec.CreateFromTextReader 
+      m.AddXmlDoc <| sprintf "Parses the specified %s string" formatName
+      yield m
+      
+      // Generate static Load stream method
+      let args = [ ProvidedParameter("stream", typeof<Stream>) ]
+      let m = ProvidedMethod("Load", args, resultType, IsStaticMethod = true)
+      m.InvokeCode <- fun (Singleton stream) ->       
+        <@ new StreamReader(%%stream:Stream) :> TextReader @>
+        |> spec.CreateFromTextReader 
+      m.AddXmlDoc <| sprintf "Loads %s from the specified stream" formatName
+      yield m
+
+      // Generate static Load reader method
+      let args = [ ProvidedParameter("reader", typeof<TextReader>) ]
+      let m = ProvidedMethod("Load", args, resultType, IsStaticMethod = true)
+      m.InvokeCode <- fun (Singleton reader) -> 
+        <@ %%reader:TextReader @>
+        |> spec.CreateFromTextReader 
+      m.AddXmlDoc <| sprintf "Loads %s from the specified reader" formatName
+      yield m
+      
+      // Generate static Load uri method
+      let args = [ ProvidedParameter("uri", typeof<string>) ]
+      let m = ProvidedMethod("Load", args, resultType, IsStaticMethod = true)
+      m.InvokeCode <- fun (Singleton uri) -> 
+        <@ asyncReadTextAtRuntime isRunningInFSI defaultResolutionFolder resolutionFolder %%uri
+           |> Async.RunSynchronously @>
+        |> spec.CreateFromTextReader 
+      m.AddXmlDoc <| sprintf "Loads %s from the specified uri" formatName
+      yield m
+
+      // Generate static AsyncLoad uri method
+      let args = [ ProvidedParameter("uri", typeof<string>) ]
+      let m = ProvidedMethod("AsyncLoad", args, resultTypeAsync, IsStaticMethod = true)
+      m.InvokeCode <- fun (Singleton uri) -> 
+        <@ asyncReadTextAtRuntime isRunningInFSI defaultResolutionFolder resolutionFolder %%uri @>
+        |> spec.AsyncCreateFromTextReader
+      m.AddXmlDoc <| sprintf "Loads %s from the specified uri" formatName
+      yield m
+      
+      if sampleIsList then
+
+        let resultTypeArray = spec.RepresentationType.MakeArrayType()
+        let resultTypeArrayAsync = typedefof<Async<_>>.MakeGenericType [| resultTypeArray |] |> replacer.ToRuntime
+
+        // Generate static GetSamples method
+        let m = ProvidedMethod("GetSamples", [], resultTypeArray, IsStaticMethod = true)
+        m.InvokeCode <- fun _ -> 
+          (if sampleIsUri 
+           then <@ asyncReadTextAtRuntimeWithDesignTimeRules defaultResolutionFolder resolutionFolder sampleOrSampleUri
+                   |> Async.RunSynchronously @>
+           else <@ new StringReader(sampleOrSampleUri) :> TextReader @>)
+          |> spec.CreateFromTextReaderForSampleList
+        yield m 
+                
+        if sampleIsUri then
+          // Generate static AsyncGetSamples method
+          let m = ProvidedMethod("AsyncGetSamples", [], resultTypeArrayAsync, IsStaticMethod = true)
+          m.InvokeCode <- fun _ -> 
+            <@ asyncReadTextAtRuntimeWithDesignTimeRules defaultResolutionFolder resolutionFolder sampleOrSampleUri @>
+            |> spec.AsyncCreateFromTextReaderForSampleList
+          yield m
+
+      else 
+
+        let name = if resultType.IsArray then "GetSamples" else "GetSample"
+
+        // Generate static GetSample method
+        let m = ProvidedMethod(name, [], resultType, IsStaticMethod = true)
+        m.InvokeCode <- fun _ -> 
+          (if sampleIsUri 
+           then <@ asyncReadTextAtRuntimeWithDesignTimeRules defaultResolutionFolder resolutionFolder sampleOrSampleUri
+                   |> Async.RunSynchronously @>
+           else <@ new StringReader(sampleOrSampleUri) :> TextReader @>)
+          |> spec.CreateFromTextReader
+        yield m 
+        
+        if sampleIsUri then
+          // Generate static AsyncGetSample method
+          let m = ProvidedMethod("Async" + name, [], resultTypeAsync, IsStaticMethod = true)
+          m.InvokeCode <- fun _ -> 
+            <@ asyncReadTextAtRuntimeWithDesignTimeRules defaultResolutionFolder resolutionFolder sampleOrSampleUri @>
+            |> spec.AsyncCreateFromTextReader
+          yield m
+    ] |> spec.GeneratedType.AddMembers
+
+    spec.GeneratedType
 
 // ----------------------------------------------------------------------------------------------
 // Conversions from string to various primitive types
@@ -221,167 +391,3 @@ module Conversions =
 
     returnTyp, returnTypWithoutMeasure, convert, convertBack
 
-// ----------------------------------------------------------------------------------------------
-
-module AssemblyResolver =
-
-#if SILVERLIGHT
-
-    let onUiThread f = 
-        if System.Windows.Deployment.Current.Dispatcher.CheckAccess() then 
-            f() 
-        else
-            let resultTask = System.Threading.Tasks.TaskCompletionSource<'T>()
-            System.Windows.Deployment.Current.Dispatcher.BeginInvoke(Action(fun () -> try resultTask.SetResult (f()) with err -> resultTask.SetException err)) |> ignore
-            resultTask.Task.Result
-
-    let init (cfg : TypeProviderConfig) = 
-
-        let runtimeAssembly = 
-            onUiThread (fun () ->
-                let assemblyPart = System.Windows.AssemblyPart()
-                let FileStreamReadShim(fileName) = 
-                    match System.Windows.Application.GetResourceStream(System.Uri(fileName,System.UriKind.Relative)) with 
-                    | null -> System.IO.IsolatedStorage.IsolatedStorageFile.GetUserStoreForApplication().OpenFile(fileName, System.IO.FileMode.Open) :> System.IO.Stream 
-                    | resStream -> resStream.Stream
-                let assemblyStream = FileStreamReadShim cfg.RuntimeAssembly
-            
-                assemblyPart.Load(assemblyStream))
-
-        runtimeAssembly, AssemblyReplacer.create []
-
-#else
-
-    open System.Reflection
-
-    let private (++) a b = Path.Combine(a,b)
-
-    let private referenceAssembliesPath = 
-        Environment.GetFolderPath Environment.SpecialFolder.ProgramFilesX86 
-        ++ "Reference Assemblies" 
-        ++ "Microsoft" 
-
-    let private fsharp30PortableAssembliesPath = 
-        referenceAssembliesPath
-        ++ "FSharp" 
-        ++ "3.0" 
-        ++ "Runtime" 
-        ++ ".NETPortable"
-
-    let private fsharp30Net40AssembliesPath = 
-        referenceAssembliesPath
-        ++ "FSharp" 
-        ++ "3.0" 
-        ++ "Runtime" 
-        ++ "v4.0"
-
-    let private net40AssembliesPath = 
-        referenceAssembliesPath
-        ++ "Framework" 
-        ++ ".NETFramework" 
-        ++ "v4.0" 
-
-    let private portable40AssembliesPath = 
-        referenceAssembliesPath
-        ++ "Framework" 
-        ++ ".NETPortable" 
-        ++ "v4.0" 
-        ++ "Profile" 
-        ++ "Profile47" 
-
-    let private silverlight5AssembliesPath = 
-        referenceAssembliesPath
-        ++ "Framework" 
-        ++ "Silverlight" 
-        ++ "v5.0" 
-
-    let private silverlight5SdkAssembliesPath = 
-        Environment.GetFolderPath Environment.SpecialFolder.ProgramFilesX86 
-        ++ "Microsoft SDKs" 
-        ++ "Silverlight" 
-        ++ "v5.0" 
-        ++ "Libraries"
-        ++ "Client"
-
-    let private designTimeAssemblies = 
-        AppDomain.CurrentDomain.GetAssemblies()
-        |> Seq.map (fun asm -> asm.GetName().Name, asm)
-        // If there are dups, Map.ofSeq will take the last one. When the portable version
-        // is already loaded, it will be the last one and replace the full version on the
-        // map. We don't want that, so we use distinct to only keep the first version of
-        // each assembly (assumes CurrentDomain.GetAssemblies() returns assemblies in
-        // load order, must check if that's also true for Mono)
-        |> Seq.distinctBy fst 
-        |> Map.ofSeq
-
-    let private getAssembly (asmName:AssemblyName) reflectionOnly = 
-        let folder = 
-            let version = 
-                if asmName.Version = null // version is null when trying to load the log4net assembly when running tests inside NUnit
-                then "" else asmName.Version.ToString()
-            match asmName.Name, version with
-            | "FSharp.Core", "4.3.0.0" -> fsharp30Net40AssembliesPath
-            | "FSharp.Core", "2.3.5.0" -> fsharp30PortableAssembliesPath
-            | _, "4.0.0.0" -> net40AssembliesPath
-            | _, "2.0.5.0" -> portable40AssembliesPath
-            | "System.Xml.Linq", "5.0.5.0" -> silverlight5SdkAssembliesPath
-            | _, "5.0.5.0" -> silverlight5AssembliesPath
-            | _, _ -> null
-        if folder = null then 
-            null
-        else
-            let assemblyPath = folder ++ (asmName.Name + ".dll")
-            if File.Exists assemblyPath then
-                if reflectionOnly then Assembly.ReflectionOnlyLoadFrom assemblyPath
-                else Assembly.LoadFrom assemblyPath 
-            else null
-
-    let mutable private initialized = false    
-
-    let init (cfg : TypeProviderConfig) = 
-
-        if not initialized then
-            initialized <- true
-            AppDomain.CurrentDomain.add_AssemblyResolve(fun _ args -> getAssembly (AssemblyName args.Name) false)
-            AppDomain.CurrentDomain.add_ReflectionOnlyAssemblyResolve(fun _ args -> getAssembly (AssemblyName args.Name) true)
-        
-        let isPortable = cfg.SystemRuntimeAssemblyVersion = new Version(2, 0, 5, 0)
-        let isSilverlight = cfg.SystemRuntimeAssemblyVersion = new Version(5, 0, 5, 0)
-        let isFSharp31 = typedefof<option<_>>.Assembly.GetName().Version = new Version(4, 3, 1, 0)
-
-        let differentFramework = isPortable || isSilverlight || isFSharp31
-        let useReflectionOnly =
-            differentFramework &&
-            // Ideally we would always use reflectionOnly, but that creates problems in Windows 8
-            // apps with the System.Core.dll version, so we set to false for portable
-            (not isPortable || isFSharp31)
-
-        let runtimeAssembly = 
-            if useReflectionOnly then Assembly.ReflectionOnlyLoadFrom cfg.RuntimeAssembly
-            else Assembly.LoadFrom cfg.RuntimeAssembly
-
-        let mainRuntimeAssemblyPair = Assembly.GetExecutingAssembly(), runtimeAssembly
-
-        let asmMappings = 
-            if differentFramework then
-                let runtimeAsmsPairs = 
-                    runtimeAssembly.GetReferencedAssemblies()
-                    |> Seq.filter (fun asmName -> asmName.Name <> "mscorlib")
-                    |> Seq.choose (fun asmName -> 
-                        designTimeAssemblies.TryFind asmName.Name
-                        |> Option.bind (fun designTimeAsm ->
-                            let targetAsm = getAssembly asmName useReflectionOnly
-                            if targetAsm <> null && (targetAsm.FullName <> designTimeAsm.FullName ||
-                                                     targetAsm.ReflectionOnly <> designTimeAsm.ReflectionOnly) then 
-                              Some (designTimeAsm, targetAsm)
-                            else None))
-                    |> Seq.toList
-                if runtimeAsmsPairs = [] then
-                    failwithf "Something went wrong when creating the assembly mappings"
-                mainRuntimeAssemblyPair::runtimeAsmsPairs
-            else
-                [mainRuntimeAssemblyPair]
-
-        runtimeAssembly, AssemblyReplacer.create asmMappings
-
-#endif

--- a/src/Test.fsx
+++ b/src/Test.fsx
@@ -83,44 +83,44 @@ Csv { Sample = "Titanic.csv"
 |> generate |> prettyPrint |> Console.WriteLine
 
 Xml { Sample = "Writers.xml"
+      SampleIsList = false
       Global = false
-      SampleList = false
       Culture = "" 
       ResolutionFolder = "" }
 |> generate |> prettyPrint |> Console.WriteLine
 
 Xml { Sample = "HtmlBody.xml"
+      SampleIsList = false
       Global = true
-      SampleList = false
       Culture = "" 
       ResolutionFolder = "" }
 |> generate |> prettyPrint |> Console.WriteLine
 
 Xml { Sample = "http://tomasp.net/blog/rss.aspx"
+      SampleIsList = false
       Global = false
-      SampleList = false
       Culture = "" 
       ResolutionFolder = "" }
 |> generate |> prettyPrint |> Console.WriteLine
 
 Json { Sample = "WorldBank.json"
-       SampleList = false
-       Culture = "" 
+       SampleIsList = false
        RootName = "WorldBank"
+       Culture = "" 
        ResolutionFolder = "" }
 |> generate |> prettyPrint |> Console.WriteLine
 
 Json { Sample = "TwitterStream.json"
-       SampleList = true
-       Culture = "" 
+       SampleIsList = true
        RootName = ""
+       Culture = "" 
        ResolutionFolder = "" }
 |> generate |> prettyPrint |> Console.WriteLine
 
 Json { Sample = "list_my.json"
-       SampleList = false
-       Culture = "" 
+       SampleIsList = false
        RootName = "Topic"
+       Culture = "" 
        ResolutionFolder = "" }
 |> generate |> prettyPrint |> Console.WriteLine
 

--- a/src/TypeProviderInstantiation.fs
+++ b/src/TypeProviderInstantiation.fs
@@ -19,16 +19,16 @@ type CsvProviderArgs =
 
 type XmlProviderArgs = 
     { Sample : string
+      SampleIsList : bool
       Global : bool
-      SampleList : bool
       Culture : string
       ResolutionFolder : string }
 
 type JsonProviderArgs = 
     { Sample : string
-      SampleList : bool
-      Culture : string
+      SampleIsList : bool
       RootName : string
+      Culture : string
       ResolutionFolder : string }
 
 type WorldBankProviderArgs =
@@ -73,16 +73,16 @@ type TypeProviderInstantiation =
             | Xml x ->
                 (fun cfg -> new XmlProvider(cfg) :> TypeProviderForNamespaces),
                 [| box x.Sample
+                   box x.SampleIsList
                    box x.Global
-                   box x.SampleList
                    box x.Culture
                    box x.ResolutionFolder |] 
             | Json x -> 
                 (fun cfg -> new JsonProvider(cfg) :> TypeProviderForNamespaces),
                 [| box x.Sample
-                   box x.SampleList
-                   box x.Culture
+                   box x.SampleIsList
                    box x.RootName
+                   box x.Culture
                    box x.ResolutionFolder|] 
             | WorldBank x ->
                 (fun cfg -> new WorldBankProvider(cfg) :> TypeProviderForNamespaces),

--- a/src/XmlProvider/XmlGenerator.fs
+++ b/src/XmlProvider/XmlGenerator.fs
@@ -18,7 +18,7 @@ open FSharp.Data.RuntimeImplementation.StructuralTypes
 
 /// Context that is used to generate the XML types.
 type internal XmlGenerationContext =
-  { DomainType : ProvidedTypeDefinition
+  { DomainTypesType : ProvidedTypeDefinition
     Replacer : AssemblyReplacer
     UniqueNiceName : string -> string 
     UnifyGlobally : bool
@@ -26,7 +26,7 @@ type internal XmlGenerationContext =
   static member Create(domainTy, unifyGlobally, replacer) =
     let uniqueNiceName = NameUtils.uniqueGenerator NameUtils.nicePascalName
     uniqueNiceName "XElement" |> ignore
-    { DomainType = domainTy
+    { DomainTypesType = domainTy
       Replacer = replacer
       GeneratedResults = new Dictionary<_, _>()
       UnifyGlobally = unifyGlobally
@@ -74,7 +74,7 @@ module internal XmlTypeBuilder =
     | Record(Some nameWithNS, props) -> 
         let name = XName.Get(nameWithNS).LocalName
         let objectTy = ProvidedTypeDefinition(ctx.UniqueNiceName name, Some(ctx.Replacer.ToRuntime typeof<XmlElement>), HideObjectMethods = true)
-        ctx.DomainType.AddMember(objectTy)
+        ctx.DomainTypesType.AddMember(objectTy)
 
         // If we unify types globally, then save type for this record
         if ctx.UnifyGlobally then
@@ -97,7 +97,7 @@ module internal XmlTypeBuilder =
               // a choice type that is erased to 'option<string>' (for simplicity, assuming that
               // the attribute is always optional)
               let choiceTy = ProvidedTypeDefinition(ctx.UniqueNiceName (name + "Choice"), Some(typeof<option<string>>), HideObjectMethods = true)
-              ctx.DomainType.AddMember(choiceTy)
+              ctx.DomainTypesType.AddMember(choiceTy)
               for KeyValue(kind, typ) in types do 
                 match typ with
                 | InferedType.Null -> ()

--- a/src/XmlProvider/XmlProvider.fs
+++ b/src/XmlProvider/XmlProvider.fs
@@ -1,16 +1,15 @@
 ﻿namespace ProviderImplementation
 
-open System
 open System.IO
 open System.Xml.Linq
 open Microsoft.FSharp.Core.CompilerServices
 open ProviderImplementation.ProvidedTypes
-open ProviderImplementation.StructureInference
+open ProviderImplementation.ProviderHelpers
 open FSharp.Data.RuntimeImplementation
-open FSharp.Data.RuntimeImplementation.ProviderFileSystem
-open FSharp.Data.RuntimeImplementation.StructuralTypes
 
 // ----------------------------------------------------------------------------------------------
+
+#nowarn "10001"
 
 [<TypeProvider>]
 type public XmlProvider(cfg:TypeProviderConfig) as this =
@@ -19,126 +18,65 @@ type public XmlProvider(cfg:TypeProviderConfig) as this =
   // Generate namespace and type 'FSharp.Data.XmlProvider'
   let asm, replacer = AssemblyResolver.init cfg
   let ns = "FSharp.Data"
-  let xmlProvTy = ProvidedTypeDefinition(asm, ns, "XmlProvider", Some(typeof<obj>))
+  let xmlProvTy = ProvidedTypeDefinition(asm, ns, "XmlProvider", Some typeof<obj>)
 
   let buildTypes (typeName:string) (args:obj[]) =
 
-    // Generate the required type with empty constructor
-    let resTy = ProvidedTypeDefinition(asm, ns, typeName, Some(typeof<obj>))
-    ProvidedConstructor([], InvokeCode = fun _ -> <@@ new obj() @@>)
-    |> resTy.AddMember
+    // Generate the required type
+    let tpType = ProvidedTypeDefinition(asm, ns, typeName, Some typeof<obj>)
 
     // A type that is used to hide all generated domain types
-    let domainTy = ProvidedTypeDefinition("DomainTypes", Some(typeof<obj>))
-    resTy.AddMember domainTy
+    let domainTy = ProvidedTypeDefinition("DomainTypes", Some typeof<obj>)
+    tpType.AddMember domainTy
 
     let sample = args.[0] :?> string
-    let globalInference = args.[1] :?> bool
-    let sampleList = args.[2] :?> bool
+    let sampleIsList = args.[1] :?> bool
+    let globalInference = args.[2] :?> bool
     let culture = args.[3] :?> string
-    let cultureInfo = Operations.GetCulture culture
     let resolutionFolder = args.[4] :?> string
-    let isHostedExecution = cfg.IsHostedExecution
-    let defaultResolutionFolder = cfg.ResolutionFolder
 
-    let parse value = 
-      if sampleList then
-        try
-          XDocument.Parse(value).Root.Descendants()
-        with _  ->
-          value.Split('\n', '\r')
-          |> Seq.filter (not << String.IsNullOrWhiteSpace)
-          |> Seq.map (fun value -> XDocument.Parse(value).Root)
-      else
-        XDocument.Parse(value).Root |> Seq.singleton
+    let cultureInfo = Operations.GetCulture culture
+    let parseSingle _ value = XDocument.Parse(value).Root
+    let parseList _ value = XDocument.Parse(value).Root.Descendants()
+    
+    let getSpecFromSamples samples = 
+      let inferedType = 
+        samples
+        |> Seq.map (fun sampleXml -> XmlInference.inferType cultureInfo (*allowNulls*)true globalInference sampleXml)
+        |> Seq.fold (StructureInference.subtypeInfered (*allowNulls*)true) StructuralTypes.Top
 
-    // Infer the schema from a specified uri or inline text
-    let sampleXml, sampleIsUri = 
-      try
-        match ProviderHelpers.tryGetUri sample with
-        | Some uri ->
-            use reader = ProviderHelpers.readTextAtDesignTime defaultResolutionFolder this.Invalidate resolutionFolder uri
-            parse (reader.ReadToEnd()), true
-        | None ->
-            parse sample, false
-      with e ->
-        failwithf "Specified argument is neither a file, nor well-formed XML: %s" e.Message
+      let ctx = XmlGenerationContext.Create(domainTy, globalInference, replacer)  
+      let resTy, resTypConv = XmlTypeBuilder.generateXmlType culture ctx inferedType
 
-    let inferedType = 
-      sampleXml
-      |> Seq.map (fun item -> XmlInference.inferType cultureInfo (*allowNulls*)true globalInference item)
-      |> Seq.fold (subtypeInfered (*allowNulls*)true) Top
+      { GeneratedType = tpType
+        RepresentationType = resTy
+        CreateFromTextReader = fun reader -> 
+          resTypConv <@@ XmlElement.Create(%reader) @@>
+        AsyncCreateFromTextReader = fun readerAsync -> 
+          resTypConv <@@ XmlElement.AsyncCreate(%readerAsync) @@>
+        CreateFromTextReaderForSampleList = fun reader -> 
+          resTypConv <@@ XmlElement.CreateList(%reader) @@>
+        AsyncCreateFromTextReaderForSampleList = fun readerAsync -> 
+          resTypConv <@@ XmlElement.AsyncCreateList(%readerAsync) @@> }
 
-    let ctx = XmlGenerationContext.Create(domainTy, globalInference, replacer)
-    let methResTy, methResConv = XmlTypeBuilder.generateXmlType culture ctx inferedType
-
-    // Generate static Parse method
-    let args = [ ProvidedParameter("text", typeof<string>) ]
-    let m = ProvidedMethod("Parse", args, methResTy, IsStaticMethod = true)
-    m.InvokeCode <- fun (Singleton text) -> 
-      <@@ XmlElement.Create(XDocument.Parse(%%text).Root) @@>
-      |> methResConv
-    m.AddXmlDoc "Parses the specified XML string"
-    resTy.AddMember m
-
-    // Generate static Load stream method
-    let args = [ ProvidedParameter("stream", typeof<Stream>) ]
-    let m = ProvidedMethod("Load", args, methResTy, IsStaticMethod = true)
-    m.InvokeCode <- fun (Singleton stream) -> 
-      <@@ use reader = new StreamReader(%%stream:Stream)
-          XmlElement.Create(XDocument.Parse(reader.ReadToEnd()).Root) @@>
-      |> methResConv 
-    m.AddXmlDoc "Loads XML from the specified stream"
-    resTy.AddMember m
-
-    // Generate static Load reader method
-    let args = [ ProvidedParameter("reader", typeof<TextReader>) ]
-    let m = ProvidedMethod("Load", args, methResTy, IsStaticMethod = true)
-    m.InvokeCode <- fun (Singleton reader) -> 
-      <@@ XmlElement.Create(XDocument.Parse((%%reader:TextReader).ReadToEnd()).Root) @@>
-      |> methResConv 
-    m.AddXmlDoc "Loads XML from the specified reader"
-    resTy.AddMember m
-
-    // Generate static Load uri method
-    let args = [ ProvidedParameter("uri", typeof<string>) ]
-    let m = ProvidedMethod("Load", args, methResTy, IsStaticMethod = true)
-    m.InvokeCode <- fun (Singleton uri) -> 
-      <@@ use reader = readTextAtRunTime isHostedExecution defaultResolutionFolder resolutionFolder %%uri
-          XmlElement.Create(XDocument.Parse(reader.ReadToEnd()).Root) @@>
-      |> methResConv
-    m.AddXmlDoc "Loads XML from the specified uri"
-    resTy.AddMember m
-
-    if not sampleList then
-      // Generate static GetSample method
-      let m = ProvidedMethod("GetSample", [],  methResTy, IsStaticMethod = true)
-      m.InvokeCode <- fun _ -> 
-        (if sampleIsUri then
-          <@@ use reader = readTextAtRunTimeWithDesignTimeOptions defaultResolutionFolder resolutionFolder sample
-              XmlElement.Create(XDocument.Parse(reader.ReadToEnd()).Root) @@>
-         else
-          <@@ XmlElement.Create(XDocument.Parse(sample).Root) @@>)
-        |> methResConv
-      resTy.AddMember m
-
-    // Return the generated type
-    resTy
+    generateConstructors "XML" sample sampleIsList
+                         parseSingle parseList getSpecFromSamples 
+                         this cfg replacer resolutionFolder
 
   // Add static parameter that specifies the API we want to get (compile-time) 
   let parameters = 
     [ ProvidedStaticParameter("Sample", typeof<string>)
+      ProvidedStaticParameter("SampleIsList", typeof<bool>, parameterDefaultValue = false)
       ProvidedStaticParameter("Global", typeof<bool>, parameterDefaultValue = false)
-      ProvidedStaticParameter("SampleList", typeof<bool>, parameterDefaultValue = false)
       ProvidedStaticParameter("Culture", typeof<string>, parameterDefaultValue = "") 
       ProvidedStaticParameter("ResolutionFolder", typeof<string>, parameterDefaultValue = "") ]
 
   let helpText = 
     """<summary>Typed representation of a XML file</summary>
        <param name='Sample'>Location of a XML sample file or a string containing a sample XML document</param>
+       <param name='SampleIsList'>If true, the children of the root in the sample document represent individual samples for the inference.</param>
        <param name='Global'>If true, the inference unifies all XML elements with the same name</param>                     
        <param name='Culture'>The culture used for parsing numbers and dates.</param>                     
-       <param name='SampleList'>If true, the children of the root in the sample document represent individual samples for the inference.</param>
        <param name='ResolutionFolder'>A directory that is used when resolving relative file references (at design time and in hosted execution)</param>"""
 
   do xmlProvTy.AddXmlDoc helpText

--- a/src/XmlProvider/XmlRuntime.fs
+++ b/src/XmlProvider/XmlRuntime.fs
@@ -4,17 +4,70 @@
 namespace FSharp.Data.RuntimeImplementation
 
 open System
+open System.ComponentModel
+open System.IO
 open System.Xml.Linq
 open System.Globalization
 
 /// Underlying representation of the generated XML types
 type XmlElement = 
+  
   // NOTE: Using a record here to hide the ToString, GetHashCode & Equals
   // (but since this is used across multiple files, we have explicit Create method)
   { XElement : XElement }
-  /// Creates a JsonDocument representing the specified value
+  
+  /// Creates a XmlElement representing the specified value
+  [<EditorBrowsableAttribute(EditorBrowsableState.Never)>]
+  [<CompilerMessageAttribute("This method is not intended for use from F#.", 10001, IsHidden=true, IsError=false)>]
   static member Create(element) =
     { XElement = element }
+  
+  [<EditorBrowsableAttribute(EditorBrowsableState.Never)>]
+  [<CompilerMessageAttribute("This method is not intended for use from F#.", 10001, IsHidden=true, IsError=false)>]
+  static member Create(reader:TextReader) =    
+    use reader = reader
+    let text = reader.ReadToEnd()
+    let element = XDocument.Parse(text).Root 
+    { XElement = element }
+  
+  [<EditorBrowsableAttribute(EditorBrowsableState.Never)>]
+  [<CompilerMessageAttribute("This method is not intended for use from F#.", 10001, IsHidden=true, IsError=false)>]
+  static member AsyncCreate(readerAsync:Async<TextReader>) = async {
+    use! reader = readerAsync
+    let text = reader.ReadToEnd()
+    let element = XDocument.Parse(text).Root 
+    return { XElement = element }
+  }
+
+  [<EditorBrowsableAttribute(EditorBrowsableState.Never)>]
+  [<CompilerMessageAttribute("This method is not intended for use from F#.", 10001, IsHidden=true, IsError=false)>]
+  static member CreateList(reader:TextReader) = 
+    use reader = reader
+    let text = reader.ReadToEnd()
+    try
+      XDocument.Parse(text).Root.Descendants()
+      |> Seq.map (fun value -> { XElement = value })
+      |> Seq.toArray
+    with _ ->
+      text.Split('\n', '\r')
+      |> Array.filter (not << String.IsNullOrWhiteSpace)
+      |> Array.map (fun text -> { XElement = XDocument.Parse(text).Root })
+
+  [<EditorBrowsableAttribute(EditorBrowsableState.Never)>]
+  [<CompilerMessageAttribute("This method is not intended for use from F#.", 10001, IsHidden=true, IsError=false)>]
+  static member AsyncCreateList(readerAsync:Async<TextReader>) = async {
+    use! reader = readerAsync
+    let text = reader.ReadToEnd()
+    return
+      try
+        XDocument.Parse(text).Root.Descendants()
+        |> Seq.map (fun value -> { XElement = value })
+        |> Seq.toArray
+      with _ ->
+        text.Split('\n', '\r')
+        |> Array.filter (not << String.IsNullOrWhiteSpace)
+        |> Array.map (fun text -> { XElement = XDocument.Parse(text).Root })
+  }
 
 /// Static helper methods called from the generated code
 type XmlOperations = 

--- a/tests/FSharp.Data.Tests.DesignTime/SignatureTestCases.config
+++ b/tests/FSharp.Data.Tests.DesignTime/SignatureTestCases.config
@@ -7,11 +7,11 @@ Csv,LastFM.tsv,,,,false,false,false
 Csv,Titanic.csv,,,,true,false,false
 Csv,Titanic.csv,,,passengerid = int ; Pclass -> Class; Parch -> ParentsOrChildren = int<meter>;SibSp->SiblingsOrSpouse,true,true,true
 Xml,Writers.xml,false,false,
-Xml,HtmlBody.xml,true,false,
-Xml,http://tomasp.net/blog/rss.aspx,true,false,
+Xml,HtmlBody.xml,false,true,
+Xml,http://tomasp.net/blog/rss.aspx,false,true,
 Xml,projects.xml,false,false,
 Xml,Philosophy.xml,false,false,
-Json,WorldBank.json,false,,WorldBank
+Json,WorldBank.json,false,WorldBank,
 Json,TwitterStream.json,true,,
 Json,TwitterSample.json,true,,
 Json,OptionValues.json,false,,
@@ -24,6 +24,6 @@ Json,Empty.json,false,,
 Json,projects.json,false,,
 Json,Dates.json,false,,
 Json,GitHub.json,false,,
-Json,list_my.json,false,,Topic
+Json,list_my.json,false,Topic,
 WorldBank,World Development Indicators;Global Financial Development,true
 Freebase,AIzaSyBTcOKmU7L7gFB4AdyAz75JRmdHixdLYjY,5,true,true

--- a/tests/FSharp.Data.Tests.DesignTime/SignatureTests.fs
+++ b/tests/FSharp.Data.Tests.DesignTime/SignatureTests.fs
@@ -33,15 +33,15 @@ type TestCase =
         | Xml x -> 
             ["Xml"
              x.Sample
+             x.SampleIsList.ToString()
              x.Global.ToString()
-             x.SampleList.ToString()
              x.Culture]
         | Json x -> 
             ["Json"
              x.Sample
-             x.SampleList.ToString()
-             x.Culture
-             x.RootName]
+             x.SampleIsList.ToString()
+             x.RootName
+             x.Culture]
         | WorldBank x -> 
             ["WorldBank"
              x.Sources
@@ -72,15 +72,15 @@ type TestCase =
                   ResolutionFolder = "" }
         | "Xml" ->
             Xml { Sample = args.[1]
-                  Global = args.[2] |> bool.Parse
-                  SampleList = args.[3] |> bool.Parse
+                  SampleIsList = args.[2] |> bool.Parse
+                  Global = args.[3] |> bool.Parse
                   Culture = args.[4]
                   ResolutionFolder = "" }
         | "Json" ->
             Json { Sample = args.[1]
-                   SampleList = args.[2] |> bool.Parse
-                   Culture = args.[3] 
-                   RootName = args.[4]
+                   SampleIsList = args.[2] |> bool.Parse
+                   RootName = args.[3]
+                   Culture = args.[4] 
                    ResolutionFolder = ""}
         | "WorldBank" ->
             WorldBank { Sources = args.[1]

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Csv,AirQuality.csv,;,,,True,False,False.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Csv,AirQuality.csv,;,,,True,False,False.expected
@@ -1,12 +1,13 @@
 class CsvProvider : FDR.CsvFile<CsvProvider+Row>
-    new : () -> CsvProvider
     static member Parse: text:string -> CsvProvider
     static member Load: stream:System.IO.Stream -> CsvProvider
     static member Load: reader:System.IO.TextReader -> CsvProvider
     static member Load: uri:string -> CsvProvider
+    static member AsyncLoad: uri:string -> CsvProvider async
+    static member GetSample: () -> CsvProvider
+    static member AsyncGetSample: () -> CsvProvider async
 
 class CsvProvider+Row : float * float * decimal * int * int * int
-    member AsTuple: float * float * decimal * int * int * int with get
     member Ozone: float with get
     member Solar.R: float with get
     member Wind: decimal with get

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Csv,DnbHistoriskeKurser.csv,,nb-NO,,True,False,False.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Csv,DnbHistoriskeKurser.csv,,nb-NO,,True,False,False.expected
@@ -1,12 +1,13 @@
 class CsvProvider : FDR.CsvFile<CsvProvider+Row>
-    new : () -> CsvProvider
     static member Parse: text:string -> CsvProvider
     static member Load: stream:System.IO.Stream -> CsvProvider
     static member Load: reader:System.IO.TextReader -> CsvProvider
     static member Load: uri:string -> CsvProvider
+    static member AsyncLoad: uri:string -> CsvProvider async
+    static member GetSample: () -> CsvProvider
+    static member AsyncGetSample: () -> CsvProvider async
 
 class CsvProvider+Row : System.DateTime * string * string * string * string * string * string * string * string * string * string
-    member AsTuple: System.DateTime * string * string * string * string * string * string * string * string * string * string with get
     member Dato: System.DateTime with get
     member USD: string with get
     member EUR: string with get

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Csv,LastFM.tsv,,,,False,False,False.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Csv,LastFM.tsv,,,,False,False,False.expected
@@ -1,12 +1,13 @@
 class CsvProvider : FDR.CsvFile<CsvProvider+Row>
-    new : () -> CsvProvider
     static member Parse: text:string -> CsvProvider
     static member Load: stream:System.IO.Stream -> CsvProvider
     static member Load: reader:System.IO.TextReader -> CsvProvider
     static member Load: uri:string -> CsvProvider
+    static member AsyncLoad: uri:string -> CsvProvider async
+    static member GetSample: () -> CsvProvider
+    static member AsyncGetSample: () -> CsvProvider async
 
 class CsvProvider+Row : string * System.DateTime * System.Guid option * string * string * string
-    member AsTuple: string * System.DateTime * System.Guid option * string * string * string with get
     member Column1: string with get
     member Column2: System.DateTime with get
     member Column3: System.Guid option with get

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Csv,MSFT.csv,,,,True,False,False.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Csv,MSFT.csv,,,,True,False,False.expected
@@ -1,12 +1,13 @@
 class CsvProvider : FDR.CsvFile<CsvProvider+Row>
-    new : () -> CsvProvider
     static member Parse: text:string -> CsvProvider
     static member Load: stream:System.IO.Stream -> CsvProvider
     static member Load: reader:System.IO.TextReader -> CsvProvider
     static member Load: uri:string -> CsvProvider
+    static member AsyncLoad: uri:string -> CsvProvider async
+    static member GetSample: () -> CsvProvider
+    static member AsyncGetSample: () -> CsvProvider async
 
 class CsvProvider+Row : System.DateTime * decimal * decimal * decimal * decimal * int * decimal
-    member AsTuple: System.DateTime * decimal * decimal * decimal * decimal * int * decimal with get
     member Date: System.DateTime with get
     member Open: decimal with get
     member High: decimal with get

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Csv,SmallTest.csv,,,,True,False,False.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Csv,SmallTest.csv,,,,True,False,False.expected
@@ -1,12 +1,13 @@
 class CsvProvider : FDR.CsvFile<CsvProvider+Row>
-    new : () -> CsvProvider
     static member Parse: text:string -> CsvProvider
     static member Load: stream:System.IO.Stream -> CsvProvider
     static member Load: reader:System.IO.TextReader -> CsvProvider
     static member Load: uri:string -> CsvProvider
+    static member AsyncLoad: uri:string -> CsvProvider async
+    static member GetSample: () -> CsvProvider
+    static member AsyncGetSample: () -> CsvProvider async
 
 class CsvProvider+Row : string * decimal * decimal
-    member AsTuple: string * decimal * decimal with get
     member Name: string with get
     member Distance: decimal<metre> with get
     member Time: decimal<s> with get

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Csv,Titanic.csv,,,,True,False,False.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Csv,Titanic.csv,,,,True,False,False.expected
@@ -1,12 +1,13 @@
 class CsvProvider : FDR.CsvFile<CsvProvider+Row>
-    new : () -> CsvProvider
     static member Parse: text:string -> CsvProvider
     static member Load: stream:System.IO.Stream -> CsvProvider
     static member Load: reader:System.IO.TextReader -> CsvProvider
     static member Load: uri:string -> CsvProvider
+    static member AsyncLoad: uri:string -> CsvProvider async
+    static member GetSample: () -> CsvProvider
+    static member AsyncGetSample: () -> CsvProvider async
 
 class CsvProvider+Row : int * bool * int * string * string * float * int * int * string * decimal * string * string
-    member AsTuple: int * bool * int * string * string * float * int * int * string * decimal * string * string with get
     member PassengerId: int with get
     member Survived: bool with get
     member Pclass: int with get

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Csv,Titanic.csv,,,passengerid = int ; Pclass -&gt; Class; Parch -&gt; ParentsOrChildren = int&lt;meter&gt;;SibSp-&gt;SiblingsOrSpouse,True,True,True.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Csv,Titanic.csv,,,passengerid = int ; Pclass -&gt; Class; Parch -&gt; ParentsOrChildren = int&lt;meter&gt;;SibSp-&gt;SiblingsOrSpouse,True,True,True.expected
@@ -1,12 +1,13 @@
 class CsvProvider : FDR.CsvFile<CsvProvider+Row>
-    new : () -> CsvProvider
     static member Parse: text:string -> CsvProvider
     static member Load: stream:System.IO.Stream -> CsvProvider
     static member Load: reader:System.IO.TextReader -> CsvProvider
     static member Load: uri:string -> CsvProvider
+    static member AsyncLoad: uri:string -> CsvProvider async
+    static member GetSample: () -> CsvProvider
+    static member AsyncGetSample: () -> CsvProvider async
 
 class CsvProvider+Row : int * bool option * int option * string option * string option * decimal option * int option * int * string option * decimal option * string option * string option
-    member AsTuple: int * bool option * int option * string option * string option * decimal option * int option * int * string option * decimal option * string option * string option with get
     member PassengerId: int with get
     member Survived: bool option with get
     member Class: int option with get

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Csv,file with spaces.csv,,,,True,False,False.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Csv,file with spaces.csv,,,,True,False,False.expected
@@ -1,12 +1,13 @@
 class CsvProvider : FDR.CsvFile<CsvProvider+Row>
-    new : () -> CsvProvider
     static member Parse: text:string -> CsvProvider
     static member Load: stream:System.IO.Stream -> CsvProvider
     static member Load: reader:System.IO.TextReader -> CsvProvider
     static member Load: uri:string -> CsvProvider
+    static member AsyncLoad: uri:string -> CsvProvider async
+    static member GetSample: () -> CsvProvider
+    static member AsyncGetSample: () -> CsvProvider async
 
 class CsvProvider+Row : int * decimal
-    member AsTuple: int * decimal with get
     member Distance: int<metre> with get
     member Time: decimal<second> with get
 

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Freebase,5,True,True.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Freebase,5,True,True.expected
@@ -4,6 +4,7 @@ class FreebaseDataProvider
 class FreebaseDataProvider+ServiceTypes
 
 class FreebaseDataProvider+ServiceTypes+FreebaseService : FDR.Freebase.FreebaseDataContext
+    member Waste: FreebaseDataProvider+ServiceTypes+DomainObjects+Waste with get
     member Sports: FreebaseDataProvider+ServiceTypes+DomainObjects+Sports with get
     member Arts and Entertainment: FreebaseDataProvider+ServiceTypes+DomainObjects+Arts and Entertainment with get
     member Products and Services: FreebaseDataProvider+ServiceTypes+DomainObjects+Products and Services with get
@@ -14,6 +15,9 @@ class FreebaseDataProvider+ServiceTypes+FreebaseService : FDR.Freebase.FreebaseD
     member Time and Space: FreebaseDataProvider+ServiceTypes+DomainObjects+Time and Space with get
     member Transportation: FreebaseDataProvider+ServiceTypes+DomainObjects+Transportation with get
     member Commons: FreebaseDataProvider+ServiceTypes+DomainObjects+Commons with get
+    member afvalnl: FreebaseDataProvider+ServiceTypes+DomainObjects+afvalnl with get
+    member afval: FreebaseDataProvider+ServiceTypes+DomainObjects+afval with get
+    member Afval.nl: FreebaseDataProvider+ServiceTypes+DomainObjects+Afval.nl with get
 
 class FreebaseDataProvider+ServiceTypes+Type
 
@@ -178,6 +182,9 @@ class FreebaseDataProvider+ServiceTypes+Boxing
 class FreebaseDataProvider+ServiceTypes+Uncategorized
 
 class FreebaseDataProvider+ServiceTypes+DomainObjects
+
+class FreebaseDataProvider+ServiceTypes+DomainObjects+Waste : FDR.Freebase.FreebaseDomainCategory
+    member afvalnl's types: <NULL> with get
 
 class FreebaseDataProvider+ServiceTypes+DomainObjects+Sports : FDR.Freebase.FreebaseDomainCategory
     member Soccer: FreebaseDataProvider+ServiceTypes+DomainObjects+SoccerDomain with get
@@ -355,6 +362,15 @@ class FreebaseDataProvider+ServiceTypes+DomainObjects+Commons : FDR.Freebase.Fre
     member Cricket: FreebaseDataProvider+ServiceTypes+DomainObjects+CricketDomain with get
     member Conferences and Conventions: FreebaseDataProvider+ServiceTypes+DomainObjects+Conferences and Conventions Domain with get
     member Projects: FreebaseDataProvider+ServiceTypes+DomainObjects+ProjectsDomain with get
+
+class FreebaseDataProvider+ServiceTypes+DomainObjects+afvalnl : FDR.Freebase.FreebaseDomainCategory
+    member afvalnl's types: <NULL> with get
+
+class FreebaseDataProvider+ServiceTypes+DomainObjects+afval : FDR.Freebase.FreebaseDomainCategory
+    member afvalnl's types: <NULL> with get
+
+class FreebaseDataProvider+ServiceTypes+DomainObjects+Afval.nl : FDR.Freebase.FreebaseDomainCategory
+    member afvalnl's types: <NULL> with get
 
 class FreebaseDataProvider+ServiceTypes+Type+Type
 
@@ -784,6 +800,12 @@ class FreebaseDataProvider+ServiceTypes+DomainObjects+GovernmentDomain : FDR.Fre
     member Poll respondent categories: FreebaseDataProvider+ServiceTypes+Government+Government+Poll_respondent_categoryDataCollection with get
     member Polled entities: FreebaseDataProvider+ServiceTypes+Government+Government+Polled_entityDataCollection with get
     member Election with polls: FreebaseDataProvider+ServiceTypes+Government+Government+Election_with_pollsDataCollection with get
+    member Government Services: FreebaseDataProvider+ServiceTypes+Government+Government+Government_serviceDataCollection with get
+    member Government Service Channels: FreebaseDataProvider+ServiceTypes+Government+Government+Government_service_channelDataCollection with get
+    member Government Issued Permits: FreebaseDataProvider+ServiceTypes+Government+Government+Government_issued_permitDataCollection with get
+    member Government Service Types: FreebaseDataProvider+ServiceTypes+Government+Government+Government_service_typeDataCollection with get
+    member Government Permit Types: FreebaseDataProvider+ServiceTypes+Government+Government+Government_permit_typeDataCollection with get
+    member /government/service_audience_types: FreebaseDataProvider+ServiceTypes+Government+Government+Government_service_audience_typeDataCollection with get
 
 class FreebaseDataProvider+ServiceTypes+DomainObjects+LanguageDomain : FDR.Freebase.FreebaseDomain
     member Human Languages: FreebaseDataProvider+ServiceTypes+Language+Language+Human_languageDataCollection with get
@@ -1268,6 +1290,7 @@ class FreebaseDataProvider+ServiceTypes+DomainObjects+MedicineDomain : FDR.Freeb
     member Drug ingredients: FreebaseDataProvider+ServiceTypes+Medicine+Medicine+Drug_ingredientDataCollection with get
     member Drug dosage flavors: FreebaseDataProvider+ServiceTypes+Medicine+Medicine+Drug_dosage_flavorDataCollection with get
     member Drug regulating authorities: FreebaseDataProvider+ServiceTypes+Medicine+Medicine+Drug_regulating_authorityDataCollection with get
+    member Routed drugs: FreebaseDataProvider+ServiceTypes+Medicine+Medicine+Routed_drugDataCollection with get
 
 class FreebaseDataProvider+ServiceTypes+DomainObjects+MilitaryDomain : FDR.Freebase.FreebaseDomain
     member Armed Forces: FreebaseDataProvider+ServiceTypes+Military+Military+Armed_forceDataCollection with get
@@ -1883,6 +1906,7 @@ class FreebaseDataProvider+ServiceTypes+DomainObjects+TimeDomain : FDR.Freebase.
     member Day Of Weeks: FreebaseDataProvider+ServiceTypes+Time+Time+Day_of_weekDataCollection with get
     member Time Zones: FreebaseDataProvider+ServiceTypes+Time+Time+Time_zoneDataCollection with get
     member Commemorative events: FreebaseDataProvider+ServiceTypes+Time+Time+Commemorative_eventDataCollection with get
+    member Defunct time zones: FreebaseDataProvider+ServiceTypes+Time+Time+Defunct_time_zoneDataCollection with get
 
 class FreebaseDataProvider+ServiceTypes+DomainObjects+InternetDomain : FDR.Freebase.FreebaseDomain
     member Websites: FreebaseDataProvider+ServiceTypes+Internet+Internet+WebsiteDataCollection with get

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Json,Dates.json,False,,.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Json,Dates.json,False,,.expected
@@ -1,10 +1,11 @@
 class JsonProvider
-    new : () -> JsonProvider
     static member Parse: text:string -> JsonProvider+DomainTypes+Entity
     static member Load: stream:System.IO.Stream -> JsonProvider+DomainTypes+Entity
     static member Load: reader:System.IO.TextReader -> JsonProvider+DomainTypes+Entity
     static member Load: uri:string -> JsonProvider+DomainTypes+Entity
+    static member AsyncLoad: uri:string -> JsonProvider+DomainTypes+Entity async
     static member GetSample: () -> JsonProvider+DomainTypes+Entity
+    static member AsyncGetSample: () -> JsonProvider+DomainTypes+Entity async
 
 class JsonProvider+DomainTypes
 

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Json,DoubleNested.json,False,,.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Json,DoubleNested.json,False,,.expected
@@ -1,10 +1,11 @@
 class JsonProvider
-    new : () -> JsonProvider
     static member Parse: text:string -> JsonProvider+DomainTypes+Entity
     static member Load: stream:System.IO.Stream -> JsonProvider+DomainTypes+Entity
     static member Load: reader:System.IO.TextReader -> JsonProvider+DomainTypes+Entity
     static member Load: uri:string -> JsonProvider+DomainTypes+Entity
+    static member AsyncLoad: uri:string -> JsonProvider+DomainTypes+Entity async
     static member GetSample: () -> JsonProvider+DomainTypes+Entity
+    static member AsyncGetSample: () -> JsonProvider+DomainTypes+Entity async
 
 class JsonProvider+DomainTypes
 

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Json,Empty.json,False,,.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Json,Empty.json,False,,.expected
@@ -1,10 +1,11 @@
 class JsonProvider
-    new : () -> JsonProvider
     static member Parse: text:string -> JsonProvider+DomainTypes+Entity
     static member Load: stream:System.IO.Stream -> JsonProvider+DomainTypes+Entity
     static member Load: reader:System.IO.TextReader -> JsonProvider+DomainTypes+Entity
     static member Load: uri:string -> JsonProvider+DomainTypes+Entity
+    static member AsyncLoad: uri:string -> JsonProvider+DomainTypes+Entity async
     static member GetSample: () -> JsonProvider+DomainTypes+Entity
+    static member AsyncGetSample: () -> JsonProvider+DomainTypes+Entity async
 
 class JsonProvider+DomainTypes
 

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Json,GitHub.json,False,,.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Json,GitHub.json,False,,.expected
@@ -1,10 +1,11 @@
 class JsonProvider
-    new : () -> JsonProvider
     static member Parse: text:string -> JsonProvider+DomainTypes+Entity[]
     static member Load: stream:System.IO.Stream -> JsonProvider+DomainTypes+Entity[]
     static member Load: reader:System.IO.TextReader -> JsonProvider+DomainTypes+Entity[]
     static member Load: uri:string -> JsonProvider+DomainTypes+Entity[]
-    static member GetSample: () -> JsonProvider+DomainTypes+Entity[]
+    static member AsyncLoad: uri:string -> JsonProvider+DomainTypes+Entity[] async
+    static member GetSamples: () -> JsonProvider+DomainTypes+Entity[]
+    static member AsyncGetSamples: () -> JsonProvider+DomainTypes+Entity[] async
 
 class JsonProvider+DomainTypes
 

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Json,Nested.json,False,,.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Json,Nested.json,False,,.expected
@@ -1,10 +1,11 @@
 class JsonProvider
-    new : () -> JsonProvider
     static member Parse: text:string -> JsonProvider+DomainTypes+Entity
     static member Load: stream:System.IO.Stream -> JsonProvider+DomainTypes+Entity
     static member Load: reader:System.IO.TextReader -> JsonProvider+DomainTypes+Entity
     static member Load: uri:string -> JsonProvider+DomainTypes+Entity
+    static member AsyncLoad: uri:string -> JsonProvider+DomainTypes+Entity async
     static member GetSample: () -> JsonProvider+DomainTypes+Entity
+    static member AsyncGetSample: () -> JsonProvider+DomainTypes+Entity async
 
 class JsonProvider+DomainTypes
 

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Json,OptionValues.json,False,,.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Json,OptionValues.json,False,,.expected
@@ -1,10 +1,11 @@
 class JsonProvider
-    new : () -> JsonProvider
     static member Parse: text:string -> JsonProvider+DomainTypes+Entity
     static member Load: stream:System.IO.Stream -> JsonProvider+DomainTypes+Entity
     static member Load: reader:System.IO.TextReader -> JsonProvider+DomainTypes+Entity
     static member Load: uri:string -> JsonProvider+DomainTypes+Entity
+    static member AsyncLoad: uri:string -> JsonProvider+DomainTypes+Entity async
     static member GetSample: () -> JsonProvider+DomainTypes+Entity
+    static member AsyncGetSample: () -> JsonProvider+DomainTypes+Entity async
 
 class JsonProvider+DomainTypes
 

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Json,Simple.json,False,,.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Json,Simple.json,False,,.expected
@@ -1,10 +1,11 @@
 class JsonProvider
-    new : () -> JsonProvider
     static member Parse: text:string -> JsonProvider+DomainTypes+Entity
     static member Load: stream:System.IO.Stream -> JsonProvider+DomainTypes+Entity
     static member Load: reader:System.IO.TextReader -> JsonProvider+DomainTypes+Entity
     static member Load: uri:string -> JsonProvider+DomainTypes+Entity
+    static member AsyncLoad: uri:string -> JsonProvider+DomainTypes+Entity async
     static member GetSample: () -> JsonProvider+DomainTypes+Entity
+    static member AsyncGetSample: () -> JsonProvider+DomainTypes+Entity async
 
 class JsonProvider+DomainTypes
 

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Json,SimpleArray.json,False,,.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Json,SimpleArray.json,False,,.expected
@@ -1,10 +1,11 @@
 class JsonProvider
-    new : () -> JsonProvider
     static member Parse: text:string -> JsonProvider+DomainTypes+Entity
     static member Load: stream:System.IO.Stream -> JsonProvider+DomainTypes+Entity
     static member Load: reader:System.IO.TextReader -> JsonProvider+DomainTypes+Entity
     static member Load: uri:string -> JsonProvider+DomainTypes+Entity
+    static member AsyncLoad: uri:string -> JsonProvider+DomainTypes+Entity async
     static member GetSample: () -> JsonProvider+DomainTypes+Entity
+    static member AsyncGetSample: () -> JsonProvider+DomainTypes+Entity async
 
 class JsonProvider+DomainTypes
 

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Json,TwitterSample.json,True,,.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Json,TwitterSample.json,True,,.expected
@@ -1,9 +1,11 @@
 class JsonProvider
-    new : () -> JsonProvider
     static member Parse: text:string -> JsonProvider+DomainTypes+Entity
     static member Load: stream:System.IO.Stream -> JsonProvider+DomainTypes+Entity
     static member Load: reader:System.IO.TextReader -> JsonProvider+DomainTypes+Entity
     static member Load: uri:string -> JsonProvider+DomainTypes+Entity
+    static member AsyncLoad: uri:string -> JsonProvider+DomainTypes+Entity async
+    static member GetSamples: () -> JsonProvider+DomainTypes+Entity[]
+    static member AsyncGetSamples: () -> JsonProvider+DomainTypes+Entity[] async
 
 class JsonProvider+DomainTypes
 

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Json,TwitterStream.json,True,,.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Json,TwitterStream.json,True,,.expected
@@ -1,9 +1,11 @@
 class JsonProvider
-    new : () -> JsonProvider
     static member Parse: text:string -> JsonProvider+DomainTypes+Entity
     static member Load: stream:System.IO.Stream -> JsonProvider+DomainTypes+Entity
     static member Load: reader:System.IO.TextReader -> JsonProvider+DomainTypes+Entity
     static member Load: uri:string -> JsonProvider+DomainTypes+Entity
+    static member AsyncLoad: uri:string -> JsonProvider+DomainTypes+Entity async
+    static member GetSamples: () -> JsonProvider+DomainTypes+Entity[]
+    static member AsyncGetSamples: () -> JsonProvider+DomainTypes+Entity[] async
 
 class JsonProvider+DomainTypes
 

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Json,WikiData.json,False,,.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Json,WikiData.json,False,,.expected
@@ -1,10 +1,11 @@
 class JsonProvider
-    new : () -> JsonProvider
     static member Parse: text:string -> JsonProvider+DomainTypes+Entity
     static member Load: stream:System.IO.Stream -> JsonProvider+DomainTypes+Entity
     static member Load: reader:System.IO.TextReader -> JsonProvider+DomainTypes+Entity
     static member Load: uri:string -> JsonProvider+DomainTypes+Entity
+    static member AsyncLoad: uri:string -> JsonProvider+DomainTypes+Entity async
     static member GetSample: () -> JsonProvider+DomainTypes+Entity
+    static member AsyncGetSample: () -> JsonProvider+DomainTypes+Entity async
 
 class JsonProvider+DomainTypes
 

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Json,WorldBank.json,False,WorldBank,.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Json,WorldBank.json,False,WorldBank,.expected
@@ -1,10 +1,11 @@
 class JsonProvider
-    new : () -> JsonProvider
     static member Parse: text:string -> JsonProvider+DomainTypes+WorldBankChoice
     static member Load: stream:System.IO.Stream -> JsonProvider+DomainTypes+WorldBankChoice
     static member Load: reader:System.IO.TextReader -> JsonProvider+DomainTypes+WorldBankChoice
     static member Load: uri:string -> JsonProvider+DomainTypes+WorldBankChoice
+    static member AsyncLoad: uri:string -> JsonProvider+DomainTypes+WorldBankChoice async
     static member GetSample: () -> JsonProvider+DomainTypes+WorldBankChoice
+    static member AsyncGetSample: () -> JsonProvider+DomainTypes+WorldBankChoice async
 
 class JsonProvider+DomainTypes
 

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Json,list_my.json,False,Topic,.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Json,list_my.json,False,Topic,.expected
@@ -1,10 +1,11 @@
 class JsonProvider
-    new : () -> JsonProvider
     static member Parse: text:string -> JsonProvider+DomainTypes+Topic[]
     static member Load: stream:System.IO.Stream -> JsonProvider+DomainTypes+Topic[]
     static member Load: reader:System.IO.TextReader -> JsonProvider+DomainTypes+Topic[]
     static member Load: uri:string -> JsonProvider+DomainTypes+Topic[]
-    static member GetSample: () -> JsonProvider+DomainTypes+Topic[]
+    static member AsyncLoad: uri:string -> JsonProvider+DomainTypes+Topic[] async
+    static member GetSamples: () -> JsonProvider+DomainTypes+Topic[]
+    static member AsyncGetSamples: () -> JsonProvider+DomainTypes+Topic[] async
 
 class JsonProvider+DomainTypes
 

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Json,projects.json,False,,.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Json,projects.json,False,,.expected
@@ -1,10 +1,11 @@
 class JsonProvider
-    new : () -> JsonProvider
     static member Parse: text:string -> JsonProvider+DomainTypes+Entity
     static member Load: stream:System.IO.Stream -> JsonProvider+DomainTypes+Entity
     static member Load: reader:System.IO.TextReader -> JsonProvider+DomainTypes+Entity
     static member Load: uri:string -> JsonProvider+DomainTypes+Entity
+    static member AsyncLoad: uri:string -> JsonProvider+DomainTypes+Entity async
     static member GetSample: () -> JsonProvider+DomainTypes+Entity
+    static member AsyncGetSample: () -> JsonProvider+DomainTypes+Entity async
 
 class JsonProvider+DomainTypes
 

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Xml,HtmlBody.xml,False,True,.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Xml,HtmlBody.xml,False,True,.expected
@@ -1,10 +1,11 @@
 class XmlProvider
-    new : () -> XmlProvider
     static member Parse: text:string -> XmlProvider+DomainTypes+Div
     static member Load: stream:System.IO.Stream -> XmlProvider+DomainTypes+Div
     static member Load: reader:System.IO.TextReader -> XmlProvider+DomainTypes+Div
     static member Load: uri:string -> XmlProvider+DomainTypes+Div
+    static member AsyncLoad: uri:string -> XmlProvider+DomainTypes+Div async
     static member GetSample: () -> XmlProvider+DomainTypes+Div
+    static member AsyncGetSample: () -> XmlProvider+DomainTypes+Div async
 
 class XmlProvider+DomainTypes
 

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Xml,Philosophy.xml,False,False,.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Xml,Philosophy.xml,False,False,.expected
@@ -1,10 +1,11 @@
 class XmlProvider
-    new : () -> XmlProvider
     static member Parse: text:string -> XmlProvider+DomainTypes+Authors
     static member Load: stream:System.IO.Stream -> XmlProvider+DomainTypes+Authors
     static member Load: reader:System.IO.TextReader -> XmlProvider+DomainTypes+Authors
     static member Load: uri:string -> XmlProvider+DomainTypes+Authors
+    static member AsyncLoad: uri:string -> XmlProvider+DomainTypes+Authors async
     static member GetSample: () -> XmlProvider+DomainTypes+Authors
+    static member AsyncGetSample: () -> XmlProvider+DomainTypes+Authors async
 
 class XmlProvider+DomainTypes
 

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Xml,Writers.xml,False,False,.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Xml,Writers.xml,False,False,.expected
@@ -1,10 +1,11 @@
 class XmlProvider
-    new : () -> XmlProvider
     static member Parse: text:string -> XmlProvider+DomainTypes+Authors
     static member Load: stream:System.IO.Stream -> XmlProvider+DomainTypes+Authors
     static member Load: reader:System.IO.TextReader -> XmlProvider+DomainTypes+Authors
     static member Load: uri:string -> XmlProvider+DomainTypes+Authors
+    static member AsyncLoad: uri:string -> XmlProvider+DomainTypes+Authors async
     static member GetSample: () -> XmlProvider+DomainTypes+Authors
+    static member AsyncGetSample: () -> XmlProvider+DomainTypes+Authors async
 
 class XmlProvider+DomainTypes
 

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Xml,http_tomasp.net_blog_rss.aspx,False,True,.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Xml,http_tomasp.net_blog_rss.aspx,False,True,.expected
@@ -1,10 +1,11 @@
 class XmlProvider
-    new : () -> XmlProvider
     static member Parse: text:string -> XmlProvider+DomainTypes+Rss
     static member Load: stream:System.IO.Stream -> XmlProvider+DomainTypes+Rss
     static member Load: reader:System.IO.TextReader -> XmlProvider+DomainTypes+Rss
     static member Load: uri:string -> XmlProvider+DomainTypes+Rss
+    static member AsyncLoad: uri:string -> XmlProvider+DomainTypes+Rss async
     static member GetSample: () -> XmlProvider+DomainTypes+Rss
+    static member AsyncGetSample: () -> XmlProvider+DomainTypes+Rss async
 
 class XmlProvider+DomainTypes
 

--- a/tests/FSharp.Data.Tests.DesignTime/expected/Xml,projects.xml,False,False,.expected
+++ b/tests/FSharp.Data.Tests.DesignTime/expected/Xml,projects.xml,False,False,.expected
@@ -1,10 +1,11 @@
 class XmlProvider
-    new : () -> XmlProvider
     static member Parse: text:string -> XmlProvider+DomainTypes+Ordercontainer
     static member Load: stream:System.IO.Stream -> XmlProvider+DomainTypes+Ordercontainer
     static member Load: reader:System.IO.TextReader -> XmlProvider+DomainTypes+Ordercontainer
     static member Load: uri:string -> XmlProvider+DomainTypes+Ordercontainer
+    static member AsyncLoad: uri:string -> XmlProvider+DomainTypes+Ordercontainer async
     static member GetSample: () -> XmlProvider+DomainTypes+Ordercontainer
+    static member AsyncGetSample: () -> XmlProvider+DomainTypes+Ordercontainer async
 
 class XmlProvider+DomainTypes
 

--- a/tests/FSharp.Data.Tests/CsvProvider.fs
+++ b/tests/FSharp.Data.Tests/CsvProvider.fs
@@ -22,21 +22,21 @@ type SimpleCsv = CsvProvider<simpleCsv>
 
 [<Test>]
 let ``Bool column correctly infered and accessed`` () = 
-  let csv = new SimpleCsv()
+  let csv = SimpleCsv.GetSample()
   let first = csv.Data |> Seq.head
   let actual:bool = first.Column1
   actual |> should be True
 
 [<Test>]
 let ``Decimal column correctly infered and accessed`` () = 
-  let csv = new SimpleCsv()
+  let csv = SimpleCsv.GetSample()
   let first = csv.Data |> Seq.head
   let actual:decimal = first.Column3
   actual |> should equal 3.0M
 
 [<Test>]
 let ``Guid column correctly infered and accessed`` () = 
-  let csv = new CsvProvider<"Data/LastFM.tsv", HasHeaders=false>()
+  let csv = CsvProvider<"Data/LastFM.tsv", HasHeaders=false>.GetSample()
   let first = csv.Data |> Seq.head
   let actual:Guid option = first.Column3
   actual |> should equal (Some (Guid.Parse("f1b1cf71-bd35-4e99-8624-24a6e15f133a")))
@@ -49,7 +49,7 @@ Float1,Float2,Float3,Float4,Int,Float5,Float6,Date
 
 [<Test>]
 let ``Inference of numbers with empty values`` () = 
-  let csv = new CsvProvider<csvWithEmptyValues>()
+  let csv = CsvProvider<csvWithEmptyValues>.GetSample()
   let rows = csv.Data |> Seq.toArray
   
   let row = rows.[0]
@@ -79,7 +79,7 @@ let ``Inference of numbers with empty values`` () =
 
 [<Test>] 
 let ``Can create type for small document``() =
-  let csv = new CsvProvider<"Data/SmallTest.csv">()
+  let csv = CsvProvider<"Data/SmallTest.csv">.GetSample()
   let row1 = csv.Data |> Seq.head 
   row1.Distance |> should equal 50.<metre>
   let time = row1.Time
@@ -93,7 +93,7 @@ let ``CsvFile.Data is re-entrant if the underlying stream is``() =
 
 [<Test>] 
 let ``Can parse sample file with whitespace in the name``() =
-  let csv = new CsvProvider<"Data/file with spaces.csv">()
+  let csv = CsvProvider<"Data/file with spaces.csv">.GetSample()
   let row1 = csv.Data |> Seq.head 
   row1.Distance |> should equal 50.<metre>
   let time = row1.Time
@@ -101,19 +101,19 @@ let ``Can parse sample file with whitespace in the name``() =
 
 [<Test>]
 let ``Infers type of an emtpy CSV file`` () = 
-  let csv = new CsvProvider<"Column1, Column2">()
+  let csv = CsvProvider<"Column1, Column2">.GetSample()
   let actual : string list = [ for r in csv.Data -> r.Column1 ]
   actual |> shouldEqual []
 
 [<Test>]
 let ``Does not treat invariant culture number such as 3.14 as a date in cultures using 3,14`` () =
-  let csv = new CsvProvider<"Data/DnbHistoriskeKurser.csv", ",", "nb-NO", 10>()
+  let csv = CsvProvider<"Data/DnbHistoriskeKurser.csv", ",", "nb-NO", 10>.GetSample()
   let row = csv.Data |> Seq.head
   (row.Dato, row.USD) |> shouldEqual (DateTime(2013, 2, 7), "5.4970")
 
 [<Test>]
 let ``Empty lines are skipped and don't make everything optional`` () =
-  let csv = new CsvProvider<"Data/banklist.csv">()
+  let csv = CsvProvider<"Data/banklist.csv">.GetSample()
   let row = csv.Data |> Seq.head
   row.``Bank Name`` |> should equal "Alabama Trust Bank, National Association"
   row.``CERT #`` |> should equal 35224
@@ -125,7 +125,7 @@ let csvWithRepeatedAndEmptyColumns = """Foo3,Foo3,Bar,
 
 [<Test>]
 let ``Repeated and empty column names``() = 
-  let csv = new CsvProvider<csvWithRepeatedAndEmptyColumns>()
+  let csv = CsvProvider<csvWithRepeatedAndEmptyColumns>.GetSample()
   let row = csv.Data |> Seq.head
   row.Foo3.GetType() |> should equal typeof<string>
   row.Foo4.GetType() |> should equal typeof<int>
@@ -138,7 +138,7 @@ TRUE,no,3
 
 [<Test>]
 let ``Columns correctly inferred and accessed when headers are missing`` () = 
-    let csv = new CsvProvider<simpleCsvNoHeaders, HasHeaders=false>()
+    let csv = CsvProvider<simpleCsvNoHeaders, HasHeaders=false>.GetSample()
     let row = csv.Data |> Seq.head
     let col1:bool = row.Column1
     let col2:bool = row.Column2
@@ -156,7 +156,7 @@ let ``Columns correctly inferred and accessed when headers are missing`` () =
 
 [<Test>]
 let ``IgnoreErrors skips lines with wrong number of columns`` () = 
-    let csv = new CsvProvider<"a,b,c\n1,2\n0,1,2,3,4\n2,3,4", IgnoreErrors=true>()
+    let csv = CsvProvider<"a,b,c\n1,2\n0,1,2,3,4\n2,3,4", IgnoreErrors=true>.GetSample()
     let row = csv.Data |> Seq.head
     row |> should equal (2,3,4)
 
@@ -167,7 +167,7 @@ let ``Lines with wrong number of columns throw exception when ignore errors is s
 
 [<Test>]
 let ``IgnoreErrors skips lines with wrong number of columns when there's no header`` () = 
-    let csv = new CsvProvider<"1,2\n0,1,2,3,4\n2,3,4\n5,6", IgnoreErrors=true, HasHeaders=false>()
+    let csv = CsvProvider<"1,2\n0,1,2,3,4\n2,3,4\n5,6", IgnoreErrors=true, HasHeaders=false>.GetSample()
     let row1 = csv.Data |> Seq.head
     let row2 = csv.Data |> Seq.skip 1 |> Seq.head
     row1 |> should equal (1,2)
@@ -175,18 +175,18 @@ let ``IgnoreErrors skips lines with wrong number of columns when there's no head
 
 [<Test>]
 let ``IgnoreErrors skips lines with wrong types`` () = 
-    let csv = new CsvProvider<"a (int),b (int),c (int)\nx,y,c\n2,3,4", IgnoreErrors=true>()
+    let csv = CsvProvider<"a (int),b (int),c (int)\nx,y,c\n2,3,4", IgnoreErrors=true>.GetSample()
     let row = csv.Data |> Seq.head
     row |> should equal (2,3,4)
 
 [<Test>]
 let ``Lines with wrong types throw exception when ignore errors is set to false`` () = 
-    let csv = new CsvProvider<"a (int),b (int),c (int)\nx,y,z\n2,3,4">()
+    let csv = CsvProvider<"a (int),b (int),c (int)\nx,y,z\n2,3,4">.GetSample()
     (fun () -> csv.Data |> Seq.head |> ignore) |> should throw typeof<Exception>
 
 [<Test>]
 let ``Columns explicitly overrided to string option should return None when empty or whitespace`` () = 
-    let csv = new CsvProvider<"a,b,c\n , ,1\na,b,2",Schema=",string option,int option">()
+    let csv = CsvProvider<"a,b,c\n , ,1\na,b,2",Schema=",string option,int option">.GetSample()
     let rows = csv.Data |> Seq.toArray
     let row1 = rows.[0]
     let row2 = rows.[1]
@@ -197,7 +197,7 @@ let ``Columns explicitly overrided to string option should return None when empt
 
 [<Test>]
 let ``NaN's should work correctly when using option types`` () = 
-    let csv = new CsvProvider<"a,b\n1,\n:,1.0", Schema="float option,float option">()
+    let csv = CsvProvider<"a,b\n1,\n:,1.0", Schema="float option,float option">.GetSample()
     let rows = csv.Data |> Seq.toArray
     let row1 = rows.[0]
     let row2 = rows.[1]
@@ -208,6 +208,6 @@ let ``NaN's should work correctly when using option types`` () =
     
 [<Test>]
 let ``Currency symbols on decimal columns should work``() =
-    let csv = new CsvProvider<"$66.92,0.9458,Jan-13,0,0,0,1", HasHeaders=false, Culture="en-US">()
+    let csv = CsvProvider<"$66.92,0.9458,Jan-13,0,0,0,1", HasHeaders=false, Culture="en-US">.GetSample()
     let row = csv.Data |> Seq.head
     row.Column1 : decimal |> should equal 66.92M


### PR DESCRIPTION
This partially implements #18

There's a corner case with arrays and async that is still not working at runtime, reproducible by running the `FSharp.Data.Tests.DesignTime.SignatureTests.Generating expressions works (Json,GitHub.json,false,,)` test, I'll fix that later

I'll also update the documentation before merging this

@tpetricek doing the same for CsvProvider, we can't use the same pattern for the default constructor. Do you think we should keep the constructor as is and add a static method for the async version, or should we remove the constructor and get two static methods, like in the other providers? The current solution with the constructor has a big annoyance, which is VS intellisense doesn't work for the tp parameters on expressions like `new CsvProvider<`, but on the other hand, `GetSample` is ugly and it would be nice to not propagate it to CsvProvider also. Maybe we could take the oportunity and rename it? Maybe an overload of `Load`/`Parse` with no parameters?
