### PR TITLE
add travis ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: objective-c
+
+env:
+  matrix:
+    - MONO_VERSION="3.2.5"
+
+install:
+  - wget "http://download.xamarin.com/MonoFrameworkMDK/Macx86/MonoFramework-MDK-${MONO_VERSION}.macos10.xamarin.x86.pkg"
+  - sudo installer -pkg "MonoFramework-MDK-${MONO_VERSION}.macos10.xamarin.x86.pkg" -target /
+
+script: 
+  - ./build.sh All
+

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ The F# Data library (`FSharp.Data.dll`) implements everything you need to access
 and scripts. It implements F# type providers for working with structured file formats (CSV, JSON and XML) and 
 for accessing the WorldBank and Freebase data. It also includes helpers for parsing JSON files and for sending HTTP requests.
 
+Status: [![Build Status](https://travis-ci.org/enricosada/FSharp.Data.png)](https://travis-ci.org/enricosada/FSharp.Data)
+
 ## Documentation 
 
 One of the key benefits of this library is that it comes with a comprehensive documentation. The documentation is 

--- a/build.cmd
+++ b/build.cmd
@@ -1,6 +1,6 @@
 @echo off
 if not exist packages\FAKE\tools\Fake.exe ( 
-  .nuget\nuget.exe install FAKE -OutputDirectory packages -ExcludeVersion -Prerelease
+  .nuget\nuget.exe install FAKE -OutputDirectory packages -ExcludeVersion
 )
 packages\FAKE\tools\FAKE.exe build.fsx %*
 pause

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ ! -f packages/FAKE/tools/Fake.exe ]; then
-  mono .NuGet/NuGet.exe install FAKE -OutputDirectory packages -ExcludeVersion -Prerelease
+  mono --runtime=v4.0 .NuGet/NuGet.exe install FAKE -OutputDirectory packages -ExcludeVersion
 fi
-mono packages/FAKE/tools/FAKE.exe build.fsx $@
+mono --runtime=v4.0 packages/FAKE/tools/FAKE.exe build.fsx $@


### PR DESCRIPTION
This pr add [travis ci](https://travis-ci.org) build configuration ( #306 )

build is for every branch/commit/pull request and for personal forks

build is failing  [![Build Status](https://travis-ci.org/enricosada/FSharp.Data.png)](https://travis-ci.org/enricosada/FSharp.Data)  because of unit tests ( see [log](https://travis-ci.org/enricosada/FSharp.Data/builds/16347834#L874) )

I tested 'build.cmd All' on windows, still failing but with less test errors.

i modified the fake script to fix compilation on mac osx ( and travis ), 
FAKE is now stable version ( not prerelease )

TODO you should do before merge:
- You should login on https://travis-ci.org/ and enable service hook for fsharp/FSharp.Data . 
  After that there will be a new build every commit (see [travis help](http://about.travis-ci.org/docs/user/getting-started/#Step-one%3A-Sign-in) ) on the [fsharp/FSharp.Data](http://github.com/fsharp/FSharp.Data) repository
- on REAME.md there is the badge, should be changed to fsharp/FSharp.Data.
