### PR TITLE
Fixed encoding of Uri slashes.

### DIFF
--- a/src/CommonRuntime/UriUtils.fs
+++ b/src/CommonRuntime/UriUtils.fs
@@ -1,0 +1,136 @@
+﻿// --------------------------------------------------------------------------------------
+// Fixes the way slashs are encoded in System.Uri across Mono and .NET.
+// --------------------------------------------------------------------------------------
+module FSharp.Data.Runtime.UriUtils
+
+open System
+open System.Reflection
+
+type private UriInfo = { Path : string; Query : string }
+
+let private uriInfo (uri : Uri) (source : string) = 
+    let fragPos = source.IndexOf("#")
+    let queryPos = source.IndexOf("?")
+    let start = source.IndexOf(uri.Host) + uri.Host.Length
+    let pathEnd = 
+        match queryPos, fragPos with
+        | -1, -1 -> source.Length + 1 
+        | -1, _ -> fragPos
+        | _ -> queryPos
+
+    let path =
+        if queryPos > -1 then source.Substring(start, pathEnd - start)
+        else source.Substring(start)
+    
+    let query = 
+        if fragPos > -1 then source.Substring(queryPos, fragPos - queryPos)
+        else if queryPos > -1 then source.Substring(queryPos)
+        else ""
+    
+    { Path = path; Query = query }
+
+
+let private privateInstanceFlags = BindingFlags.NonPublic ||| BindingFlags.Instance
+
+let private purifierDotNet = lazy(
+    let uriType = typeof<Uri>
+    let flagsField = uriType.GetField("m_Flags", privateInstanceFlags)
+    let stringField = uriType.GetField("m_String", privateInstanceFlags)
+    let infoField = uriType.GetField("m_Info", privateInstanceFlags)
+
+    let infoFieldType = infoField.FieldType
+    let infoStringField = infoFieldType.GetField("String", privateInstanceFlags)
+    let moreInfoField = infoFieldType.GetField("MoreInfo", privateInstanceFlags)
+
+    let moreInfoType = moreInfoField.FieldType
+    let moreInfoAbsoluteUri = moreInfoType.GetField("AbsoluteUri", privateInstanceFlags)
+    let moreInfoQuery = moreInfoType.GetField("Query", privateInstanceFlags)
+    let moreInfoPath = moreInfoType.GetField("Path", privateInstanceFlags)
+
+    //Code inspired by Rasmus Faber's solution in this post: http://stackoverflow.com/questions/781205/getting-a-url-with-an-url-encoded-slash
+    (fun (uri : Uri) ->
+        uri.PathAndQuery |> ignore // need to access PathAndQuery
+        uri.AbsoluteUri |> ignore //need to access this as well the MoreInfo prop is initialized.
+
+        let flags = 
+            flagsField.GetValue(uri) 
+            |> unbox 
+            |> uint64 
+            |> (&&&) (~~~ 0x30UL) // Flags.PathNotCanonical|Flags.QueryNotCanonical
+
+        flagsField.SetValue(uri, flags)
+        let info = infoField.GetValue(uri)
+        let source = stringField.GetValue(uri) |> string
+        infoStringField.SetValue(info, source)
+        let moreInfo = moreInfoField.GetValue(info)
+        moreInfoAbsoluteUri.SetValue(moreInfo, source)
+        let uriInfo = uriInfo uri source
+        moreInfoPath.SetValue(moreInfo, uriInfo.Path)
+        moreInfoQuery.SetValue(moreInfo, uriInfo.Query)
+
+        uri))
+
+let private purifierMono = lazy(
+    let uriType = typeof<Uri>
+
+    let sourceField = uriType.GetField("source", privateInstanceFlags)
+    let queryField = uriType.GetField("query", privateInstanceFlags)
+    let pathField = uriType.GetField("path", privateInstanceFlags)
+    let cachedToStringField = uriType.GetField("cachedToString", privateInstanceFlags)
+    let cachedAbsoluteUriField = uriType.GetField("cachedAbsoluteUri",privateInstanceFlags)
+
+    (fun (uri : Uri) ->
+        let source = string (sourceField.GetValue(uri))
+        cachedToStringField.SetValue(uri, source)
+        cachedAbsoluteUriField.SetValue(uri, source)
+        let uriInfo = uriInfo uri source
+        pathField.SetValue(uri, uriInfo.Path)
+        queryField.SetValue(uri, uriInfo.Query)
+
+        uri))
+
+let private isMono =
+    let uriType = typeof<Uri>
+    (uriType.GetField("m_Flags", privateInstanceFlags) = null)
+
+let private hasBrokenDotNetUri =
+    if isMono then false
+    else
+        let uriType = typeof<Uri>
+        //ShouldUseLegacyV2Quirks was introduced in .net 4.5
+        //Eventhough 4.5 is an inplace update of 4.0 this call will return 
+        //a different value if an application specifically targets 4.0 or 4.5+
+        let legacyV2Quirks = uriType.GetProperty("ShouldUseLegacyV2Quirks", BindingFlags.Static ||| BindingFlags.NonPublic)
+        match legacyV2Quirks with
+        | null -> true //neither 4.0 or 4.5
+        | _ ->
+            let isBrokenUri = unbox (legacyV2Quirks.GetValue(null, null))
+            if not isBrokenUri then false //application targets 4.5
+            else
+                //4.0 uses legacyV2quirks on the UriParser but you can set
+                //  <uri>
+                //    <schemeSettings>
+                //      <add name="http" genericUriParserOptions="DontUnescapePathDotsAndSlashes" />
+                //          </schemeSettings>
+                //  </uri>
+                //
+                //  this will fix AbsoluteUri but not ToString()
+                //  i.e new Uri("http://google.com/%2F").AbsoluteUri
+                //       will return the url untouched but:
+                //  new Uri("http://google.com/%2F").ToString()
+                //      will still return http://google.com//
+                //
+                //  so instead of using reflection perform a one off function test.
+
+                let uri = new Uri("http://google.com/%2F")
+                uri.ToString().EndsWith("%2F", StringComparison.InvariantCulture)
+
+let enableUriSlashes : (Uri -> Uri) =
+#if FX_NO_URI_WORKAROUND
+    (fun x -> x)
+#else
+    if isMono then purifierMono.Force()
+    else if hasBrokenDotNetUri then purifierDotNet.Force()
+    else (fun x -> x)
+#endif
+

--- a/src/FSharp.Data.DesignTime.fsproj
+++ b/src/FSharp.Data.DesignTime.fsproj
@@ -41,6 +41,7 @@
     <OtherFlags>--warnon:1182</OtherFlags>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="CommonRuntime\UriUtils.fs" />
     <Compile Include="Net\Http.fs" />
     <Compile Include="CommonRuntime\IO.fs" />
     <Compile Include="CommonRuntime\Caching.fs" />

--- a/src/FSharp.Data.Experimental.DesignTime.fsproj
+++ b/src/FSharp.Data.Experimental.DesignTime.fsproj
@@ -41,6 +41,7 @@
     <OtherFlags>--warnon:1182</OtherFlags>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="CommonRuntime\UriUtils.fs" />
     <Compile Include="Net\Http.fs" />
     <Compile Include="CommonRuntime\IO.fs" />
     <Compile Include="CommonRuntime\Caching.fs" />

--- a/src/FSharp.Data.Experimental.Portable47.fsproj
+++ b/src/FSharp.Data.Experimental.Portable47.fsproj
@@ -42,6 +42,7 @@
     <OtherFlags>--warnon:1182</OtherFlags>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="CommonRuntime\UriUtils.fs" />
     <Compile Include="Net\Http.fs" />
     <Compile Include="CommonRuntime\IO.fs" />
     <Compile Include="CommonRuntime\Caching.fs" />

--- a/src/FSharp.Data.Experimental.Portable7.fsproj
+++ b/src/FSharp.Data.Experimental.Portable7.fsproj
@@ -43,6 +43,7 @@
     <OtherFlags>--warnon:1182</OtherFlags>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="CommonRuntime\UriUtils.fs" />
     <Compile Include="Net\Http.fs" />
     <Compile Include="CommonRuntime\IO.fs" />
     <Compile Include="CommonRuntime\Caching.fs" />

--- a/src/FSharp.Data.Experimental.fsproj
+++ b/src/FSharp.Data.Experimental.fsproj
@@ -41,6 +41,7 @@
     <OtherFlags>--warnon:1182</OtherFlags>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="CommonRuntime\UriUtils.fs" />
     <Compile Include="Net\Http.fs" />
     <Compile Include="CommonRuntime\IO.fs" />
     <Compile Include="CommonRuntime\Caching.fs" />

--- a/src/FSharp.Data.Portable47.fsproj
+++ b/src/FSharp.Data.Portable47.fsproj
@@ -42,6 +42,7 @@
     <OtherFlags>--warnon:1182</OtherFlags>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="CommonRuntime\UriUtils.fs" />
     <Compile Include="Net\Http.fs" />
     <Compile Include="CommonRuntime\IO.fs" />
     <Compile Include="CommonRuntime\Caching.fs" />

--- a/src/FSharp.Data.Portable7.fsproj
+++ b/src/FSharp.Data.Portable7.fsproj
@@ -43,6 +43,7 @@
     <OtherFlags>--warnon:1182</OtherFlags>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="CommonRuntime\UriUtils.fs" />
     <Compile Include="Net\Http.fs" />
     <Compile Include="CommonRuntime\IO.fs" />
     <Compile Include="CommonRuntime\Caching.fs" />

--- a/src/FSharp.Data.fsproj
+++ b/src/FSharp.Data.fsproj
@@ -41,6 +41,7 @@
     <OtherFlags>--warnon:1182</OtherFlags>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="CommonRuntime\UriUtils.fs" />
     <Compile Include="Net\Http.fs" />
     <Compile Include="CommonRuntime\IO.fs" />
     <Compile Include="CommonRuntime\Caching.fs" />

--- a/tests/FSharp.Data.Tests/FSharp.Data.Tests.fsproj
+++ b/tests/FSharp.Data.Tests/FSharp.Data.Tests.fsproj
@@ -145,6 +145,7 @@
     <Compile Include="XmlProvider.fs" />
     <Compile Include="JsonProvider.fs" />
     <Compile Include="FreebaseProvider.fs" />
+    <Compile Include="UriUtils.fs" />
     <None Include="packages.config" />
     <None Include="app.config" />
   </ItemGroup>

--- a/tests/FSharp.Data.Tests/UriUtils.fs
+++ b/tests/FSharp.Data.Tests/UriUtils.fs
@@ -1,0 +1,42 @@
+﻿// --------------------------------------------------------------------------------------
+// Tests for Http Utilities (mainly HttpUtility.JavaScriptStringEncode now)
+// --------------------------------------------------------------------------------------
+
+#if INTERACTIVE
+#r "../../bin/FSharp.Data.dll"
+#r "../../packages/NUnit.2.6.3/lib/nunit.framework.dll"
+#load "../Common/FsUnit.fs"
+#else
+module FSharp.Data.Tests.UriUtility
+#endif
+
+open FsUnit
+open NUnit.Framework
+open System
+open FSharp.Data.Runtime.UriUtils
+
+let uri = new Uri("http://www.myapi.com/%2F?Foo=Bar%2F#frag") |> encodeUriSlashes
+
+[<Test>]
+let ``ToString contains escaped slashes`` () =
+    uri.ToString() |> should equal "http://www.myapi.com/%2F?Foo=Bar%2F#frag"
+
+[<Test>]
+let ``AbsoluteUri contains escaped slashes`` () =
+    uri.AbsoluteUri |> should equal "http://www.myapi.com/%2F?Foo=Bar%2F#frag"
+
+[<Test>]
+let ``Query contains escaped slashes`` () =
+    uri.Query |> should equal "?Foo=Bar%2F"
+
+[<Test>]
+let ``PathAndQuery contains escaped slashes`` () =
+    uri.PathAndQuery |> should equal "/%2F?Foo=Bar%2F"
+
+[<Test>]
+let ``AbsolutePath contains escaped slashes`` () =
+    uri.AbsolutePath |> should equal "/%2F"
+
+[<Test>]
+let ``Uri Fragment is properly set`` () = 
+    uri.Fragment |> should equal "#frag"


### PR DESCRIPTION
@ovatsus here's the fix you asked. I tested it on XS and ApiaryTypeProvider now works.

But my trial of Visual Studio 2013 expired and I couldn't test it on Windows. Also, I wasn't able to run the tests on Mono...

Could you please please finish the job for me? :D
