### PR TITLE
When targeting the portable version, don't generate the get sample metho...

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ You can see the version history [here](RELEASE_NOTES.md).
   * Windows: Run *build.cmd* [![Windows build status](http://teamcity.codebetter.com/app/rest/builds/buildType:\(id:bt1184\)/statusIcon)](http://teamcity.codebetter.com/viewType.html?buildTypeId=bt1184)
   * Mono: Run *build.sh*  [![Mono build status](https://travis-ci.org/fsharp/FSharp.Data.png)](https://travis-ci.org/fsharp/FSharp.Data)
 
+## Supported platforms
+
+- VS2012 compiling to FSharp.Core 4.3.0.0
+- VS2012 compiling to FSharp.Core 2.3.5.0 (PCL profile 47)
+- VS2013 compiling to FSharp.Core 4.3.0.0
+- VS2013 compiling to FSharp.Core 4.3.1.0
+- VS2013 compiling to FSharp.Core 2.3.5.0  (PCL profile 47)
+- VS2013 compiling to FSharp.Core 2.3.6.0  (PCL profile 47)
+- VS2013 compiling to FSharp.Core 3.3.1.0  (PCL profile 7)
+- Mono F# 3.0 with FSharp.Core 4.3.0.0
+- Mono F# 3.1 with FSharp.Core 4.3.0.0
+- Mono F# 3.1 with FSharp.Core 4.3.1.0
+
 ## Documentation 
 
 One of the key benefits of this library is that it comes with a comprehensive documentation. The documentation is 

--- a/src/Apiary/ApiaryProvider.fs
+++ b/src/Apiary/ApiaryProvider.fs
@@ -15,7 +15,7 @@ type public ApiaryProvider(cfg:TypeProviderConfig) as this =
   inherit TypeProviderForNamespaces()
 
   // Generate namespace and type 'FSharp.Apiary.ApiaryProvider'
-  let asm, replacer = AssemblyResolver.init cfg
+  let asm, _, replacer = AssemblyResolver.init cfg
   let ns = "FSharp.Data"
   let apiaryProvTy = ProvidedTypeDefinition(asm, ns, "ApiaryProvider", Some(typeof<obj>))
 

--- a/src/CommonProviderImplementation/Debug.fs
+++ b/src/CommonProviderImplementation/Debug.fs
@@ -15,15 +15,6 @@ open Microsoft.FSharp.Quotations.Patterns
 open Microsoft.FSharp.Reflection
 open ProviderImplementation.ProvidedTypes
 
-type Platform =
-    | Full
-    | Portable47
-    | Portable7
-    member x.RuntimeAssemblyVersion =
-        match x with
-        | Full | Portable7 -> Version(4, 0, 0, 0)
-        | Portable47 -> Version(2, 0, 5, 0)
-
 module Debug = 
 
     /// Converts a sequence of strings to a single string separated with the delimiters
@@ -31,7 +22,7 @@ module Debug =
 
     /// Simulates a real instance of TypeProviderConfig and then creates an instance of the last
     /// type provider added to a namespace by the type provider constructor
-    let generate (resolutionFolder: string) (runtimeAssembly: string) (platform:Platform) typeProviderForNamespacesConstructor args =
+    let generate (resolutionFolder: string) (runtimeAssembly: string) typeProviderForNamespacesConstructor args =
 
         let cfg = new TypeProviderConfig(fun _ -> false)
         let (?<-) cfg prop value =
@@ -39,7 +30,6 @@ module Debug =
         cfg?ResolutionFolder <- resolutionFolder
         cfg?RuntimeAssembly <- runtimeAssembly
         cfg?ReferencedAssemblies <- Array.zeroCreate<string> 0
-        cfg?SystemRuntimeAssemblyVersion <- platform.RuntimeAssemblyVersion
 
         let typeProviderForNamespaces = typeProviderForNamespacesConstructor cfg :> TypeProviderForNamespaces
 

--- a/src/Csv/CsvProvider.fs
+++ b/src/Csv/CsvProvider.fs
@@ -21,7 +21,7 @@ type public CsvProvider(cfg:TypeProviderConfig) as this =
   inherit DisposableTypeProviderForNamespaces()
 
   // Generate namespace and type 'FSharp.Data.CsvProvider'
-  let asm, replacer = AssemblyResolver.init cfg
+  let asm, version, replacer = AssemblyResolver.init cfg
   let ns = "FSharp.Data"
   let csvProvTy = ProvidedTypeDefinition(asm, ns, "CsvProvider", Some typeof<obj>)
 
@@ -88,7 +88,7 @@ type public CsvProvider(cfg:TypeProviderConfig) as this =
 
     generateConstructors "CSV" sample (*sampleIsList*)false 
                          parse (fun _ _ -> failwith "Not Applicable") getSpecFromSamples
-                         this cfg replacer resolutionFolder true
+                         version this cfg replacer resolutionFolder true
 
   let defaultMissingValues = String.Join(",", TextConversions.DefaultMissingValues)
   // Add static parameter that specifies the API we want to get (compile-time) 

--- a/src/Freebase/FreebaseProvider.fs
+++ b/src/Freebase/FreebaseProvider.fs
@@ -46,7 +46,7 @@ module List =
 /// Find the handles in the Freebase type provider runtime DLL. 
 type internal FreebaseRuntimeInfo (config : TypeProviderConfig) =
 
-    let runtimeAssembly, replacer = AssemblyResolver.init config
+    let runtimeAssembly, _, replacer = AssemblyResolver.init config
 
     member val FreebaseDataContextType =     typeof<FreebaseDataContext>     |> replacer.ToRuntime
     member val IFreebaseDataContextType =    typeof<IFreebaseDataContext>    |> replacer.ToRuntime

--- a/src/Json/JsonProvider.fs
+++ b/src/Json/JsonProvider.fs
@@ -18,7 +18,7 @@ type public JsonProvider(cfg:TypeProviderConfig) as this =
   inherit DisposableTypeProviderForNamespaces()
 
   // Generate namespace and type 'FSharp.Data.JsonProvider'
-  let asm, replacer = AssemblyResolver.init cfg
+  let asm, version, replacer = AssemblyResolver.init cfg
   let ns = "FSharp.Data"
   let jsonProvTy = ProvidedTypeDefinition(asm, ns, "JsonProvider", Some typeof<obj>)
 
@@ -57,7 +57,7 @@ type public JsonProvider(cfg:TypeProviderConfig) as this =
 
     generateConstructors "JSON" sample sampleIsList
                          parseSingle parseList getSpecFromSamples 
-                         this cfg replacer resolutionFolder false
+                         version this cfg replacer resolutionFolder false
 
   // Add static parameter that specifies the API we want to get (compile-time) 
   let parameters = 

--- a/src/Test.Experimental.fsx
+++ b/src/Test.Experimental.fsx
@@ -18,22 +18,24 @@ let (++) a b = Path.Combine(a, b)
 let resolutionFolder = __SOURCE_DIRECTORY__ ++ ".." ++ "tests" ++ "FSharp.Data.Tests" ++ "Data"
 let assemblyName = "FSharp.Data.Experimental.dll"
 
-let platform = Full
+type Platform = Net40 | Portable7 | Portable47
+
+let platform = Portable47
 
 let runtimeAssembly = 
     match platform with
-    | Full -> __SOURCE_DIRECTORY__ ++ ".." ++ "bin" ++ assemblyName
-    | Portable47 -> __SOURCE_DIRECTORY__ ++ ".." ++ "bin" ++ "portable47" ++ assemblyName
+    | Net40 -> __SOURCE_DIRECTORY__ ++ ".." ++ "bin" ++ assemblyName
     | Portable7 -> __SOURCE_DIRECTORY__ ++ ".." ++ "bin" ++ "portable7" ++ assemblyName
+    | Portable47 -> __SOURCE_DIRECTORY__ ++ ".." ++ "bin" ++ "portable47" ++ assemblyName    
 
 let signatureOnly = false
 let ignoreOutput = false
 
-let generate (inst:TypeProviderInstantiation) = inst.GenerateType resolutionFolder runtimeAssembly platform
+let generate (inst:TypeProviderInstantiation) = inst.GenerateType resolutionFolder runtimeAssembly
 let prettyPrint t = Debug.prettyPrint signatureOnly ignoreOutput 10 100 t
 
 Apiary { ApiName = "bionames"
-         SpecialNames = "Rhogeessa=TaxonName,Apomys=TaxonName,Philautus acutirostris=TaxonName,Philautus acutirostris=TaxonName,Dobsonia andersoni=TaxonName" }
+         SpecialNames = "Rhogeessa=TaxonName,Apomys=TaxonName,Philautus acutirostris=TaxonName" }
 |> generate |> prettyPrint |> Console.WriteLine
 
 let testCases = 

--- a/src/Test.fsx
+++ b/src/Test.fsx
@@ -18,18 +18,20 @@ let (++) a b = Path.Combine(a, b)
 let resolutionFolder = __SOURCE_DIRECTORY__ ++ ".." ++ "tests" ++ "FSharp.Data.Tests" ++ "Data"
 let assemblyName = "FSharp.Data.dll"
 
+type Platform = Net40 | Portable7 | Portable47
+
 let platform = Portable47
 
 let runtimeAssembly = 
     match platform with
-    | Full -> __SOURCE_DIRECTORY__ ++ ".." ++ "bin" ++ assemblyName
-    | Portable47 -> __SOURCE_DIRECTORY__ ++ ".." ++ "bin" ++ "portable47" ++ assemblyName
+    | Net40 -> __SOURCE_DIRECTORY__ ++ ".." ++ "bin" ++ assemblyName
     | Portable7 -> __SOURCE_DIRECTORY__ ++ ".." ++ "bin" ++ "portable7" ++ assemblyName
+    | Portable47 -> __SOURCE_DIRECTORY__ ++ ".." ++ "bin" ++ "portable47" ++ assemblyName    
 
 let signatureOnly = false
 let ignoreOutput = false
 
-let generate (inst:TypeProviderInstantiation) = inst.GenerateType resolutionFolder runtimeAssembly platform
+let generate (inst:TypeProviderInstantiation) = inst.GenerateType resolutionFolder runtimeAssembly
 let prettyPrint (t:ProvidedTypes.ProvidedTypeDefinition) = 
     if t.Name.StartsWith "FreebaseDataProvider" 
     then Debug.prettyPrint signatureOnly ignoreOutput 5 10 t

--- a/src/TypeProviderInstantiation.Experimental.fs
+++ b/src/TypeProviderInstantiation.Experimental.fs
@@ -9,14 +9,14 @@ type ApiaryProviderArgs =
 type TypeProviderInstantiation = 
     | Apiary of ApiaryProviderArgs
 
-    member x.GenerateType resolutionFolder runtimeAssembly platform =
+    member x.GenerateType resolutionFolder runtimeAssembly =
         let f, args =
             match x with
             | Apiary x ->
                 (fun cfg -> new ApiaryProvider(cfg) :> TypeProviderForNamespaces),
                 [| box x.ApiName
                    box x.SpecialNames |] 
-        Debug.generate resolutionFolder runtimeAssembly platform f args
+        Debug.generate resolutionFolder runtimeAssembly f args
 
     override x.ToString() =
         match x with

--- a/src/TypeProviderInstantiation.fs
+++ b/src/TypeProviderInstantiation.fs
@@ -56,7 +56,7 @@ type TypeProviderInstantiation =
     | WorldBank of WorldBankProviderArgs
     | Freebase of FreebaseProviderArgs    
 
-    member x.GenerateType resolutionFolder runtimeAssembly platform =
+    member x.GenerateType resolutionFolder runtimeAssembly =
         let f, args =
             match x with
             | Csv x -> 
@@ -103,7 +103,7 @@ type TypeProviderInstantiation =
                    box x.LocalCache
                    box x.AllowLocalQueryEvaluation 
                    box x.UseRefinedTypes |]
-        Debug.generate resolutionFolder runtimeAssembly platform f args
+        Debug.generate resolutionFolder runtimeAssembly f args
 
     override x.ToString() =
         match x with

--- a/src/WorldBank/WorldBankProvider.fs
+++ b/src/WorldBank/WorldBankProvider.fs
@@ -19,7 +19,7 @@ open FSharp.Data.Runtime.WorldBank
 type public WorldBankProvider(cfg:TypeProviderConfig) as this = 
     inherit TypeProviderForNamespaces()
 
-    let asm, replacer = AssemblyResolver.init cfg
+    let asm, _, replacer = AssemblyResolver.init cfg
     let ns = "FSharp.Data" 
 
     let defaultServiceUrl = "http://api.worldbank.org"

--- a/src/Xml/XmlProvider.fs
+++ b/src/Xml/XmlProvider.fs
@@ -16,7 +16,7 @@ type public XmlProvider(cfg:TypeProviderConfig) as this =
   inherit DisposableTypeProviderForNamespaces()
 
   // Generate namespace and type 'FSharp.Data.XmlProvider'
-  let asm, replacer = AssemblyResolver.init cfg
+  let asm, version, replacer = AssemblyResolver.init cfg
   let ns = "FSharp.Data"
   let xmlProvTy = ProvidedTypeDefinition(asm, ns, "XmlProvider", Some typeof<obj>)
 
@@ -53,7 +53,7 @@ type public XmlProvider(cfg:TypeProviderConfig) as this =
 
     generateConstructors "XML" sample sampleIsList
                          parseSingle parseList getSpecFromSamples 
-                         this cfg replacer resolutionFolder false
+                         version this cfg replacer resolutionFolder false
 
   // Add static parameter that specifies the API we want to get (compile-time) 
   let parameters = 

--- a/tests/FSharp.Data.Tests.DesignTime/SignatureTests.fs
+++ b/tests/FSharp.Data.Tests.DesignTime/SignatureTests.fs
@@ -18,9 +18,9 @@ WebRequest.DefaultWebProxy.Credentials <- CredentialCache.DefaultNetworkCredenti
 
 type TypeProviderInstantiation with
 
-    member x.Dump resolutionFolder runtimeAssembly platform signatureOnly ignoreOutput =
+    member x.Dump resolutionFolder runtimeAssembly signatureOnly ignoreOutput =
         let output = 
-            x.GenerateType resolutionFolder runtimeAssembly platform
+            x.GenerateType resolutionFolder runtimeAssembly
             |> match x with
                | Freebase _ -> Debug.prettyPrint signatureOnly ignoreOutput 5 10
                | _ -> Debug.prettyPrint signatureOnly ignoreOutput 10 100
@@ -51,7 +51,7 @@ let generateAllExpected() =
     if not <| Directory.Exists expectedDirectory then 
         Directory.CreateDirectory expectedDirectory |> ignore
     for testCase in testCases do
-        let output = testCase.Dump resolutionFolder runtimeAssembly Platform.Full (*signatureOnly*)false (*ignoreOutput*)false
+        let output = testCase.Dump resolutionFolder runtimeAssembly (*signatureOnly*)false (*ignoreOutput*)false
         File.WriteAllText(getExpectedPath testCase, output)
 
 let normalize (str:string) =
@@ -63,7 +63,7 @@ let normalize (str:string) =
 [<TestCaseSource "testCases">]
 let ``Validate signature didn't change `` (testCase:TypeProviderInstantiation) = 
     let expected = getExpectedPath testCase |> File.ReadAllText |> normalize
-    let output = testCase.Dump resolutionFolder runtimeAssembly Platform.Full (*signatureOnly*)false (*ignoreOutput*)false |> normalize
+    let output = testCase.Dump resolutionFolder runtimeAssembly (*signatureOnly*)false (*ignoreOutput*)false |> normalize
     if output <> expected then
         printfn "Obtained Signature:\n%s" output
     output |> should equal expected
@@ -72,10 +72,10 @@ let ``Validate signature didn't change `` (testCase:TypeProviderInstantiation) =
 [<TestCaseSource "testCases">]
 [<Platform "Net">]
 let ``Generating expressions works in portable profile 47 `` (testCase:TypeProviderInstantiation) = 
-    testCase.Dump resolutionFolder portable47RuntimeAssembly Platform.Portable47 (*signatureOnly*)false (*ignoreOutput*)true |> ignore
+    testCase.Dump resolutionFolder portable47RuntimeAssembly (*signatureOnly*)false (*ignoreOutput*)true |> ignore
 
 [<Test>]
 [<TestCaseSource "testCases">]
 [<Platform "Net">]
 let ``Generating expressions works in portable profile 7 `` (testCase:TypeProviderInstantiation) = 
-    testCase.Dump resolutionFolder portable7RuntimeAssembly Platform.Portable7 (*signatureOnly*)false (*ignoreOutput*)true |> ignore
+    testCase.Dump resolutionFolder portable7RuntimeAssembly (*signatureOnly*)false (*ignoreOutput*)true |> ignore

--- a/tests/FSharp.Data.Tests.Experimental.DesignTime/SignatureTests.fs
+++ b/tests/FSharp.Data.Tests.Experimental.DesignTime/SignatureTests.fs
@@ -18,9 +18,9 @@ WebRequest.DefaultWebProxy.Credentials <- CredentialCache.DefaultNetworkCredenti
 
 type TypeProviderInstantiation with
 
-    member x.Dump resolutionFolder runtimeAssembly platform signatureOnly ignoreOutput =
+    member x.Dump resolutionFolder runtimeAssembly signatureOnly ignoreOutput =
         let output = 
-            x.GenerateType resolutionFolder runtimeAssembly platform
+            x.GenerateType resolutionFolder runtimeAssembly
             |> Debug.prettyPrint signatureOnly ignoreOutput 10 100
         output.Replace("FSharp.Data.Runtime.", "FDR.")
               .Replace(__SOURCE_DIRECTORY__, "<SOURCE_DIRECTORY>")
@@ -52,7 +52,7 @@ let generateAllExpected() =
     if not <| Directory.Exists expectedDirectory then 
         Directory.CreateDirectory expectedDirectory |> ignore
     for testCase in testCases do
-        let output = testCase.Dump resolutionFolder runtimeAssembly Platform.Full (*signatureOnly*)false (*ignoreOutput*)false
+        let output = testCase.Dump resolutionFolder runtimeAssembly (*signatureOnly*)false (*ignoreOutput*)false
         File.WriteAllText(getExpectedPath testCase, output)
 
 let normalize (str:string) =
@@ -65,7 +65,7 @@ let normalize (str:string) =
 [<Platform "Net">]
 let ``Validate signature didn't change `` (testCase:TypeProviderInstantiation) = 
     let expected = getExpectedPath testCase |> File.ReadAllText |> normalize
-    let output = testCase.Dump resolutionFolder runtimeAssembly Platform.Full (*signatureOnly*)false (*ignoreOutput*)false |> normalize 
+    let output = testCase.Dump resolutionFolder runtimeAssembly (*signatureOnly*)false (*ignoreOutput*)false |> normalize 
     if output <> expected then
         printfn "Obtained Signature:\n%s" output
     output |> should equal expected
@@ -74,10 +74,10 @@ let ``Validate signature didn't change `` (testCase:TypeProviderInstantiation) =
 [<TestCaseSource "testCases">]
 [<Platform "Net">]
 let ``Generating expressions works in portable profile 47 `` (testCase:TypeProviderInstantiation) = 
-    testCase.Dump resolutionFolder portable47RuntimeAssembly Platform.Portable47 (*signatureOnly*)false (*ignoreOutput*)true |> ignore
+    testCase.Dump resolutionFolder portable47RuntimeAssembly (*signatureOnly*)false (*ignoreOutput*)true |> ignore
 
 [<Test>]
 [<TestCaseSource "testCases">]
 [<Platform "Net">]
 let ``Generating expressions works in portable profile 7 `` (testCase:TypeProviderInstantiation) = 
-    testCase.Dump resolutionFolder portable7RuntimeAssembly Platform.Portable7 (*signatureOnly*)false (*ignoreOutput*)true |> ignore
+    testCase.Dump resolutionFolder portable7RuntimeAssembly (*signatureOnly*)false (*ignoreOutput*)true |> ignore


### PR DESCRIPTION
...ds if a file is used, as it won't work at runtime (closes #407) + check if the designtime and runtime assembly versions match
