### PR TITLE
Added recent changes from codeplex to address a few recent bugs.

### DIFF
--- a/src/CommonProviderImplementation/ProvidedTypes.fs
+++ b/src/CommonProviderImplementation/ProvidedTypes.fs
@@ -693,6 +693,19 @@ type SymbolKind =
 type ProvidedSymbolType(kind: SymbolKind, args: Type list) =
     inherit Type()
 
+    let rec isEquivalentTo (thisTy: Type) (otherTy: Type) =
+        match thisTy, otherTy with
+        | (:? ProvidedSymbolType as thisTy), (:? ProvidedSymbolType as thatTy) -> (thisTy.Kind,thisTy.Args) = (thatTy.Kind, thatTy.Args)
+        | (:? ProvidedSymbolType as thisTy), otherTy | otherTy, (:? ProvidedSymbolType as thisTy) ->
+            match thisTy.Kind, thisTy.Args with
+            | SymbolKind.SDArray, [ty] | SymbolKind.Array _, [ty] when otherTy.IsArray-> ty.Equals(otherTy.GetElementType())
+            | SymbolKind.ByRef, [ty] when otherTy.IsByRef -> ty.Equals(otherTy.GetElementType())
+            | SymbolKind.Pointer, [ty] when otherTy.IsPointer -> ty.Equals(otherTy.GetElementType())
+            | SymbolKind.Generic baseTy, args -> otherTy.IsGenericType && isEquivalentTo baseTy (otherTy.GetGenericTypeDefinition()) && Seq.forall2 isEquivalentTo args (otherTy.GetGenericArguments())
+            | _ -> false
+        | a, b -> a.Equals b
+
+
     static member convType (parameters: Type list) (ty:Type) = 
         if ty.IsGenericType then 
             let args = Array.map (ProvidedSymbolType.convType parameters) (ty.GetGenericArguments())
@@ -741,7 +754,7 @@ type ProvidedSymbolType(kind: SymbolKind, args: Type list) =
             if otherTy.IsGenericType then
                 let otherGtd = otherTy.GetGenericTypeDefinition()
                 let otherArgs = otherTy.GetGenericArguments()
-                let yes = gtd.Equals(otherGtd) && Seq.forall2 (=) args otherArgs
+                let yes = gtd.Equals(otherGtd) && Seq.forall2 isEquivalentTo args otherArgs
                 yes
                 else
                     base.IsAssignableFrom(otherTy)
@@ -799,14 +812,15 @@ type ProvidedSymbolType(kind: SymbolKind, args: Type list) =
         | SymbolKind.Generic gty,_ -> 9797 + hash gty + List.sumBy hash args
         | SymbolKind.FSharpTypeAbbreviation _,_ -> 3092
         | _ -> failwith "unreachable"
+    
+    override this.Equals(other: obj) =
+        match other with
+        | :? ProvidedSymbolType as otherTy -> (kind, args) = (otherTy.Kind, otherTy.Args)
+        | _ -> false
+
     member this.Kind = kind
     member this.Args = args
     
-    override this.Equals(that:obj) = 
-        match that with 
-        | :? ProvidedSymbolType as that -> (kind,args) = (that.Kind, that.Args)
-        | _ -> false
-
     override this.GetConstructors _bindingAttr                                                      = notRequired "GetConstructors" this.Name
     override this.GetMethodImpl(_name, _bindingAttr, _binderBinder, _callConvention, _types, _modifiers) = 
         match kind with
@@ -1984,7 +1998,6 @@ type AssemblyGenerator(assemblyFileName) =
                 let cattr = pcinfo.GetCustomAttributesDataImpl() 
                 defineCustomAttrs cb.SetCustomAttribute cattr
                 let ilg = cb.GetILGenerator()
-                ilg.Emit(OpCodes.Ldarg_0)
                 let locals = Dictionary<Quotations.Var,LocalBuilder>()
                 let parameterVars = 
                     [| yield Quotations.Var("this", pcinfo.DeclaringType)
@@ -1994,9 +2007,11 @@ type AssemblyGenerator(assemblyFileName) =
                     [| for v in parameterVars -> Quotations.Expr.Var v |]
                 match pcinfo.GetBaseConstructorCallInternal true with
                 | None ->  
+                    ilg.Emit(OpCodes.Ldarg_0)
                     let cinfo = ptd.BaseType.GetConstructor(BindingFlags.Public ||| BindingFlags.NonPublic ||| BindingFlags.Instance, null, [| |], null)
                     ilg.Emit(OpCodes.Call,cinfo)
                 | Some f -> 
+                    // argExprs should always include 'this'
                     let (cinfo,argExprs) = f (Array.toList parameters)
                     for argExpr in argExprs do 
                         emitExpr (ilg, locals, parameterVars) ExpectedStackState.Value argExpr


### PR DESCRIPTION
See: added simple equivalence check fotsymbolic types:
https://fsharp3sample.codeplex.com/SourceControl/changeset/24323

Add correct base constructor IL op codes:
https://fsharp3sample.codeplex.com/SourceControl/changeset/24356
