### PR TITLE
use mono 3.2.7 and fsharp 3.1.1.1 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,18 @@ language: objective-c
 env:
   global:
     - FREEBASE_API_KEY=AIzaSyBTcOKmU7L7gFB4AdyAz75JRmdHixdLYjY
-  matrix:
-    - MONO_VERSION=3.2.6
+    - MONO_VERSION=3.2.7
+    - FSHARP_VERSION=3.1.1.1
 
 install:
   - wget "http://download.xamarin.com/MonoFrameworkMDK/Macx86/MonoFramework-MDK-${MONO_VERSION}.macos10.xamarin.x86.pkg"
   - sudo installer -pkg "MonoFramework-MDK-${MONO_VERSION}.macos10.xamarin.x86.pkg" -target /
+  - wget "https://github.com/fsharp/fsharp/archive/${FSHARP_VERSION}.tar.gz" -O /tmp/fsharp-${FSHARP_VERSION}.tar.gz
+  - (cd /tmp; tar xf fsharp-${FSHARP_VERSION}.tar.gz) && pushd /tmp/fsharp-${FSHARP_VERSION}
+  - ./autogen.sh --prefix=/Library/Frameworks/Mono.framework/Versions/${MONO_VERSION}
+  - make
+  - sudo make install
+  - popd
 
 script: 
   - ./build.sh CleanInternetCaches && ./build.sh All


### PR DESCRIPTION
build and install fsharp 3.1
this add +10, +15 min to build, but is ok

fix #447

Build fails, i think error was introduced with #435 ( 5d9215f067ac7f17679836886569fc31f0080b43 ), the first failing build, not because of user quota.

To test my conjecture:

I created a new branch [fsharp31_on_last_successful_build](https://github.com/enricosada/FSharp.Data/tree/fsharp31_on_last_successful_build) based on  [last travis successful build](https://travis-ci.org/fsharp/FSharp.Data/builds/19287979) ( 2efe9cbc4cd00def44cdfe8d42f3ab258480a43d ) and cherry-picked my changes into it.
The [build](https://travis-ci.org/enricosada/FSharp.Data/builds/19881494) fail on signature test, _after_ compile error.

I can repro locally, i'll try to fix it, but maybe a revert will be easier
