### PR TITLE
Fix typo in ja/template.cshtml and remove duplicates.

### DIFF
--- a/docs/tools/templates/ja/template.cshtml
+++ b/docs/tools/templates/ja/template.cshtml
@@ -91,10 +91,10 @@
                 (<a href="@Root/../library/Http.html">En</a>)
                 </span></li>
 
-            <li class="nav-header">Tutorials</li>
+            <li class="nav-header">チュートリアル</li>
             <li><span>
-                <a href="@Root/tutorials/JsonToXml.html">Converting between JSON and XML</a>
-                (<a href="@Root/../tutorials/JsonToXml.html">En</a>=
+                <a href="@Root/tutorials/JsonToXml.html">JSONとXMLの相互変換</a>
+                (<a href="@Root/../tutorials/JsonToXml.html">En</a>)
                 </span></li>
 
             <li class="nav-header">F# Data 試験用ライブラリ</li>
@@ -105,12 +105,6 @@
             <li><span>
                 <a href="@Root/experimental/ApiaryProvider.html">Apiary 型プロバイダー</a>
                 (<a href="@Root/../experimental/ApiaryProvider.html">En</a>)
-                </span></li>
-
-            <li class="nav-header">チュートリアル</li>
-            <li><span>
-                <a href="@Root/tutorials/JsonToXml.html">JsonToXml</a>
-                (<a href="@Root/../tutorials/JsonToXml.html">En</a>)
                 </span></li>
 
             <li class="nav-header">リファレンス</li>


### PR DESCRIPTION
In ja/template.cshtml, Tutorials sections are duplicated so I removed one.
And fix typo in this file.
