### PR TITLE
Json parser property test (string -> JsonValue -> string)

### DIFF
--- a/tests/FSharp.Data.Tests/FSharp.Data.Tests.fsproj
+++ b/tests/FSharp.Data.Tests/FSharp.Data.Tests.fsproj
@@ -201,7 +201,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FsCheck">
-      <HintPath>..\..\packages\FsCheck.0.9.4.0\lib\net40-Client\FsCheck.dll</HintPath>
+      <HintPath>..\..\packages\FsCheck.0.9.2.0\lib\net40-Client\FsCheck.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/tests/FSharp.Data.Tests/JsonParserProperties.fs
+++ b/tests/FSharp.Data.Tests/JsonParserProperties.fs
@@ -1,7 +1,7 @@
 ﻿#if INTERACTIVE
 #r "../../bin/FSharp.Data.dll"
 #r "../../packages/NUnit.2.6.3/lib/nunit.framework.dll"
-#r "../../packages/FsCheck.0.9.4.0/lib/net40-Client/FsCheck.dll"
+#r "../../packages/FsCheck.0.9.2.0/lib/net40-Client/FsCheck.dll"
 #load "../Common/FsUnit.fs"
 #else
 module FSharp.Data.Tests.JsonParserProperties

--- a/tests/FSharp.Data.Tests/app.config
+++ b/tests/FSharp.Data.Tests/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0" />
+        <bindingRedirect oldVersion="2.0.0.0" newVersion="4.3.0.0" />
         <bindingRedirect oldVersion="2.3.5.0" newVersion="4.3.0.0" />
         <bindingRedirect oldVersion="4.0.0.0" newVersion="4.3.0.0" />
       </dependentAssembly>

--- a/tests/FSharp.Data.Tests/packages.config
+++ b/tests/FSharp.Data.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FsCheck" version="0.9.4.0" targetFramework="net40" />
+  <package id="FsCheck" version="0.9.2.0" targetFramework="net40" />
   <package id="Nancy" version="0.20.0" targetFramework="net45" />
   <package id="Nancy.Hosting.Self" version="0.20.0" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net40" />


### PR DESCRIPTION
I added a new FsCheck property test verifying "round trip" for parsing string to JsonValue and then back to string. Also renamed the file to JsonParserProperties.
Exponential part of numbers are deliberately omitted, as there are some conversions applied for these, that would cause the test to fail. 
