### PR TITLE
Make Json string escape more efficient

### DIFF
--- a/src/Json/JsonValue.fs
+++ b/src/Json/JsonValue.fs
@@ -53,17 +53,23 @@ type JsonValue =
       | Number number -> sb.Append(number.ToString(CultureInfo.InvariantCulture))
       | Float number -> sb.Append(number.ToString(CultureInfo.InvariantCulture))
       | String s ->
-          sb.Append("\"" + JsonValue.JsonStringEncode(s) + "\"")
+          sb.Append("\"") |> ignore
+          JsonValue.JsonStringEncodeTo sb s
+          sb.Append("\"")
       | Record properties ->
           let isNotFirst = ref false
           sb.Append "{"  |> ignore
           for k, v in properties do
             if !isNotFirst then sb.Append "," |> ignore else isNotFirst := true
-            newLine 2
+            newLine 2            
             if saveOptions = JsonSaveOptions.None then
-              sb.AppendFormat("\"{0}\": ", JsonValue.JsonStringEncode(k)) |> ignore
+              sb.Append("\"") |> ignore
+              JsonValue.JsonStringEncodeTo sb k
+              sb.Append("\": ") |> ignore
             else
-              sb.AppendFormat("\"{0}\":", JsonValue.JsonStringEncode(k)) |> ignore
+              sb.Append("\"") |> ignore
+              JsonValue.JsonStringEncodeTo sb k
+              sb.Append("\":") |> ignore
             serialize sb (indentation + 2) v |> ignore
           newLine 0
           sb.Append "}"
@@ -82,37 +88,28 @@ type JsonValue =
 
   // Encode characters that are not valid in JS string. The implementation is based
   // on https://github.com/mono/mono/blob/master/mcs/class/System.Web/System.Web/HttpUtility.cs
-  // (but we use just a single iteration and create StringBuilder as needed)
-  static member internal JsonStringEncode (value : string) = 
-    if String.IsNullOrEmpty value then "" else 
-      let chars = value.ToCharArray() 
-    
-      // We only create StringBuilder when we find a character that 
-      // we actually need to encode (and then we copy all skipped chars)
-      let sb = ref null 
-      let inline ensureBuilder i = 
-        if !sb = null then 
-          sb := new StringBuilder(value.Length + 5)
-          (!sb).Append(value.Substring(0, i))
-        else !sb
-
-      // Iterate over characters and encode 
-      for i in 0 .. chars.Length - 1 do 
-        let c = int (chars.[i])
-        if c >= 0 && c <= 7 || c = 11 || c >= 14 && c <= 31 then
-          (ensureBuilder i).AppendFormat("\\u{0:x4}", c) |> ignore
+  // (but we use just a single iteration and create StringBuilder as needed)    
+  static member internal JsonStringEncodeTo (sb:StringBuilder) (value:string) =
+    if String.IsNullOrEmpty value then ()
+    else 
+      for i = 0 to value.Length - 1 do
+        let c = value.[i]
+        let ci = int c
+        if ci >= 0 && ci <= 7 || ci = 11 || ci >= 14 && ci <= 31 then
+          sb.AppendFormat("\\u{0:x4}", ci) |> ignore
         else 
-          match chars.[i] with
-          | '\b' -> (ensureBuilder i).Append "\\b" |> ignore
-          | '\t' -> (ensureBuilder i).Append "\\t" |> ignore
-          | '\n' -> (ensureBuilder i).Append "\\n" |> ignore
-          | '\f' -> (ensureBuilder i).Append "\\f" |> ignore
-          | '\r' -> (ensureBuilder i).Append "\\r" |> ignore
-          | '"' -> (ensureBuilder i).Append "\\\"" |> ignore
-          | '\\' -> (ensureBuilder i).Append "\\\\" |> ignore
-          | _ -> if !sb <> null then (!sb).Append(char c) |> ignore
-      if !sb = null then value else
-        (ensureBuilder chars.Length).ToString()
+          match c with
+          | '\b' -> sb.Append "\\b" |> ignore
+          | '\t' -> sb.Append "\\t" |> ignore
+          | '\n' -> sb.Append "\\n" |> ignore
+          | '\f' -> sb.Append "\\f" |> ignore
+          | '\r' -> sb.Append "\\r" |> ignore
+          | '"'  -> sb.Append "\\\"" |> ignore
+          | '\\' -> sb.Append "\\\\" |> ignore
+          | _    -> sb.Append c |> ignore
+      ()
+
+
 
 /// [omit]
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]

--- a/tests/FSharp.Data.Tests/JsonValue.fs
+++ b/tests/FSharp.Data.Tests/JsonValue.fs
@@ -392,20 +392,23 @@ let ``Can parse various JSON documents``() =
 [<Test>]
 let ``Basic special characters encoded correctly`` () = 
   let input = " \"quoted\" and \'quoted\' and \r\n and \uABCD "
-  let actual = JsonValue.JsonStringEncode input
+  let sb = new Text.StringBuilder()
+  JsonValue.JsonStringEncodeTo sb input
   let expected = " \\\"quoted\\\" and 'quoted' and \\r\\n and \uABCD "
-  actual |> should equal expected
+  (sb.ToString()) |> should equal expected
 
 [<Test>]
 let ``Encoding of simple string is valid JSON`` () = 
   let input = "sample \"json\" with \t\r\n \' quotes etc."
-  let actual = JsonValue.JsonStringEncode input
+  let sb = new Text.StringBuilder()
+  JsonValue.JsonStringEncodeTo sb input
   let expected = "sample \\\"json\\\" with \\t\\r\\n ' quotes etc."
-  actual |> should equal expected
+  (sb.ToString()) |> should equal expected
 
 [<Test>]
 let ``Encoding of markup is not overzealous`` () =
   let input = "<SecurityLabel><MOD>ModelAdministrators</MOD></SecurityLabel>"
-  let actual = JsonValue.JsonStringEncode input
+  let sb = new Text.StringBuilder()
+  JsonValue.JsonStringEncodeTo sb input
   let expected = input // Should not escape </>
-  actual |> should equal expected
+  (sb.ToString()) |> should equal expected


### PR DESCRIPTION
By writing directly to Json output StringBuilder instead of creating new
one for each escaped string.
