### PR TITLE
Support heterogeneous types at the top level in XmlProvider (fix #294)

### DIFF
--- a/src/Xml/XmlRuntime.fs
+++ b/src/Xml/XmlRuntime.fs
@@ -82,3 +82,10 @@ type XmlRuntime =
 
   static member ConvertOptional<'R>(xml:XmlElement, nameWithNS, f:Func<XmlElement,'R>) =
     XmlRuntime.GetChildOption(xml, nameWithNS) |> Option.map f.Invoke
+
+  /// Returns Some if the specified XmlElement has the specified name
+  /// (otherwise None is returned). This is used when the current element
+  /// can be one of multiple elements.
+  static member ConvertAsName<'R>(xml:XmlElement, nameWithNS, f:Func<XmlElement,'R>) = 
+    if xml.XElement.Name = XName.Get(nameWithNS) then Some(f.Invoke xml)
+    else None

--- a/tests/FSharp.Data.Tests/Data/AnyFeed.xml
+++ b/tests/FSharp.Data.Tests/Data/AnyFeed.xml
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<samples>
+  <feed xmlns="http://www.w3.org/2005/Atom">
+
+    <title>Example Feed</title>
+    <subtitle>A subtitle.</subtitle>
+    <link href="http://example.org/feed/" rel="self" />
+    <link href="http://example.org/" />
+    <id>urn:uuid:60a76c80-d399-11d9-b91C-0003939e0af6</id>
+    <updated>2003-12-13T18:30:02Z</updated>
+
+
+    <entry>
+      <title>Atom-Powered Robots Run Amok</title>
+      <link href="http://example.org/2003/12/13/atom03" />
+      <link rel="alternate" type="text/html" href="http://example.org/2003/12/13/atom03.html"/>
+      <link rel="edit" href="http://example.org/2003/12/13/atom03/edit"/>
+      <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+      <updated>2003-12-13T18:30:02Z</updated>
+      <summary>Some text.</summary>
+      <author>
+        <name>John Doe</name>
+        <email>johndoe@example.com</email>
+      </author>
+    </entry>
+
+  </feed>
+  <rss version="2.0">
+
+    <channel>
+      <title>W3Schools Home Page</title>
+      <link>http://www.w3schools.com</link>
+      <description>Free web building tutorials</description>
+      <item>
+        <title>RSS Tutorial</title>
+        <link>http://www.w3schools.com/rss</link>
+        <description>New RSS tutorial on W3Schools</description>
+      </item>
+      <item>
+        <title>XML Tutorial</title>
+        <link>http://www.w3schools.com/xml</link>
+        <description>New XML tutorial on W3Schools</description>
+      </item>
+    </channel>
+
+  </rss>
+</samples>


### PR DESCRIPTION
I don't think there is a way to reuse any of the existing handling, so I added a new case (the trick is that here, the _current_ element can be one of several options, rather than child element being one of several options).
