### PR TITLE
Unpolute FSharp.Data namespace

### DIFF
--- a/docs/content/ja/library/Http.fsx
+++ b/docs/content/ja/library/Http.fsx
@@ -25,7 +25,7 @@ F# Dataライブラリにはオーバーロードを持った4つのメソッド
 *)
 
 #r "../../../../bin/FSharp.Data.dll"
-open FSharp.Data
+open FSharp.Data.Http
 
 (**
 ## 単純なリクエストの送信

--- a/docs/content/library/Http.fsx
+++ b/docs/content/library/Http.fsx
@@ -21,7 +21,7 @@ or add reference to a project. The type is located in `FSharp.Net` namespace:
 *)
 
 #r "../../../bin/FSharp.Data.dll"
-open FSharp.Data
+open FSharp.Data.Http
 
 (**
 ## Sending simple requests

--- a/src/CommonRuntime/IO.fs
+++ b/src/CommonRuntime/IO.fs
@@ -8,7 +8,7 @@ module FSharp.Data.Runtime.IO
 open System
 open System.IO
 open System.Net
-open FSharp.Data
+open FSharp.Data.Http
 
 type internal UriResolutionType =
     | DesignTime

--- a/src/Freebase/FreebaseRequests.fs
+++ b/src/Freebase/FreebaseRequests.fs
@@ -18,6 +18,7 @@ open System.IO
 open System.Net 
 open System.Collections.Generic
 open FSharp.Data
+open FSharp.Data.Http
 open FSharp.Data.JsonExtensions
 open FSharp.Data.Runtime.Caching
 

--- a/src/Json/JsonExtensions.fs
+++ b/src/Json/JsonExtensions.fs
@@ -22,8 +22,8 @@ type JsonValue with
     | JsonValue.Object properties -> 
         match Map.tryFind propertyName properties with 
         | Some res -> res
-        | None -> failwithf "Didn't find property '%s' in %s" propertyName <| x.ToString(SaveOptions.DisableFormatting)
-    | _ -> failwithf "Not an object: %s" <| x.ToString(SaveOptions.DisableFormatting)
+        | None -> failwithf "Didn't find property '%s' in %s" propertyName <| x.ToString(JsonSaveOptions.DisableFormatting)
+    | _ -> failwithf "Not an object: %s" <| x.ToString(JsonSaveOptions.DisableFormatting)
 
   /// Try to get a property of a JSON value.
   /// Returns None if the value is not an object or if the property is not present.
@@ -55,28 +55,28 @@ type JsonValue with
     let cultureInfo = defaultArg cultureInfo  CultureInfo.InvariantCulture
     match JsonConversions.AsString (*useNoneForNullOrWhiteSpace*)false cultureInfo x with
     | Some s -> s
-    | _ -> failwithf "Not a string: %s" <| x.ToString(SaveOptions.DisableFormatting)  
+    | _ -> failwithf "Not a string: %s" <| x.ToString(JsonSaveOptions.DisableFormatting)  
 
   /// Get a number as an integer (assuming that the value fits in integer)
   member x.AsInteger(?cultureInfo) = 
     let cultureInfo = defaultArg cultureInfo  CultureInfo.InvariantCulture
     match JsonConversions.AsInteger cultureInfo x with
     | Some i -> i
-    | _ -> failwithf "Not an int: %s" <| x.ToString(SaveOptions.DisableFormatting)  
+    | _ -> failwithf "Not an int: %s" <| x.ToString(JsonSaveOptions.DisableFormatting)  
 
   /// Get a number as a 64-bit integer (assuming that the value fits in 64-bit integer)
   member x.AsInteger64(?cultureInfo) = 
     let cultureInfo = defaultArg cultureInfo  CultureInfo.InvariantCulture
     match JsonConversions.AsInteger64 cultureInfo x with
     | Some i -> i
-    | _ -> failwithf "Not an int64: %s" <| x.ToString(SaveOptions.DisableFormatting)  
+    | _ -> failwithf "Not an int64: %s" <| x.ToString(JsonSaveOptions.DisableFormatting)  
 
   /// Get a number as a decimal (assuming that the value fits in decimal)
   member x.AsDecimal(?cultureInfo ) = 
     let cultureInfo = defaultArg cultureInfo  CultureInfo.InvariantCulture
     match JsonConversions.AsDecimal cultureInfo x with
     | Some d -> d
-    | _ -> failwithf "Not a decimal: %s" <| x.ToString(SaveOptions.DisableFormatting)
+    | _ -> failwithf "Not a decimal: %s" <| x.ToString(JsonSaveOptions.DisableFormatting)
 
   /// Get a number as a float (assuming that the value is convertible to a float)
   member x.AsFloat(?cultureInfo, ?missingValues) = 
@@ -84,14 +84,14 @@ type JsonValue with
     let missingValues = defaultArg missingValues TextConversions.DefaultMissingValues
     match JsonConversions.AsFloat missingValues (*useNoneForMissingValues*)false cultureInfo x with
     | Some f -> f
-    | _ -> failwithf "Not a float: %s" <| x.ToString(SaveOptions.DisableFormatting)
+    | _ -> failwithf "Not a float: %s" <| x.ToString(JsonSaveOptions.DisableFormatting)
 
   /// Get the boolean value of an element (assuming that the value is a boolean)
   member x.AsBoolean(?cultureInfo) =
     let cultureInfo = defaultArg cultureInfo  CultureInfo.InvariantCulture
     match JsonConversions.AsBoolean cultureInfo x with
     | Some b -> b
-    | _ -> failwithf "Not a boolean: %s" <| x.ToString(SaveOptions.DisableFormatting)
+    | _ -> failwithf "Not a boolean: %s" <| x.ToString(JsonSaveOptions.DisableFormatting)
 
   /// Get the datetime value of an element (assuming that the value is a string
   /// containing well-formed ISO date or MSFT JSON date)
@@ -99,13 +99,13 @@ type JsonValue with
     let cultureInfo = defaultArg cultureInfo  CultureInfo.InvariantCulture
     match JsonConversions.AsDateTime cultureInfo x with
     | Some d -> d
-    | _ -> failwithf "Not a datetime: %s" <| x.ToString(SaveOptions.DisableFormatting)
+    | _ -> failwithf "Not a datetime: %s" <| x.ToString(JsonSaveOptions.DisableFormatting)
 
   /// Get the guid value of an element (assuming that the value is a guid)
   member x.AsGuid() =
     match JsonConversions.AsGuid x with
     | Some g -> g
-    | _ -> failwithf "Not a guid: %s" <| x.ToString(SaveOptions.DisableFormatting)
+    | _ -> failwithf "Not a guid: %s" <| x.ToString(JsonSaveOptions.DisableFormatting)
 
   /// Get inner text of an element
   member x.InnerText = 

--- a/src/Json/JsonRuntime.fs
+++ b/src/Json/JsonRuntime.fs
@@ -123,11 +123,11 @@ type JsonRuntime =
         else "a " + name
     match opt, originalValue with 
     | Some value, _ -> value
-    | None, Some ((JsonValue.Array _ | JsonValue.Object _) as x) -> failwithf "Expecting %s at '%s', got %s" (getTypeName()) path <| x.ToString(SaveOptions.DisableFormatting)
+    | None, Some ((JsonValue.Array _ | JsonValue.Object _) as x) -> failwithf "Expecting %s at '%s', got %s" (getTypeName()) path <| x.ToString(JsonSaveOptions.DisableFormatting)
     | None, _ when typeof<'T> = typeof<string> -> "" |> unbox
     | None, _ when typeof<'T> = typeof<float> -> Double.NaN |> unbox
     | None, None -> failwithf "'%s' is missing" path
-    | None, Some x -> failwithf "Expecting %s at '%s', got %s" (getTypeName()) path <| x.ToString(SaveOptions.DisableFormatting)
+    | None, Some x -> failwithf "Expecting %s at '%s', got %s" (getTypeName()) path <| x.ToString(JsonSaveOptions.DisableFormatting)
 
   /// Converts JSON array to array of target types
   static member ConvertArray<'T>(doc:IJsonDocument, mapping:Func<IJsonDocument,'T>) = 
@@ -139,7 +139,7 @@ type JsonRuntime =
                                 | _ -> true)
         |> Array.mapi (fun i value -> doc.CreateNew(value, "[" + (string i) + "]") |> mapping.Invoke)
     | JsonValue.Null -> [| |]
-    | x -> failwithf "Expecting an array at '%s', got %s" doc.Path <| x.ToString(SaveOptions.DisableFormatting)
+    | x -> failwithf "Expecting an array at '%s', got %s" doc.Path <| x.ToString(JsonSaveOptions.DisableFormatting)
 
   /// Get optional json property
   static member TryGetPropertyUnpacked(doc:IJsonDocument, name) =
@@ -160,7 +160,7 @@ type JsonRuntime =
   static member GetPropertyPacked(doc:IJsonDocument, name) =
     match JsonRuntime.TryGetPropertyPacked(doc, name) with
     | Some doc -> doc
-    | None -> failwithf "Property '%s' not found at '%s': %s" name doc.Path <| doc.JsonValue.ToString(SaveOptions.DisableFormatting)
+    | None -> failwithf "Property '%s' not found at '%s': %s" name doc.Path <| doc.JsonValue.ToString(JsonSaveOptions.DisableFormatting)
 
   /// Get json property and wrap in json document, and return null if not found
   static member GetPropertyPackedOrNull(doc:IJsonDocument, name) =
@@ -207,20 +207,20 @@ type JsonRuntime =
         |> Array.filter (JsonRuntime.Matches cultureStr (InferedTypeTag.ParseCode tagCode))
         |> Array.mapi (fun i value -> doc.CreateNew(value, "[" + (string i) + "]") |> mapping.Invoke)
     | JsonValue.Null -> [| |]
-    | x -> failwithf "Expecting an array at '%s', got %s" doc.Path <| x.ToString(SaveOptions.DisableFormatting)
+    | x -> failwithf "Expecting an array at '%s', got %s" doc.Path <| x.ToString(JsonSaveOptions.DisableFormatting)
 
   /// Returns single or no value from an array matching the specified tag
   static member TryGetArrayChildByTypeTag<'T>(doc, cultureStr, tagCode, mapping:Func<IJsonDocument,'T>) = 
     match JsonRuntime.GetArrayChildrenByTypeTag(doc, cultureStr, tagCode, mapping) with
     | [| child |] -> Some child
     | [| |] -> None
-    | _ -> failwithf "Expecting an array with single or no elements at '%s', got %s" doc.Path <| doc.JsonValue.ToString(SaveOptions.DisableFormatting)
+    | _ -> failwithf "Expecting an array with single or no elements at '%s', got %s" doc.Path <| doc.JsonValue.ToString(JsonSaveOptions.DisableFormatting)
 
   /// Returns a single array children that matches the specified tag
   static member GetArrayChildByTypeTag(doc, cultureStr, tagCode) = 
     match JsonRuntime.GetArrayChildrenByTypeTag(doc, cultureStr, tagCode, Func<_,_>(id)) with
     | [| child |] -> child
-    | _ -> failwithf "Expecting an array with single element at '%s', got %s" doc.Path <| doc.JsonValue.ToString(SaveOptions.DisableFormatting)
+    | _ -> failwithf "Expecting an array with single element at '%s', got %s" doc.Path <| doc.JsonValue.ToString(JsonSaveOptions.DisableFormatting)
 
   /// Returns a single or no value by tag type
   static member TryGetValueByTypeTag<'T>(doc:IJsonDocument, cultureStr, tagCode, mapping:Func<IJsonDocument,'T>) = 

--- a/src/Json/JsonValue.fs
+++ b/src/Json/JsonValue.fs
@@ -14,12 +14,14 @@ open System.IO
 open System.Text
 open System.Globalization
 open FSharp.Data
+open FSharp.Data.Http
 open FSharp.Data.Runtime
 open FSharp.Data.Runtime.HttpUtils
 open FSharp.Data.Runtime.IO
 
 /// Specifies the formatting behaviour of JSON values
-type SaveOptions = 
+[<RequireQualifiedAccess>]
+type JsonSaveOptions = 
   /// Format (indent) the JsonValue
   | None = 0
   /// Print the JsonValue in one line in a compact way
@@ -38,13 +40,13 @@ type JsonValue =
   | Boolean of bool
   | Null
 
-  override x.ToString() = x.ToString(SaveOptions.None)
+  override x.ToString() = x.ToString(JsonSaveOptions.None)
 
   member x.ToString saveOptions = 
 
     let rec serialize (sb:StringBuilder) indentation json =
       let newLine plus =
-        if saveOptions = SaveOptions.None then
+        if saveOptions = JsonSaveOptions.None then
           sb.AppendLine() |> ignore
           System.String(' ', indentation + plus) |> sb.Append |> ignore
       match json with
@@ -64,7 +66,7 @@ type JsonValue =
           for KeyValue(k, v) in properties |> Seq.sortBy (fun (KeyValue(k, v)) -> getOrder v, k) do
             if !isNotFirst then sb.Append "," |> ignore else isNotFirst := true
             newLine 2
-            if saveOptions = SaveOptions.None then
+            if saveOptions = JsonSaveOptions.None then
               sb.AppendFormat("\"{0}\": ", k) |> ignore
             else
               sb.AppendFormat("\"{0}\":", k) |> ignore
@@ -295,7 +297,7 @@ type JsonValue with
   member x.Post(uri:string) =  
     Http.Request(
       uri,
-      body = TextRequest (x.ToString(SaveOptions.DisableFormatting)),
+      body = TextRequest (x.ToString(JsonSaveOptions.DisableFormatting)),
       headers = [ContentType HttpContentTypes.Json])
 
   /// Parses the specified JSON string, tolerating invalid errors like trailing commans, and ignore content with elipsis ... or {...}

--- a/src/Net/Http.fs
+++ b/src/Net/Http.fs
@@ -2,7 +2,7 @@
 // Utilities for working with network, downloading resources with specified headers etc.
 // --------------------------------------------------------------------------------------
 
-namespace FSharp.Data
+namespace FSharp.Data.Http
 
 open System
 open System.Globalization

--- a/src/WorldBank/WorldBankRuntime.fs
+++ b/src/WorldBank/WorldBankRuntime.fs
@@ -10,6 +10,7 @@ open System.Diagnostics
 open System.Globalization
 open System.Net
 open FSharp.Data
+open FSharp.Data.Http
 open FSharp.Data.JsonExtensions
 open FSharp.Data.Runtime.Caching
 

--- a/tests/FSharp.Data.Tests/Http.fs
+++ b/tests/FSharp.Data.Tests/Http.fs
@@ -9,7 +9,7 @@ module FSharp.Data.Tests.Http
 open FsUnit
 open NUnit.Framework
 open System
-open FSharp.Data
+open FSharp.Data.Http
 
 [<Test>]
 let ``Don't throw exceptions on http error`` () = 

--- a/tests/FSharp.Data.Tests/HttpIntegrationTests.fs
+++ b/tests/FSharp.Data.Tests/HttpIntegrationTests.fs
@@ -9,7 +9,7 @@ open NUnit.Framework
 open FsUnit
 open Nancy
 open Nancy.Hosting.Self
-open FSharp.Data
+open FSharp.Data.Http
 
 // ? operator to get values from a Nancy DynamicDictionary
 let (?) (parameters:obj) param =

--- a/tests/FSharp.Data.Tests/JsonValue.fs
+++ b/tests/FSharp.Data.Tests/JsonValue.fs
@@ -177,7 +177,7 @@ let ``Can parse array of numbers``() =
 let ``Quotes in strings are property escaped``() = 
     let jsonStr = "{\"short_description\":\"This a string with \\\"quotes\\\"\"}"
     let j = JsonValue.Parse jsonStr
-    j.ToString(SaveOptions.DisableFormatting) |> should equal jsonStr
+    j.ToString(JsonSaveOptions.DisableFormatting) |> should equal jsonStr
 
 [<Test>]
 let ``Can parse simple array``() = 
@@ -197,27 +197,27 @@ let ``Can parse nested array``() =
 
 [<Test>]
 let ``Can serialize empty document``() = 
-    (JsonValue.Object Map.empty).ToString(SaveOptions.DisableFormatting) 
+    (JsonValue.Object Map.empty).ToString(JsonSaveOptions.DisableFormatting) 
     |> should equal "{}"
 
 [<Test>] 
 let ``Can serialize document with single property``() =
     ( [ "firstName", JsonValue.String "John" ]
-        |> Map.ofSeq |> JsonValue.Object ).ToString(SaveOptions.DisableFormatting)
+        |> Map.ofSeq |> JsonValue.Object ).ToString(JsonSaveOptions.DisableFormatting)
     |> should equal "{\"firstName\":\"John\"}"
 
 [<Test>] 
 let ``Can serialize document with booleans``() =
     ( [ "aa", JsonValue.Boolean true
         "bb", JsonValue.Boolean false ]
-        |> Map.ofSeq |> JsonValue.Object ).ToString(SaveOptions.DisableFormatting)
+        |> Map.ofSeq |> JsonValue.Object ).ToString(JsonSaveOptions.DisableFormatting)
     |> should equal "{\"aa\":true,\"bb\":false}"
 
 [<Test>]
 let ``Can serialize document with array, null and number``() =
     let text = "{\"items\":[{\"id\":\"Open\"},null,{\"id\":25}]}"
     let json = JsonValue.Parse text
-    json.ToString(SaveOptions.DisableFormatting) |> should equal text
+    json.ToString(JsonSaveOptions.DisableFormatting) |> should equal text
 
 let normalize (str:string) =
   str.Replace("\r\n", "\n")


### PR DESCRIPTION
@tpetricek, regarding #477, what about this:

Before:
![image](https://f.cloud.github.com/assets/738761/2305416/2909889e-a256-11e3-9198-d3a3b491add9.png)

After:
![image](https://f.cloud.github.com/assets/738761/2305418/30b7b4a8-a256-11e3-8f19-af3350588d90.png)
