### PR TITLE
Remove parent

### DIFF
--- a/src/Test.HtmlRuntime.fsx
+++ b/src/Test.HtmlRuntime.fsx
@@ -20,20 +20,6 @@ module internal Test.HtmlRuntime
 open FSharp.Data
 open FSharp.Data.Runtime
 
-#if INTERACTIVE
-type PrintableContent =
-    | Element of string * HtmlAttribute list * (PrintableContent list)
-    | Text of string
-    | Comment of string
-    static member ofHtmlNode(x) =
-        match x with
-        | HtmlElement(_, name, attrs, content) -> Element(name, attrs, content |> List.map PrintableContent.ofHtmlNode)
-        | HtmlText(_,content) -> Text(content)
-        | HtmlComment(_, content) -> Comment(content)
-
-fsi.AddPrintTransformer(PrintableContent.ofHtmlNode >> box)
-#endif
-
 let printParsed (html:string) = 
     html
     |> HtmlDocument.Parse

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Freebase,5,True,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Freebase,5,True,True.expected
@@ -1706,7 +1706,10 @@ class FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividual
     member ``Bravo November``: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividuals100+Bravo November Item with get
     this.GetIndividualById("/aviation/aircraft", "/m/07s4xq_")
 
-    member Breitling Orbiter 3: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividuals100+Breitling Orbiter 3 Item with get
+    member ``Brazilian Air Force One``: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividuals100+Brazilian Air Force One Item with get
+    this.GetIndividualById("/aviation/aircraft", "/m/026k9s4")
+
+    member ``Breitling Orbiter 3``: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividuals100+Breitling Orbiter 3 Item with get
     this.GetIndividualById("/aviation/aircraft", "/m/09kr0z")
 
     member ``Bristol Belle``: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividuals100+Bristol Belle Item with get

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Html,list_of_counties_wikipedia.html,False,.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Html,list_of_counties_wikipedia.html,False,.expected
@@ -86,13 +86,13 @@ class HtmlProvider+TableContainer : FDR.TypedHtmlDocument
                                         TextRuntime.GetNonOptionalValue("Metropolitan Area [ 4 ] [ 5 ]", TextRuntime.ConvertString(value), value))
     HtmlTable<_>.Create(rowConverter, this, "List of most populous urban areas in Scotland [ edit ]")
 
-    member ReferencesAndNotesEdit: HtmlProvider+ReferencesAndNotesEdit with get
+    member Table5: HtmlProvider+Table5 with get
     let rowConverter = new Func<_,_>(fun (row:string[]) -> 
                                         let value = TextConversions.AsString(row.[0])
                                         TextRuntime.GetNonOptionalValue("v t e List of settlements in the United Kingdom", TextRuntime.ConvertString(value), value),
                                         let value = TextConversions.AsString(row.[1])
                                         TextRuntime.GetNonOptionalValue("v t e List of settlements in the United Kingdom2", TextRuntime.ConvertString(value), value))
-    HtmlTable<_>.Create(rowConverter, this, "References and Notes [ edit ]")
+    HtmlTable<_>.Create(rowConverter, this, "Table5")
 
 
 class HtmlProvider+ListOfMostPopulousBuiltUpAreasInEnglandAndWalesEdit : FDR.HtmlTable<HtmlProvider+ListOfMostPopulousBuiltUpAreasInEnglandAndWalesEdit+Row>
@@ -101,7 +101,7 @@ class HtmlProvider+ListOfMostPopulousUrbanAreasInNorthernIrelandEdit : FDR.HtmlT
 
 class HtmlProvider+ListOfMostPopulousUrbanAreasInScotlandEdit : FDR.HtmlTable<HtmlProvider+ListOfMostPopulousUrbanAreasInScotlandEdit+Row>
 
-class HtmlProvider+ReferencesAndNotesEdit : FDR.HtmlTable<HtmlProvider+ReferencesAndNotesEdit+Row>
+class HtmlProvider+Table5 : FDR.HtmlTable<HtmlProvider+Table5+Row>
 
 class HtmlProvider+ListOfMostPopulousBuiltUpAreasInEnglandAndWalesEdit+Row : int * string * decimal * decimal * decimal * string * string * string
     member ``Area (km�) [ 3 ]``: decimal with get
@@ -175,7 +175,7 @@ class HtmlProvider+ListOfMostPopulousUrbanAreasInScotlandEdit+Row : int * string
     (let _,t2,_,_,_,_,_ = this in t2)
 
 
-class HtmlProvider+ReferencesAndNotesEdit+Row : string * string
+class HtmlProvider+Table5+Row : string * string
     member ``v t e List of settlements in the United Kingdom``: string with get
     (let t1,_ = this in t1)
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Html,us_presidents_wikipedia.html,False,.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Html,us_presidents_wikipedia.html,False,.expected
@@ -30,14 +30,6 @@ class HtmlProvider : FDR.TypedHtmlDocument
 
 
 class HtmlProvider+TableContainer : FDR.TypedHtmlDocument
-    member ExternalLinks: HtmlProvider+ExternalLinks with get
-    let rowConverter = new Func<_,_>(fun (row:string[]) -> 
-                                        let value = TextConversions.AsString(row.[0])
-                                        TextRuntime.GetNonOptionalValue("v t e Chief executives of the United States", TextRuntime.ConvertString(value), value),
-                                        let value = TextConversions.AsString(row.[1])
-                                        TextRuntime.GetNonOptionalValue("v t e Chief executives of the United States2", TextRuntime.ConvertString(value), value))
-    HtmlTable<_>.Create(rowConverter, this, "External links")
-
     member ListOfPresidents: HtmlProvider+ListOfPresidents with get
     let rowConverter = new Func<_,_>(fun (row:string[]) -> 
                                         let value = TextConversions.AsString(row.[0])
@@ -75,10 +67,18 @@ class HtmlProvider+TableContainer : FDR.TypedHtmlDocument
     member Table10: HtmlProvider+Table10 with get
     let rowConverter = new Func<_,_>(fun (row:string[]) -> 
                                         let value = TextConversions.AsString(row.[0])
+                                        TextRuntime.GetNonOptionalValue("v t e Chief executives of the United States", TextRuntime.ConvertString(value), value),
+                                        let value = TextConversions.AsString(row.[1])
+                                        TextRuntime.GetNonOptionalValue("v t e Chief executives of the United States2", TextRuntime.ConvertString(value), value))
+    HtmlTable<_>.Create(rowConverter, this, "Table10")
+
+    member Table11: HtmlProvider+Table11 with get
+    let rowConverter = new Func<_,_>(fun (row:string[]) -> 
+                                        let value = TextConversions.AsString(row.[0])
                                         TextRuntime.GetNonOptionalValue("v t e Presidents of the United States", TextRuntime.ConvertString(value), value),
                                         let value = TextConversions.AsString(row.[1])
                                         TextRuntime.GetNonOptionalValue("v t e Presidents of the United States2", TextRuntime.ConvertString(value), value))
-    HtmlTable<_>.Create(rowConverter, this, "Table10")
+    HtmlTable<_>.Create(rowConverter, this, "Table11")
 
     member Table12: HtmlProvider+Table12 with get
     let rowConverter = new Func<_,_>(fun (row:string[]) -> 
@@ -89,23 +89,15 @@ class HtmlProvider+TableContainer : FDR.TypedHtmlDocument
     HtmlTable<_>.Create(rowConverter, this, "Table12")
 
 
-class HtmlProvider+ExternalLinks : FDR.HtmlTable<HtmlProvider+ExternalLinks+Row>
-
 class HtmlProvider+ListOfPresidents : FDR.HtmlTable<HtmlProvider+ListOfPresidents+Row>
 
 class HtmlProvider+LivingFormerPresidents : FDR.HtmlTable<HtmlProvider+LivingFormerPresidents+Row>
 
 class HtmlProvider+Table10 : FDR.HtmlTable<HtmlProvider+Table10+Row>
 
+class HtmlProvider+Table11 : FDR.HtmlTable<HtmlProvider+Table11+Row>
+
 class HtmlProvider+Table12 : FDR.HtmlTable<HtmlProvider+Table12+Row>
-
-class HtmlProvider+ExternalLinks+Row : string * string
-    member ``v t e Chief executives of the United States``: string with get
-    (let t1,_ = this in t1)
-
-    member ``v t e Chief executives of the United States2``: string with get
-    (let _,t2 = this in t2)
-
 
 class HtmlProvider+ListOfPresidents+Row : string * string * string * string * string * string * string * string * string * string
     member ``Left office``: string with get
@@ -151,6 +143,14 @@ class HtmlProvider+LivingFormerPresidents+Row : string * string * string
 
 
 class HtmlProvider+Table10+Row : string * string
+    member ``v t e Chief executives of the United States``: string with get
+    (let t1,_ = this in t1)
+
+    member ``v t e Chief executives of the United States2``: string with get
+    (let _,t2 = this in t2)
+
+
+class HtmlProvider+Table11+Row : string * string
     member ``v t e Presidents of the United States``: string with get
     (let t1,_ = this in t1)
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Html,wimbledon_wikipedia.html,False,.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Html,wimbledon_wikipedia.html,False,.expected
@@ -42,24 +42,6 @@ class HtmlProvider+TableContainer : FDR.TypedHtmlDocument
                                         TextRuntime.GetNonOptionalValue("Score", TextRuntime.ConvertString(value), value))
     HtmlTable<_>.Create(rowConverter, this, "Current champions [ edit ]")
 
-    member ExternalLinksEdit: HtmlProvider+ExternalLinksEdit with get
-    let rowConverter = new Func<_,_>(fun (row:string[]) -> 
-                                        let value = TextConversions.AsString(row.[0])
-                                        TextRuntime.GetNonOptionalValue("Column1", TextRuntime.ConvertInteger("", value), value),
-                                        let value = TextConversions.AsString(row.[1])
-                                        TextRuntime.GetNonOptionalValue("Column2", TextRuntime.ConvertInteger("", value), value),
-                                        let value = TextConversions.AsString(row.[2])
-                                        TextRuntime.GetNonOptionalValue("Column3", TextRuntime.ConvertInteger("", value), value),
-                                        let value = TextConversions.AsString(row.[3])
-                                        TextRuntime.GetNonOptionalValue("Column4", TextRuntime.ConvertInteger("", value), value),
-                                        TextRuntime.OptionToNullable(TextRuntime.ConvertInteger("", TextConversions.AsString(row.[4]))),
-                                        TextRuntime.OptionToNullable(TextRuntime.ConvertInteger("", TextConversions.AsString(row.[5]))),
-                                        TextRuntime.OptionToNullable(TextRuntime.ConvertInteger("", TextConversions.AsString(row.[6]))),
-                                        TextRuntime.OptionToNullable(TextRuntime.ConvertInteger("", TextConversions.AsString(row.[7]))),
-                                        TextRuntime.OptionToNullable(TextRuntime.ConvertInteger("", TextConversions.AsString(row.[8]))),
-                                        TextRuntime.OptionToNullable(TextRuntime.ConvertInteger("", TextConversions.AsString(row.[9]))))
-    HtmlTable<_>.Create(rowConverter, this, "External links [ edit ]")
-
     member RankingPointsEdit: HtmlProvider+RankingPointsEdit with get
     let rowConverter = new Func<_,_>(fun (row:string[]) -> 
                                         let value = TextConversions.AsString(row.[0])
@@ -92,7 +74,15 @@ class HtmlProvider+TableContainer : FDR.TypedHtmlDocument
                                         TextRuntime.GetNonOptionalValue("Column2", TextRuntime.ConvertString(value), value))
     HtmlTable<_>.Create(rowConverter, this, "See also [ edit ]")
 
-    member Table32: HtmlProvider+Table32 with get
+    member Table14: HtmlProvider+Table14 with get
+    let rowConverter = new Func<_,_>(fun (row:string[]) -> 
+                                        let value = TextConversions.AsString(row.[0])
+                                        TextRuntime.GetNonOptionalValue("The Championships, Wimbledon", TextRuntime.ConvertString(value), value),
+                                        let value = TextConversions.AsString(row.[1])
+                                        TextRuntime.GetNonOptionalValue("The Championships, Wimbledon2", TextRuntime.ConvertString(value), value))
+    HtmlTable<_>.Create(rowConverter, this, "Table14")
+
+    member Table35: HtmlProvider+Table35 with get
     let rowConverter = new Func<_,_>(fun (row:string[]) -> 
                                         let value = TextConversions.AsString(row.[0])
                                         TextRuntime.GetNonOptionalValue("Column1", TextRuntime.ConvertInteger("", value), value),
@@ -108,9 +98,27 @@ class HtmlProvider+TableContainer : FDR.TypedHtmlDocument
                                         TextRuntime.OptionToNullable(TextRuntime.ConvertInteger("", TextConversions.AsString(row.[7]))),
                                         TextRuntime.OptionToNullable(TextRuntime.ConvertInteger("", TextConversions.AsString(row.[8]))),
                                         TextRuntime.OptionToNullable(TextRuntime.ConvertInteger("", TextConversions.AsString(row.[9]))))
-    HtmlTable<_>.Create(rowConverter, this, "Table32")
+    HtmlTable<_>.Create(rowConverter, this, "Table35")
 
     member Table36: HtmlProvider+Table36 with get
+    let rowConverter = new Func<_,_>(fun (row:string[]) -> 
+                                        let value = TextConversions.AsString(row.[0])
+                                        TextRuntime.GetNonOptionalValue("Column1", TextRuntime.ConvertInteger("", value), value),
+                                        let value = TextConversions.AsString(row.[1])
+                                        TextRuntime.GetNonOptionalValue("Column2", TextRuntime.ConvertInteger("", value), value),
+                                        let value = TextConversions.AsString(row.[2])
+                                        TextRuntime.GetNonOptionalValue("Column3", TextRuntime.ConvertInteger("", value), value),
+                                        let value = TextConversions.AsString(row.[3])
+                                        TextRuntime.GetNonOptionalValue("Column4", TextRuntime.ConvertInteger("", value), value),
+                                        TextRuntime.OptionToNullable(TextRuntime.ConvertInteger("", TextConversions.AsString(row.[4]))),
+                                        TextRuntime.OptionToNullable(TextRuntime.ConvertInteger("", TextConversions.AsString(row.[5]))),
+                                        TextRuntime.OptionToNullable(TextRuntime.ConvertInteger("", TextConversions.AsString(row.[6]))),
+                                        TextRuntime.OptionToNullable(TextRuntime.ConvertInteger("", TextConversions.AsString(row.[7]))),
+                                        TextRuntime.OptionToNullable(TextRuntime.ConvertInteger("", TextConversions.AsString(row.[8]))),
+                                        TextRuntime.OptionToNullable(TextRuntime.ConvertInteger("", TextConversions.AsString(row.[9]))))
+    HtmlTable<_>.Create(rowConverter, this, "Table36")
+
+    member Table38: HtmlProvider+Table38 with get
     let rowConverter = new Func<_,_>(fun (row:string[]) -> 
                                         let value = TextConversions.AsString(row.[0])
                                         TextRuntime.GetNonOptionalValue("v t e Tennis", TextRuntime.ConvertString(value), value),
@@ -118,7 +126,7 @@ class HtmlProvider+TableContainer : FDR.TypedHtmlDocument
                                         TextRuntime.GetNonOptionalValue("v t e Tennis2", TextRuntime.ConvertString(value), value),
                                         let value = TextConversions.AsString(row.[2])
                                         TextRuntime.GetNonOptionalValue("v t e Tennis3", TextRuntime.ConvertFloat("", "", value), value))
-    HtmlTable<_>.Create(rowConverter, this, "Table36")
+    HtmlTable<_>.Create(rowConverter, this, "Table38")
 
     member Table44: HtmlProvider+Table44 with get
     let rowConverter = new Func<_,_>(fun (row:string[]) -> 
@@ -127,14 +135,6 @@ class HtmlProvider+TableContainer : FDR.TypedHtmlDocument
                                         let value = TextConversions.AsString(row.[1])
                                         TextRuntime.GetNonOptionalValue("v t e All England Lawn Tennis and Croquet Club2", TextRuntime.ConvertString(value), value))
     HtmlTable<_>.Create(rowConverter, this, "Table44")
-
-    member TheChampionshipsWimbledon: HtmlProvider+TheChampionshipsWimbledon with get
-    let rowConverter = new Func<_,_>(fun (row:string[]) -> 
-                                        let value = TextConversions.AsString(row.[0])
-                                        TextRuntime.GetNonOptionalValue("The Championships, Wimbledon", TextRuntime.ConvertString(value), value),
-                                        let value = TextConversions.AsString(row.[1])
-                                        TextRuntime.GetNonOptionalValue("The Championships, Wimbledon2", TextRuntime.ConvertString(value), value))
-    HtmlTable<_>.Create(rowConverter, this, "The Championships, Wimbledon")
 
     member TrophiesAndPrizeMoneyEdit: HtmlProvider+TrophiesAndPrizeMoneyEdit with get
     let rowConverter = new Func<_,_>(fun (row:string[]) -> 
@@ -149,21 +149,21 @@ class HtmlProvider+TableContainer : FDR.TypedHtmlDocument
 
 class HtmlProvider+CurrentChampionsEdit : FDR.HtmlTable<HtmlProvider+CurrentChampionsEdit+Row>
 
-class HtmlProvider+ExternalLinksEdit : FDR.HtmlTable<HtmlProvider+ExternalLinksEdit+Row>
-
 class HtmlProvider+RankingPointsEdit : FDR.HtmlTable<HtmlProvider+RankingPointsEdit+Row>
 
 class HtmlProvider+RecordsEdit : FDR.HtmlTable<HtmlProvider+RecordsEdit+Row>
 
 class HtmlProvider+SeeAlsoEdit : FDR.HtmlTable<HtmlProvider+SeeAlsoEdit+Row>
 
-class HtmlProvider+Table32 : FDR.HtmlTable<HtmlProvider+Table32+Row>
+class HtmlProvider+Table14 : FDR.HtmlTable<HtmlProvider+Table14+Row>
+
+class HtmlProvider+Table35 : FDR.HtmlTable<HtmlProvider+Table35+Row>
 
 class HtmlProvider+Table36 : FDR.HtmlTable<HtmlProvider+Table36+Row>
 
-class HtmlProvider+Table44 : FDR.HtmlTable<HtmlProvider+Table44+Row>
+class HtmlProvider+Table38 : FDR.HtmlTable<HtmlProvider+Table38+Row>
 
-class HtmlProvider+TheChampionshipsWimbledon : FDR.HtmlTable<HtmlProvider+TheChampionshipsWimbledon+Row>
+class HtmlProvider+Table44 : FDR.HtmlTable<HtmlProvider+Table44+Row>
 
 class HtmlProvider+TrophiesAndPrizeMoneyEdit : FDR.HtmlTable<HtmlProvider+TrophiesAndPrizeMoneyEdit+Row>
 
@@ -179,38 +179,6 @@ class HtmlProvider+CurrentChampionsEdit+Row : string * string * string * string
 
     member Score: string with get
     (let _,_,_,t4 = this in t4)
-
-
-class HtmlProvider+ExternalLinksEdit+Row : int * int * int * int * System.Nullable<int> * System.Nullable<int> * System.Nullable<int> * System.Nullable<int> * System.Nullable<int> * System.Nullable<int>
-    member 1968: System.Nullable<int> with get
-    (let _,_,_,_,_,_,_,_,t9,_ = this in t9)
-
-    member 1969: System.Nullable<int> with get
-    (let _,_,_,_,_,_,_,_,_,t10 = this in t10)
-
-    member Column1: int with get
-    (let t1,_,_,_,_,_,_,_,_,_ = this in t1)
-
-    member Column2: int with get
-    (let _,t2,_,_,_,_,_,_,_,_ = this in t2)
-
-    member Column3: int with get
-    (let _,_,t3,_,_,_,_,_,_,_ = this in t3)
-
-    member Column4: int with get
-    (let _,_,_,t4,_,_,_,_,_,_ = this in t4)
-
-    member Column5: System.Nullable<int> with get
-    (let _,_,_,_,t5,_,_,_,_,_ = this in t5)
-
-    member Column6: System.Nullable<int> with get
-    (let _,_,_,_,_,t6,_,_,_,_ = this in t6)
-
-    member Column7: System.Nullable<int> with get
-    (let _,_,_,_,_,_,t7,_,_,_ = this in t7)
-
-    member Column8: System.Nullable<int> with get
-    (let _,_,_,_,_,_,_,t8,_,_ = this in t8)
 
 
 class HtmlProvider+RankingPointsEdit+Row : string * int * int
@@ -249,7 +217,15 @@ class HtmlProvider+SeeAlsoEdit+Row : float * string
     (let _,t2 = this in t2)
 
 
-class HtmlProvider+Table32+Row : int * int * int * int * System.Nullable<int> * System.Nullable<int> * System.Nullable<int> * System.Nullable<int> * System.Nullable<int> * System.Nullable<int>
+class HtmlProvider+Table14+Row : string * string
+    member ``The Championships, Wimbledon``: string with get
+    (let t1,_ = this in t1)
+
+    member ``The Championships, Wimbledon2``: string with get
+    (let _,t2 = this in t2)
+
+
+class HtmlProvider+Table35+Row : int * int * int * int * System.Nullable<int> * System.Nullable<int> * System.Nullable<int> * System.Nullable<int> * System.Nullable<int> * System.Nullable<int>
     member 1968: System.Nullable<int> with get
     (let _,_,_,_,_,_,_,_,t9,_ = this in t9)
 
@@ -281,7 +257,39 @@ class HtmlProvider+Table32+Row : int * int * int * int * System.Nullable<int> * 
     (let _,_,_,_,_,_,_,t8,_,_ = this in t8)
 
 
-class HtmlProvider+Table36+Row : string * string * float
+class HtmlProvider+Table36+Row : int * int * int * int * System.Nullable<int> * System.Nullable<int> * System.Nullable<int> * System.Nullable<int> * System.Nullable<int> * System.Nullable<int>
+    member 1968: System.Nullable<int> with get
+    (let _,_,_,_,_,_,_,_,t9,_ = this in t9)
+
+    member 1969: System.Nullable<int> with get
+    (let _,_,_,_,_,_,_,_,_,t10 = this in t10)
+
+    member Column1: int with get
+    (let t1,_,_,_,_,_,_,_,_,_ = this in t1)
+
+    member Column2: int with get
+    (let _,t2,_,_,_,_,_,_,_,_ = this in t2)
+
+    member Column3: int with get
+    (let _,_,t3,_,_,_,_,_,_,_ = this in t3)
+
+    member Column4: int with get
+    (let _,_,_,t4,_,_,_,_,_,_ = this in t4)
+
+    member Column5: System.Nullable<int> with get
+    (let _,_,_,_,t5,_,_,_,_,_ = this in t5)
+
+    member Column6: System.Nullable<int> with get
+    (let _,_,_,_,_,t6,_,_,_,_ = this in t6)
+
+    member Column7: System.Nullable<int> with get
+    (let _,_,_,_,_,_,t7,_,_,_ = this in t7)
+
+    member Column8: System.Nullable<int> with get
+    (let _,_,_,_,_,_,_,t8,_,_ = this in t8)
+
+
+class HtmlProvider+Table38+Row : string * string * float
     member ``v t e Tennis``: string with get
     (let t1,_,_ = this in t1)
 
@@ -297,14 +305,6 @@ class HtmlProvider+Table44+Row : string * string
     (let t1,_ = this in t1)
 
     member ``v t e All England Lawn Tennis and Croquet Club2``: string with get
-    (let _,t2 = this in t2)
-
-
-class HtmlProvider+TheChampionshipsWimbledon+Row : string * string
-    member ``The Championships, Wimbledon``: string with get
-    (let t1,_ = this in t1)
-
-    member ``The Championships, Wimbledon2``: string with get
     (let _,t2 = this in t2)
 
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/WorldBank,World Development Indicators;Global Financial Development,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/WorldBank,World Development Indicators;Global Financial Development,True.expected
@@ -32,7 +32,7 @@ class WorldBankDataProvider+ServiceTypes+Countries : FDR.WorldBank.CountryCollec
     member ``American Samoa``: WorldBankDataProvider+ServiceTypes+Country with get
     (this :> ICountryCollection).GetCountry("ASM", "American Samoa")
 
-    member Andean Region: WorldBankDataProvider+ServiceTypes+Country with get
+    member ``Andean Region``: WorldBankDataProvider+ServiceTypes+Country with get
     (this :> ICountryCollection).GetCountry("ANR", "Andean Region")
 
     member Andorra: WorldBankDataProvider+ServiceTypes+Country with get
@@ -389,7 +389,10 @@ class WorldBankDataProvider+ServiceTypes+Countries : FDR.WorldBank.CountryCollec
     member ``Latin America & Caribbean (developing only)``: WorldBankDataProvider+ServiceTypes+Country with get
     (this :> ICountryCollection).GetCountry("LAC", "Latin America & Caribbean (developing only)")
 
-    member Latin America and the Caribbean (IFC classification): WorldBankDataProvider+ServiceTypes+Country with get
+    member ``Latin America and the Caribbean``: WorldBankDataProvider+ServiceTypes+Country with get
+    (this :> ICountryCollection).GetCountry("LCR", "Latin America and the Caribbean")
+
+    member ``Latin America and the Caribbean (IFC classification)``: WorldBankDataProvider+ServiceTypes+Country with get
     (this :> ICountryCollection).GetCountry("CLA", "Latin America and the Caribbean (IFC classification)")
 
     member Latvia: WorldBankDataProvider+ServiceTypes+Country with get
@@ -464,7 +467,10 @@ class WorldBankDataProvider+ServiceTypes+Countries : FDR.WorldBank.CountryCollec
     member Mexico: WorldBankDataProvider+ServiceTypes+Country with get
     (this :> ICountryCollection).GetCountry("MEX", "Mexico")
 
-    member Micronesia, Fed. Sts.: WorldBankDataProvider+ServiceTypes+Country with get
+    member ``Mexico and Central America``: WorldBankDataProvider+ServiceTypes+Country with get
+    (this :> ICountryCollection).GetCountry("MCA", "Mexico and Central America")
+
+    member ``Micronesia, Fed. Sts.``: WorldBankDataProvider+ServiceTypes+Country with get
     (this :> ICountryCollection).GetCountry("FSM", "Micronesia, Fed. Sts.")
 
     member ``Middle East & North Africa (all income levels)``: WorldBankDataProvider+ServiceTypes+Country with get
@@ -650,7 +656,7 @@ class WorldBankDataProvider+ServiceTypes+Countries : FDR.WorldBank.CountryCollec
     member ``South Sudan``: WorldBankDataProvider+ServiceTypes+Country with get
     (this :> ICountryCollection).GetCountry("SSD", "South Sudan")
 
-    member Southern Cone Extended: WorldBankDataProvider+ServiceTypes+Country with get
+    member ``Southern Cone Extended``: WorldBankDataProvider+ServiceTypes+Country with get
     (this :> ICountryCollection).GetCountry("SCE", "Southern Cone Extended")
 
     member Spain: WorldBankDataProvider+ServiceTypes+Country with get
@@ -796,7 +802,10 @@ class WorldBankDataProvider+ServiceTypes+Regions : FDR.WorldBank.RegionCollectio
     member Africa: WorldBankDataProvider+ServiceTypes+Region with get
     (this :> IRegionCollection).GetRegion("AFR")
 
-    member Arab World: WorldBankDataProvider+ServiceTypes+Region with get
+    member ``Andean Region``: WorldBankDataProvider+ServiceTypes+Region with get
+    (this :> IRegionCollection).GetRegion("ANR")
+
+    member ``Arab World``: WorldBankDataProvider+ServiceTypes+Region with get
     (this :> IRegionCollection).GetRegion("ARB")
 
     member ``Caribbean small states``: WorldBankDataProvider+ServiceTypes+Region with get
@@ -832,13 +841,19 @@ class WorldBankDataProvider+ServiceTypes+Regions : FDR.WorldBank.RegionCollectio
     member ``Latin America & Caribbean (developing only)``: WorldBankDataProvider+ServiceTypes+Region with get
     (this :> IRegionCollection).GetRegion("LAC")
 
-    member Latin America and the Caribbean (IFC classification): WorldBankDataProvider+ServiceTypes+Region with get
+    member ``Latin America and the Caribbean``: WorldBankDataProvider+ServiceTypes+Region with get
+    (this :> IRegionCollection).GetRegion("LCR")
+
+    member ``Latin America and the Caribbean (IFC classification)``: WorldBankDataProvider+ServiceTypes+Region with get
     (this :> IRegionCollection).GetRegion("CLA")
 
     member ``Least developed countries: UN classification``: WorldBankDataProvider+ServiceTypes+Region with get
     (this :> IRegionCollection).GetRegion("LDC")
 
-    member Middle East & North Africa (all income levels): WorldBankDataProvider+ServiceTypes+Region with get
+    member ``Mexico and Central America``: WorldBankDataProvider+ServiceTypes+Region with get
+    (this :> IRegionCollection).GetRegion("MCA")
+
+    member ``Middle East & North Africa (all income levels)``: WorldBankDataProvider+ServiceTypes+Region with get
     (this :> IRegionCollection).GetRegion("MEA")
 
     member ``Middle East & North Africa (developing only)``: WorldBankDataProvider+ServiceTypes+Region with get
@@ -871,7 +886,10 @@ class WorldBankDataProvider+ServiceTypes+Regions : FDR.WorldBank.RegionCollectio
     member ``South Asia (IFC classification)``: WorldBankDataProvider+ServiceTypes+Region with get
     (this :> IRegionCollection).GetRegion("CSA")
 
-    member Sub-Saharan Africa (IFC classification): WorldBankDataProvider+ServiceTypes+Region with get
+    member ``Southern Cone Extended``: WorldBankDataProvider+ServiceTypes+Region with get
+    (this :> IRegionCollection).GetRegion("SCE")
+
+    member ``Sub-Saharan Africa (IFC classification)``: WorldBankDataProvider+ServiceTypes+Region with get
     (this :> IRegionCollection).GetRegion("CAA")
 
     member ``Sub-Saharan Africa (all income levels)``: WorldBankDataProvider+ServiceTypes+Region with get
@@ -1133,10 +1151,19 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Age dependency ratio (% of working-age population)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.POP.DPND")
 
-    member Age dependency ratio, old (% of working-age population): FDR.WorldBank.Indicator async with get
+    member ``Age dependency ratio (% of working-age population)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SP.POP.DPND")
+
+    member ``Age dependency ratio, old (% of working-age population)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.POP.DPND.OL")
 
-    member Age dependency ratio, young (% of working-age population): FDR.WorldBank.Indicator async with get
+    member ``Age dependency ratio, old (% of working-age population)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SP.POP.DPND.OL")
+
+    member ``Age dependency ratio, young (% of working-age population)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SP.POP.DPND.YG")
+
+    member ``Age dependency ratio, young (% of working-age population)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.POP.DPND.YG")
 
     member ``Agricultural irrigated land (% of total agricultural land)``: FDR.WorldBank.Indicator async with get
@@ -1169,7 +1196,13 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Agricultural raw materials exports (% of merchandise exports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.AGRI.ZS.UN")
 
-    member Agricultural raw materials imports (% of merchandise imports): FDR.WorldBank.Indicator async with get
+    member ``Agricultural raw materials exports (% of merchandise exports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.AGRI.ZS.UN")
+
+    member ``Agricultural raw materials imports (% of merchandise imports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.VAL.AGRI.ZS.UN")
+
+    member ``Agricultural raw materials imports (% of merchandise imports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.VAL.AGRI.ZS.UN")
 
     member ``Agriculture value added per worker (constant 2005 US$)``: FDR.WorldBank.Indicator async with get
@@ -1364,10 +1397,19 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Binding coverage, all products (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.TAX.MRCH.BC.ZS")
 
-    member Binding coverage, manufactured products (%): FDR.WorldBank.Indicator async with get
+    member ``Binding coverage, all products (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.TAX.MRCH.BC.ZS")
+
+    member ``Binding coverage, manufactured products (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.TAX.MANF.BC.ZS")
 
-    member Binding coverage, primary products (%): FDR.WorldBank.Indicator async with get
+    member ``Binding coverage, manufactured products (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.TAX.MANF.BC.ZS")
+
+    member ``Binding coverage, primary products (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.TAX.TCOM.BC.ZS")
+
+    member ``Binding coverage, primary products (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.TAX.TCOM.BC.ZS")
 
     member ``Bird species, threatened``: FDR.WorldBank.Indicator async with get
@@ -1388,13 +1430,22 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Bound rate, simple mean, all products (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.TAX.MRCH.BR.ZS")
 
-    member Bound rate, simple mean, manufactured products (%): FDR.WorldBank.Indicator async with get
+    member ``Bound rate, simple mean, all products (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.TAX.MRCH.BR.ZS")
+
+    member ``Bound rate, simple mean, manufactured products (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.TAX.MANF.BR.ZS")
+
+    member ``Bound rate, simple mean, manufactured products (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.TAX.MANF.BR.ZS")
 
     member ``Bound rate, simple mean, primary products (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.TAX.TCOM.BR.ZS")
 
-    member Broad money (% of GDP): FDR.WorldBank.Indicator async with get
+    member ``Bound rate, simple mean, primary products (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.TAX.TCOM.BR.ZS")
+
+    member ``Broad money (% of GDP)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("FM.LBL.BMNY.GD.ZS")
 
     member ``Broad money (current LCU)``: FDR.WorldBank.Indicator async with get
@@ -1700,7 +1751,13 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Commercial service exports (current US$)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.SERV.CD.WT")
 
-    member Commercial service imports (current US$): FDR.WorldBank.Indicator async with get
+    member ``Commercial service exports (current US$)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.SERV.CD.WT")
+
+    member ``Commercial service imports (current US$)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.VAL.SERV.CD.WT")
+
+    member ``Commercial service imports (current US$)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.VAL.SERV.CD.WT")
 
     member ``Commitments, IBRD (COM, current US$)``: FDR.WorldBank.Indicator async with get
@@ -1736,13 +1793,22 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Completeness of birth registration (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.REG.BRTH.ZS")
 
-    member Completeness of birth registration, rural (%): FDR.WorldBank.Indicator async with get
+    member ``Completeness of birth registration (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SP.REG.BRTH.ZS")
+
+    member ``Completeness of birth registration, rural (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SP.REG.BRTH.RU.ZS")
+
+    member ``Completeness of birth registration, rural (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.REG.BRTH.RU.ZS")
 
     member ``Completeness of birth registration, urban (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.REG.BRTH.UR.ZS")
 
-    member Completeness of infant death reporting (% of reported infant deaths to estimated infant deaths): FDR.WorldBank.Indicator async with get
+    member ``Completeness of birth registration, urban (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SP.REG.BRTH.UR.ZS")
+
+    member ``Completeness of infant death reporting (% of reported infant deaths to estimated infant deaths)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.DTH.INFR.ZS")
 
     member ``Completeness of total death reporting (% of reported total deaths to estimated total deaths)``: FDR.WorldBank.Indicator async with get
@@ -1751,7 +1817,13 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Computer, communications and other services (% of commercial service exports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.OTHR.ZS.WT")
 
-    member Computer, communications and other services (% of commercial service imports): FDR.WorldBank.Indicator async with get
+    member ``Computer, communications and other services (% of commercial service exports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.OTHR.ZS.WT")
+
+    member ``Computer, communications and other services (% of commercial service imports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.VAL.OTHR.ZS.WT")
+
+    member ``Computer, communications and other services (% of commercial service imports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.VAL.OTHR.ZS.WT")
 
     member ``Concessional debt (% of total external debt)``: FDR.WorldBank.Indicator async with get
@@ -2144,7 +2216,13 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Export value index (2000 = 100)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.XD.WD")
 
-    member Export volume index (2000 = 100): FDR.WorldBank.Indicator async with get
+    member ``Export value index (2000 = 100)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.XD.WD")
+
+    member ``Export volume index (2000 = 100)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.QTY.MRCH.XD.WD")
+
+    member ``Export volume index (2000 = 100)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.QTY.MRCH.XD.WD")
 
     member ``Exports as a capacity to import (constant LCU)``: FDR.WorldBank.Indicator async with get
@@ -2336,7 +2414,13 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Food exports (% of merchandise exports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.FOOD.ZS.UN")
 
-    member Food imports (% of merchandise imports): FDR.WorldBank.Indicator async with get
+    member ``Food exports (% of merchandise exports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.FOOD.ZS.UN")
+
+    member ``Food imports (% of merchandise imports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.VAL.FOOD.ZS.UN")
+
+    member ``Food imports (% of merchandise imports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.VAL.FOOD.ZS.UN")
 
     member ``Food production index (2004-2006 = 100)``: FDR.WorldBank.Indicator async with get
@@ -2378,7 +2462,13 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Fuel exports (% of merchandise exports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.FUEL.ZS.UN")
 
-    member Fuel imports (% of merchandise imports): FDR.WorldBank.Indicator async with get
+    member ``Fuel exports (% of merchandise exports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.FUEL.ZS.UN")
+
+    member ``Fuel imports (% of merchandise imports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.VAL.FUEL.ZS.UN")
+
+    member ``Fuel imports (% of merchandise imports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.VAL.FUEL.ZS.UN")
 
     member ``GDP (constant 2005 US$)``: FDR.WorldBank.Indicator async with get
@@ -2684,7 +2774,13 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``High-technology exports (% of manufactured exports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.TECH.MF.ZS")
 
-    member High-technology exports (current US$): FDR.WorldBank.Indicator async with get
+    member ``High-technology exports (% of manufactured exports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.TECH.MF.ZS")
+
+    member ``High-technology exports (current US$)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.TECH.CD")
+
+    member ``High-technology exports (current US$)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.TECH.CD")
 
     member ``Hospital beds (per 1,000 people)``: FDR.WorldBank.Indicator async with get
@@ -2741,7 +2837,13 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``ICT goods exports (% of total goods exports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.ICTG.ZS.UN")
 
-    member ICT goods imports (% total goods imports): FDR.WorldBank.Indicator async with get
+    member ``ICT goods exports (% of total goods exports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.ICTG.ZS.UN")
+
+    member ``ICT goods imports (% total goods imports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.VAL.ICTG.ZS.UN")
+
+    member ``ICT goods imports (% total goods imports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.VAL.ICTG.ZS.UN")
 
     member ``ICT service exports (% of service exports, BoP)``: FDR.WorldBank.Indicator async with get
@@ -2780,7 +2882,13 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Import value index (2000 = 100)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.XD.WD")
 
-    member Import volume index (2000 = 100): FDR.WorldBank.Indicator async with get
+    member ``Import value index (2000 = 100)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.XD.WD")
+
+    member ``Import volume index (2000 = 100)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.QTY.MRCH.XD.WD")
+
+    member ``Import volume index (2000 = 100)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.QTY.MRCH.XD.WD")
 
     member ``Imports of goods and services (% of GDP)``: FDR.WorldBank.Indicator async with get
@@ -2882,7 +2990,13 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Insurance and financial services (% of commercial service exports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.INSF.ZS.WT")
 
-    member Insurance and financial services (% of commercial service imports): FDR.WorldBank.Indicator async with get
+    member ``Insurance and financial services (% of commercial service exports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.INSF.ZS.WT")
+
+    member ``Insurance and financial services (% of commercial service imports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.VAL.INSF.ZS.WT")
+
+    member ``Insurance and financial services (% of commercial service imports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.VAL.INSF.ZS.WT")
 
     member ``Insurance and financial services (% of service exports, BoP)``: FDR.WorldBank.Indicator async with get
@@ -2969,31 +3083,61 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``International tourism, expenditures (% of total imports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("ST.INT.XPND.MP.ZS")
 
-    member International tourism, expenditures (current US$): FDR.WorldBank.Indicator async with get
+    member ``International tourism, expenditures (% of total imports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("ST.INT.XPND.MP.ZS")
+
+    member ``International tourism, expenditures (current US$)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("ST.INT.XPND.CD")
+
+    member ``International tourism, expenditures (current US$)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("ST.INT.XPND.CD")
 
     member ``International tourism, expenditures for passenger transport items (current US$)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("ST.INT.TRNX.CD")
 
-    member International tourism, expenditures for travel items (current US$): FDR.WorldBank.Indicator async with get
+    member ``International tourism, expenditures for passenger transport items (current US$)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("ST.INT.TRNX.CD")
+
+    member ``International tourism, expenditures for travel items (current US$)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("ST.INT.TVLX.CD")
 
-    member International tourism, number of arrivals: FDR.WorldBank.Indicator async with get
+    member ``International tourism, expenditures for travel items (current US$)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("ST.INT.TVLX.CD")
+
+    member ``International tourism, number of arrivals``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("ST.INT.ARVL")
+
+    member ``International tourism, number of arrivals``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("ST.INT.ARVL")
 
     member ``International tourism, number of departures``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("ST.INT.DPRT")
 
-    member International tourism, receipts (% of total exports): FDR.WorldBank.Indicator async with get
+    member ``International tourism, number of departures``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("ST.INT.DPRT")
+
+    member ``International tourism, receipts (% of total exports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("ST.INT.RCPT.XP.ZS")
+
+    member ``International tourism, receipts (% of total exports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("ST.INT.RCPT.XP.ZS")
 
     member ``International tourism, receipts (current US$)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("ST.INT.RCPT.CD")
 
-    member International tourism, receipts for passenger transport items (current US$): FDR.WorldBank.Indicator async with get
+    member ``International tourism, receipts (current US$)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("ST.INT.RCPT.CD")
+
+    member ``International tourism, receipts for passenger transport items (current US$)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("ST.INT.TRNR.CD")
 
-    member International tourism, receipts for travel items (current US$): FDR.WorldBank.Indicator async with get
+    member ``International tourism, receipts for passenger transport items (current US$)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("ST.INT.TRNR.CD")
+
+    member ``International tourism, receipts for travel items (current US$)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("ST.INT.TVLR.CD")
+
+    member ``International tourism, receipts for travel items (current US$)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("ST.INT.TVLR.CD")
 
     member ``Internationally-recognized quality certification (% of firms)``: FDR.WorldBank.Indicator async with get
@@ -3278,7 +3422,13 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Manufactures exports (% of merchandise exports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.MANF.ZS.UN")
 
-    member Manufactures imports (% of merchandise imports): FDR.WorldBank.Indicator async with get
+    member ``Manufactures exports (% of merchandise exports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.MANF.ZS.UN")
+
+    member ``Manufactures imports (% of merchandise imports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.VAL.MANF.ZS.UN")
+
+    member ``Manufactures imports (% of merchandise imports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.VAL.MANF.ZS.UN")
 
     member ``Manufacturing, value added (% of GDP)``: FDR.WorldBank.Indicator async with get
@@ -3320,82 +3470,163 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Merchandise exports (current US$)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.CD.WT")
 
-    member Merchandise exports by the reporting economy (current US$): FDR.WorldBank.Indicator async with get
+    member ``Merchandise exports (current US$)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.CD.WT")
+
+    member ``Merchandise exports by the reporting economy (current US$)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.WL.CD")
 
-    member Merchandise exports by the reporting economy, residual (% of total merchandise exports): FDR.WorldBank.Indicator async with get
+    member ``Merchandise exports by the reporting economy (current US$)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.WL.CD")
+
+    member ``Merchandise exports by the reporting economy, residual (% of total merchandise exports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.RS.ZS")
+
+    member ``Merchandise exports by the reporting economy, residual (% of total merchandise exports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.RS.ZS")
 
     member ``Merchandise exports to developing economies in East Asia & Pacific (% of total merchandise exports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.R1.ZS")
 
-    member Merchandise exports to developing economies in Europe & Central Asia (% of total merchandise exports): FDR.WorldBank.Indicator async with get
+    member ``Merchandise exports to developing economies in East Asia & Pacific (% of total merchandise exports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.R1.ZS")
+
+    member ``Merchandise exports to developing economies in Europe & Central Asia (% of total merchandise exports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.R2.ZS")
+
+    member ``Merchandise exports to developing economies in Europe & Central Asia (% of total merchandise exports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.R2.ZS")
 
     member ``Merchandise exports to developing economies in Latin America & the Caribbean (% of total merchandise exports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.R3.ZS")
 
-    member Merchandise exports to developing economies in Middle East & North Africa (% of total merchandise exports): FDR.WorldBank.Indicator async with get
+    member ``Merchandise exports to developing economies in Latin America & the Caribbean (% of total merchandise exports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.R3.ZS")
+
+    member ``Merchandise exports to developing economies in Middle East & North Africa (% of total merchandise exports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.R4.ZS")
+
+    member ``Merchandise exports to developing economies in Middle East & North Africa (% of total merchandise exports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.R4.ZS")
 
     member ``Merchandise exports to developing economies in South Asia (% of total merchandise exports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.R5.ZS")
 
-    member Merchandise exports to developing economies in Sub-Saharan Africa (% of total merchandise exports): FDR.WorldBank.Indicator async with get
+    member ``Merchandise exports to developing economies in South Asia (% of total merchandise exports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.R5.ZS")
+
+    member ``Merchandise exports to developing economies in Sub-Saharan Africa (% of total merchandise exports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.R6.ZS")
 
-    member Merchandise exports to developing economies outside region (% of total merchandise exports): FDR.WorldBank.Indicator async with get
+    member ``Merchandise exports to developing economies in Sub-Saharan Africa (% of total merchandise exports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.R6.ZS")
+
+    member ``Merchandise exports to developing economies outside region (% of total merchandise exports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.OR.ZS")
+
+    member ``Merchandise exports to developing economies outside region (% of total merchandise exports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.OR.ZS")
 
     member ``Merchandise exports to developing economies within region (% of total merchandise exports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.WR.ZS")
 
-    member Merchandise exports to economies in the Arab World (% of total merchandise exports): FDR.WorldBank.Indicator async with get
+    member ``Merchandise exports to developing economies within region (% of total merchandise exports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.WR.ZS")
+
+    member ``Merchandise exports to economies in the Arab World (% of total merchandise exports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.AL.ZS")
+
+    member ``Merchandise exports to economies in the Arab World (% of total merchandise exports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.AL.ZS")
 
     member ``Merchandise exports to high-income economies (% of total merchandise exports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.HI.ZS")
 
-    member Merchandise imports (current US$): FDR.WorldBank.Indicator async with get
+    member ``Merchandise exports to high-income economies (% of total merchandise exports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.MRCH.HI.ZS")
+
+    member ``Merchandise imports (current US$)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.CD.WT")
+
+    member ``Merchandise imports (current US$)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.CD.WT")
 
     member ``Merchandise imports by the reporting economy (current US$)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.WL.CD")
 
-    member Merchandise imports by the reporting economy, residual (% of total merchandise imports): FDR.WorldBank.Indicator async with get
+    member ``Merchandise imports by the reporting economy (current US$)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.WL.CD")
+
+    member ``Merchandise imports by the reporting economy, residual (% of total merchandise imports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.RS.ZS")
 
-    member Merchandise imports from developing economies in East Asia & Pacific (% of total merchandise imports): FDR.WorldBank.Indicator async with get
+    member ``Merchandise imports by the reporting economy, residual (% of total merchandise imports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.RS.ZS")
+
+    member ``Merchandise imports from developing economies in East Asia & Pacific (% of total merchandise imports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.R1.ZS")
+
+    member ``Merchandise imports from developing economies in East Asia & Pacific (% of total merchandise imports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.R1.ZS")
 
     member ``Merchandise imports from developing economies in Europe & Central Asia (% of total merchandise imports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.R2.ZS")
 
-    member Merchandise imports from developing economies in Latin America & the Caribbean (% of total merchandise imports): FDR.WorldBank.Indicator async with get
+    member ``Merchandise imports from developing economies in Europe & Central Asia (% of total merchandise imports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.R2.ZS")
+
+    member ``Merchandise imports from developing economies in Latin America & the Caribbean (% of total merchandise imports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.R3.ZS")
+
+    member ``Merchandise imports from developing economies in Latin America & the Caribbean (% of total merchandise imports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.R3.ZS")
 
     member ``Merchandise imports from developing economies in Middle East & North Africa (% of total merchandise imports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.R4.ZS")
 
-    member Merchandise imports from developing economies in South Asia (% of total merchandise imports): FDR.WorldBank.Indicator async with get
+    member ``Merchandise imports from developing economies in Middle East & North Africa (% of total merchandise imports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.R4.ZS")
+
+    member ``Merchandise imports from developing economies in South Asia (% of total merchandise imports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.R5.ZS")
 
-    member Merchandise imports from developing economies in Sub-Saharan Africa (% of total merchandise imports): FDR.WorldBank.Indicator async with get
+    member ``Merchandise imports from developing economies in South Asia (% of total merchandise imports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.R5.ZS")
+
+    member ``Merchandise imports from developing economies in Sub-Saharan Africa (% of total merchandise imports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.R6.ZS")
+
+    member ``Merchandise imports from developing economies in Sub-Saharan Africa (% of total merchandise imports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.R6.ZS")
 
     member ``Merchandise imports from developing economies outside region (% of total merchandise imports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.OR.ZS")
 
-    member Merchandise imports from developing economies within region (% of total merchandise imports): FDR.WorldBank.Indicator async with get
+    member ``Merchandise imports from developing economies outside region (% of total merchandise imports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.OR.ZS")
+
+    member ``Merchandise imports from developing economies within region (% of total merchandise imports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.WR.ZS")
+
+    member ``Merchandise imports from developing economies within region (% of total merchandise imports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.WR.ZS")
 
     member ``Merchandise imports from economies in the Arab World (% of total merchandise imports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.AL.ZS")
 
-    member Merchandise imports from high-income economies (% of total merchandise imports): FDR.WorldBank.Indicator async with get
+    member ``Merchandise imports from economies in the Arab World (% of total merchandise imports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.AL.ZS")
+
+    member ``Merchandise imports from high-income economies (% of total merchandise imports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.HI.ZS")
 
-    member Merchandise trade (% of GDP): FDR.WorldBank.Indicator async with get
+    member ``Merchandise imports from high-income economies (% of total merchandise imports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.VAL.MRCH.HI.ZS")
+
+    member ``Merchandise trade (% of GDP)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TG.VAL.TOTL.GD.ZS")
+
+    member ``Merchandise trade (% of GDP)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TG.VAL.TOTL.GD.ZS")
 
     member ``Methane emissions (kt of CO2 equivalent)``: FDR.WorldBank.Indicator async with get
@@ -3506,7 +3737,10 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Net barter terms of trade index (2000 = 100)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TT.PRI.MRCH.XD.WD")
 
-    member Net bilateral aid flows from DAC donors, Australia (current US$): FDR.WorldBank.Indicator async with get
+    member ``Net barter terms of trade index (2000 = 100)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TT.PRI.MRCH.XD.WD")
+
+    member ``Net bilateral aid flows from DAC donors, Australia (current US$)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("DC.DAC.AUSL.CD")
 
     member ``Net bilateral aid flows from DAC donors, Austria (current US$)``: FDR.WorldBank.Indicator async with get
@@ -3836,7 +4070,13 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Ores and metals exports (% of merchandise exports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.MMTL.ZS.UN")
 
-    member Ores and metals imports (% of merchandise imports): FDR.WorldBank.Indicator async with get
+    member ``Ores and metals exports (% of merchandise exports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.MMTL.ZS.UN")
+
+    member ``Ores and metals imports (% of merchandise imports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.VAL.MMTL.ZS.UN")
+
+    member ``Ores and metals imports (% of merchandise imports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.VAL.MMTL.ZS.UN")
 
     member ``Organic water pollutant (BOD) emissions (kg per day per worker)``: FDR.WorldBank.Indicator async with get
@@ -4226,7 +4466,10 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Population (Total)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.POP.TOTL")
 
-    member Population ages 0-14 (% of total): FDR.WorldBank.Indicator async with get
+    member ``Population (Total)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SP.POP.TOTL")
+
+    member ``Population ages 0-14 (% of total)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.POP.0014.TO.ZS")
 
     member ``Population ages 15-64 (% of total)``: FDR.WorldBank.Indicator async with get
@@ -4241,7 +4484,10 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Population growth (annual %)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.POP.GROW")
 
-    member Population in largest city: FDR.WorldBank.Indicator async with get
+    member ``Population growth (annual %)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SP.POP.GROW")
+
+    member ``Population in largest city``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("EN.URB.LCTY")
 
     member ``Population in the largest city (% of urban population)``: FDR.WorldBank.Indicator async with get
@@ -4259,7 +4505,10 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Population, female (% of total)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.POP.TOTL.FE.ZS")
 
-    member Portfolio Investment, net (BoP, current US$): FDR.WorldBank.Indicator async with get
+    member ``Population, female (% of total)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SP.POP.TOTL.FE.ZS")
+
+    member ``Portfolio Investment, net (BoP, current US$)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("BN.KLT.PTXL.CD")
 
     member ``Portfolio equity, net inflows (BoP, current US$)``: FDR.WorldBank.Indicator async with get
@@ -4577,7 +4826,10 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Researchers in R&D (per million people)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.POP.SCIE.RD.P6")
 
-    member Reserves and related items (BoP, current US$): FDR.WorldBank.Indicator async with get
+    member ``Researchers in R&D (per million people)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SP.POP.SCIE.RD.P6")
+
+    member ``Reserves and related items (BoP, current US$)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("BN.RES.INCL.CD")
 
     member ``Residual, debt stock-flow reconciliation (current US$)``: FDR.WorldBank.Indicator async with get
@@ -4631,13 +4883,22 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Rural population``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.RUR.TOTL")
 
-    member Rural population (% of total population): FDR.WorldBank.Indicator async with get
+    member ``Rural population``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SP.RUR.TOTL")
+
+    member ``Rural population (% of total population)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SP.RUR.TOTL.ZS")
+
+    member ``Rural population (% of total population)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.RUR.TOTL.ZS")
 
     member ``Rural population growth (annual %)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.RUR.TOTL.ZG")
 
-    member S&P Global Equity Indices (annual % change): FDR.WorldBank.Indicator async with get
+    member ``Rural population growth (annual %)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SP.RUR.TOTL.ZG")
+
+    member ``S&P Global Equity Indices (annual % change)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("CM.MKT.INDX.ZG")
 
     member ``SF6 gas emissions (thousand metric tons of CO2 equivalent)``: FDR.WorldBank.Indicator async with get
@@ -4796,19 +5057,37 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Share of tariff lines with international peaks, all products (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.TAX.MRCH.IP.ZS")
 
-    member Share of tariff lines with international peaks, manufactured products (%): FDR.WorldBank.Indicator async with get
+    member ``Share of tariff lines with international peaks, all products (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.TAX.MRCH.IP.ZS")
+
+    member ``Share of tariff lines with international peaks, manufactured products (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.TAX.MANF.IP.ZS")
+
+    member ``Share of tariff lines with international peaks, manufactured products (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.TAX.MANF.IP.ZS")
 
     member ``Share of tariff lines with international peaks, primary products (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.TAX.TCOM.IP.ZS")
 
-    member Share of tariff lines with specific rates, all products (%): FDR.WorldBank.Indicator async with get
+    member ``Share of tariff lines with international peaks, primary products (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.TAX.TCOM.IP.ZS")
+
+    member ``Share of tariff lines with specific rates, all products (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.TAX.MRCH.SR.ZS")
+
+    member ``Share of tariff lines with specific rates, all products (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.TAX.MRCH.SR.ZS")
 
     member ``Share of tariff lines with specific rates, manufactured products (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.TAX.MANF.SR.ZS")
 
-    member Share of tariff lines with specific rates, primary products (%): FDR.WorldBank.Indicator async with get
+    member ``Share of tariff lines with specific rates, manufactured products (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.TAX.MANF.SR.ZS")
+
+    member ``Share of tariff lines with specific rates, primary products (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.TAX.TCOM.SR.ZS")
+
+    member ``Share of tariff lines with specific rates, primary products (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.TAX.TCOM.SR.ZS")
 
     member ``Share of women employed in the nonagricultural sector (% of total nonagricultural employment)``: FDR.WorldBank.Indicator async with get
@@ -4886,37 +5165,73 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Tariff rate, applied, simple mean, all products (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.TAX.MRCH.SM.AR.ZS")
 
-    member Tariff rate, applied, simple mean, manufactured products (%): FDR.WorldBank.Indicator async with get
+    member ``Tariff rate, applied, simple mean, all products (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.TAX.MRCH.SM.AR.ZS")
+
+    member ``Tariff rate, applied, simple mean, manufactured products (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.TAX.MANF.SM.AR.ZS")
 
-    member Tariff rate, applied, simple mean, primary products (%): FDR.WorldBank.Indicator async with get
+    member ``Tariff rate, applied, simple mean, manufactured products (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.TAX.MANF.SM.AR.ZS")
+
+    member ``Tariff rate, applied, simple mean, primary products (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.TAX.TCOM.SM.AR.ZS")
+
+    member ``Tariff rate, applied, simple mean, primary products (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.TAX.TCOM.SM.AR.ZS")
 
     member ``Tariff rate, applied, weighted mean, all products (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.TAX.MRCH.WM.AR.ZS")
 
-    member Tariff rate, applied, weighted mean, manufactured products (%): FDR.WorldBank.Indicator async with get
+    member ``Tariff rate, applied, weighted mean, all products (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.TAX.MRCH.WM.AR.ZS")
+
+    member ``Tariff rate, applied, weighted mean, manufactured products (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.TAX.MANF.WM.AR.ZS")
+
+    member ``Tariff rate, applied, weighted mean, manufactured products (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.TAX.MANF.WM.AR.ZS")
 
     member ``Tariff rate, applied, weighted mean, primary products (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.TAX.TCOM.WM.AR.ZS")
 
-    member Tariff rate, most favored nation, simple mean, all products (%): FDR.WorldBank.Indicator async with get
+    member ``Tariff rate, applied, weighted mean, primary products (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.TAX.TCOM.WM.AR.ZS")
+
+    member ``Tariff rate, most favored nation, simple mean, all products (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.TAX.MRCH.SM.FN.ZS")
 
-    member Tariff rate, most favored nation, simple mean, manufactured products (%): FDR.WorldBank.Indicator async with get
+    member ``Tariff rate, most favored nation, simple mean, all products (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.TAX.MRCH.SM.FN.ZS")
+
+    member ``Tariff rate, most favored nation, simple mean, manufactured products (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.TAX.MANF.SM.FN.ZS")
+
+    member ``Tariff rate, most favored nation, simple mean, manufactured products (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.TAX.MANF.SM.FN.ZS")
 
     member ``Tariff rate, most favored nation, simple mean, primary products (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.TAX.TCOM.SM.FN.ZS")
 
-    member Tariff rate, most favored nation, weighted mean, all products (%): FDR.WorldBank.Indicator async with get
+    member ``Tariff rate, most favored nation, simple mean, primary products (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.TAX.TCOM.SM.FN.ZS")
+
+    member ``Tariff rate, most favored nation, weighted mean, all products (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.TAX.MRCH.WM.FN.ZS")
+
+    member ``Tariff rate, most favored nation, weighted mean, all products (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.TAX.MRCH.WM.FN.ZS")
 
     member ``Tariff rate, most favored nation, weighted mean, manufactured products (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.TAX.MANF.WM.FN.ZS")
 
-    member Tariff rate, most favored nation, weighted mean, primary products (%): FDR.WorldBank.Indicator async with get
+    member ``Tariff rate, most favored nation, weighted mean, manufactured products (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.TAX.MANF.WM.FN.ZS")
+
+    member ``Tariff rate, most favored nation, weighted mean, primary products (%)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.TAX.TCOM.WM.FN.ZS")
+
+    member ``Tariff rate, most favored nation, weighted mean, primary products (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.TAX.TCOM.WM.FN.ZS")
 
     member ``Tax payments (number)``: FDR.WorldBank.Indicator async with get
@@ -4964,7 +5279,10 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Technicians in R&D (per million people)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.POP.TECH.RD.P6")
 
-    member Teenage mothers (% of women ages 15-19 who have had children or are currently pregnant): FDR.WorldBank.Indicator async with get
+    member ``Technicians in R&D (per million people)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SP.POP.TECH.RD.P6")
+
+    member ``Teenage mothers (% of women ages 15-19 who have had children or are currently pregnant)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.MTR.1519.ZS")
 
     member ``Telephone lines``: FDR.WorldBank.Indicator async with get
@@ -5087,7 +5405,13 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Transport services (% of commercial service exports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.TRAN.ZS.WT")
 
-    member Transport services (% of commercial service imports): FDR.WorldBank.Indicator async with get
+    member ``Transport services (% of commercial service exports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.TRAN.ZS.WT")
+
+    member ``Transport services (% of commercial service imports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.VAL.TRAN.ZS.WT")
+
+    member ``Transport services (% of commercial service imports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.VAL.TRAN.ZS.WT")
 
     member ``Transport services (% of service exports, BoP)``: FDR.WorldBank.Indicator async with get
@@ -5099,7 +5423,13 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Travel services (% of commercial service exports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TX.VAL.TRVL.ZS.WT")
 
-    member Travel services (% of commercial service imports): FDR.WorldBank.Indicator async with get
+    member ``Travel services (% of commercial service exports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TX.VAL.TRVL.ZS.WT")
+
+    member ``Travel services (% of commercial service imports)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("TM.VAL.TRVL.ZS.WT")
+
+    member ``Travel services (% of commercial service imports)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.VAL.TRVL.ZS.WT")
 
     member ``Travel services (% of service exports, BoP)``: FDR.WorldBank.Indicator async with get
@@ -5189,16 +5519,28 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Unmet need for contraception (% of married women ages 15-49)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.UWT.TFRT")
 
-    member Urban population: FDR.WorldBank.Indicator async with get
+    member ``Unmet need for contraception (% of married women ages 15-49)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SP.UWT.TFRT")
+
+    member ``Urban population``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.URB.TOTL")
 
-    member Urban population (% of total): FDR.WorldBank.Indicator async with get
+    member ``Urban population``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SP.URB.TOTL")
+
+    member ``Urban population (% of total)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SP.URB.TOTL.IN.ZS")
+
+    member ``Urban population (% of total)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.URB.TOTL.IN.ZS")
 
     member ``Urban population growth (annual %)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.URB.GROW")
 
-    member Use of IMF credit (DOD, current US$): FDR.WorldBank.Indicator async with get
+    member ``Urban population growth (annual %)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SP.URB.GROW")
+
+    member ``Use of IMF credit (DOD, current US$)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("DT.DOD.DIMF.CD")
 
     member ``Use of insecticide-treated bed nets (% of under-5 population)``: FDR.WorldBank.Indicator async with get
@@ -5455,13 +5797,22 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Age dependency ratio (% of working-age population)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.POP.DPND")
 
-    member Age dependency ratio, old (% of working-age population): FDR.WorldBank.IndicatorDescription with get
+    member ``Age dependency ratio (% of working-age population)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SP.POP.DPND")
+
+    member ``Age dependency ratio, old (% of working-age population)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SP.POP.DPND.OL")
+
+    member ``Age dependency ratio, old (% of working-age population)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.POP.DPND.OL")
 
     member ``Age dependency ratio, young (% of working-age population)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.POP.DPND.YG")
 
-    member Agricultural irrigated land (% of total agricultural land): FDR.WorldBank.IndicatorDescription with get
+    member ``Age dependency ratio, young (% of working-age population)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SP.POP.DPND.YG")
+
+    member ``Agricultural irrigated land (% of total agricultural land)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("AG.LND.IRIG.AG.ZS")
 
     member ``Agricultural land (% of land area)``: FDR.WorldBank.IndicatorDescription with get
@@ -5491,7 +5842,13 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Agricultural raw materials exports (% of merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.AGRI.ZS.UN")
 
-    member Agricultural raw materials imports (% of merchandise imports): FDR.WorldBank.IndicatorDescription with get
+    member ``Agricultural raw materials exports (% of merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.AGRI.ZS.UN")
+
+    member ``Agricultural raw materials imports (% of merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.AGRI.ZS.UN")
+
+    member ``Agricultural raw materials imports (% of merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.AGRI.ZS.UN")
 
     member ``Agriculture value added per worker (constant 2005 US$)``: FDR.WorldBank.IndicatorDescription with get
@@ -5686,10 +6043,19 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Binding coverage, all products (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MRCH.BC.ZS")
 
-    member Binding coverage, manufactured products (%): FDR.WorldBank.IndicatorDescription with get
+    member ``Binding coverage, all products (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MRCH.BC.ZS")
+
+    member ``Binding coverage, manufactured products (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MANF.BC.ZS")
 
-    member Binding coverage, primary products (%): FDR.WorldBank.IndicatorDescription with get
+    member ``Binding coverage, manufactured products (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MANF.BC.ZS")
+
+    member ``Binding coverage, primary products (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.TCOM.BC.ZS")
+
+    member ``Binding coverage, primary products (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.TCOM.BC.ZS")
 
     member ``Bird species, threatened``: FDR.WorldBank.IndicatorDescription with get
@@ -5710,10 +6076,19 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Bound rate, simple mean, all products (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MRCH.BR.ZS")
 
-    member Bound rate, simple mean, manufactured products (%): FDR.WorldBank.IndicatorDescription with get
+    member ``Bound rate, simple mean, all products (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MRCH.BR.ZS")
+
+    member ``Bound rate, simple mean, manufactured products (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MANF.BR.ZS")
 
-    member Bound rate, simple mean, primary products (%): FDR.WorldBank.IndicatorDescription with get
+    member ``Bound rate, simple mean, manufactured products (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MANF.BR.ZS")
+
+    member ``Bound rate, simple mean, primary products (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.TCOM.BR.ZS")
+
+    member ``Bound rate, simple mean, primary products (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.TCOM.BR.ZS")
 
     member ``Broad money (% of GDP)``: FDR.WorldBank.IndicatorDescription with get
@@ -6022,7 +6397,13 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Commercial service exports (current US$)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.SERV.CD.WT")
 
-    member Commercial service imports (current US$): FDR.WorldBank.IndicatorDescription with get
+    member ``Commercial service exports (current US$)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.SERV.CD.WT")
+
+    member ``Commercial service imports (current US$)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.SERV.CD.WT")
+
+    member ``Commercial service imports (current US$)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.SERV.CD.WT")
 
     member ``Commitments, IBRD (COM, current US$)``: FDR.WorldBank.IndicatorDescription with get
@@ -6058,10 +6439,19 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Completeness of birth registration (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.REG.BRTH.ZS")
 
-    member Completeness of birth registration, rural (%): FDR.WorldBank.IndicatorDescription with get
+    member ``Completeness of birth registration (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SP.REG.BRTH.ZS")
+
+    member ``Completeness of birth registration, rural (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.REG.BRTH.RU.ZS")
 
-    member Completeness of birth registration, urban (%): FDR.WorldBank.IndicatorDescription with get
+    member ``Completeness of birth registration, rural (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SP.REG.BRTH.RU.ZS")
+
+    member ``Completeness of birth registration, urban (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SP.REG.BRTH.UR.ZS")
+
+    member ``Completeness of birth registration, urban (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.REG.BRTH.UR.ZS")
 
     member ``Completeness of infant death reporting (% of reported infant deaths to estimated infant deaths)``: FDR.WorldBank.IndicatorDescription with get
@@ -6073,7 +6463,13 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Computer, communications and other services (% of commercial service exports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.OTHR.ZS.WT")
 
-    member Computer, communications and other services (% of commercial service imports): FDR.WorldBank.IndicatorDescription with get
+    member ``Computer, communications and other services (% of commercial service exports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.OTHR.ZS.WT")
+
+    member ``Computer, communications and other services (% of commercial service imports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.OTHR.ZS.WT")
+
+    member ``Computer, communications and other services (% of commercial service imports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.OTHR.ZS.WT")
 
     member ``Concessional debt (% of total external debt)``: FDR.WorldBank.IndicatorDescription with get
@@ -6466,7 +6862,13 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Export value index (2000 = 100)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.XD.WD")
 
-    member Export volume index (2000 = 100): FDR.WorldBank.IndicatorDescription with get
+    member ``Export value index (2000 = 100)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.XD.WD")
+
+    member ``Export volume index (2000 = 100)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.QTY.MRCH.XD.WD")
+
+    member ``Export volume index (2000 = 100)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.QTY.MRCH.XD.WD")
 
     member ``Exports as a capacity to import (constant LCU)``: FDR.WorldBank.IndicatorDescription with get
@@ -6658,7 +7060,13 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Food exports (% of merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.FOOD.ZS.UN")
 
-    member Food imports (% of merchandise imports): FDR.WorldBank.IndicatorDescription with get
+    member ``Food exports (% of merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.FOOD.ZS.UN")
+
+    member ``Food imports (% of merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.FOOD.ZS.UN")
+
+    member ``Food imports (% of merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.FOOD.ZS.UN")
 
     member ``Food production index (2004-2006 = 100)``: FDR.WorldBank.IndicatorDescription with get
@@ -6700,7 +7108,13 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Fuel exports (% of merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.FUEL.ZS.UN")
 
-    member Fuel imports (% of merchandise imports): FDR.WorldBank.IndicatorDescription with get
+    member ``Fuel exports (% of merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.FUEL.ZS.UN")
+
+    member ``Fuel imports (% of merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.FUEL.ZS.UN")
+
+    member ``Fuel imports (% of merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.FUEL.ZS.UN")
 
     member ``GDP (constant 2005 US$)``: FDR.WorldBank.IndicatorDescription with get
@@ -7006,7 +7420,13 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``High-technology exports (% of manufactured exports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.TECH.MF.ZS")
 
-    member High-technology exports (current US$): FDR.WorldBank.IndicatorDescription with get
+    member ``High-technology exports (% of manufactured exports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.TECH.MF.ZS")
+
+    member ``High-technology exports (current US$)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.TECH.CD")
+
+    member ``High-technology exports (current US$)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.TECH.CD")
 
     member ``Hospital beds (per 1,000 people)``: FDR.WorldBank.IndicatorDescription with get
@@ -7063,7 +7483,13 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``ICT goods exports (% of total goods exports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.ICTG.ZS.UN")
 
-    member ICT goods imports (% total goods imports): FDR.WorldBank.IndicatorDescription with get
+    member ``ICT goods exports (% of total goods exports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.ICTG.ZS.UN")
+
+    member ``ICT goods imports (% total goods imports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.ICTG.ZS.UN")
+
+    member ``ICT goods imports (% total goods imports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.ICTG.ZS.UN")
 
     member ``ICT service exports (% of service exports, BoP)``: FDR.WorldBank.IndicatorDescription with get
@@ -7102,7 +7528,13 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Import value index (2000 = 100)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.XD.WD")
 
-    member Import volume index (2000 = 100): FDR.WorldBank.IndicatorDescription with get
+    member ``Import value index (2000 = 100)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.XD.WD")
+
+    member ``Import volume index (2000 = 100)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.QTY.MRCH.XD.WD")
+
+    member ``Import volume index (2000 = 100)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.QTY.MRCH.XD.WD")
 
     member ``Imports of goods and services (% of GDP)``: FDR.WorldBank.IndicatorDescription with get
@@ -7204,7 +7636,13 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Insurance and financial services (% of commercial service exports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.INSF.ZS.WT")
 
-    member Insurance and financial services (% of commercial service imports): FDR.WorldBank.IndicatorDescription with get
+    member ``Insurance and financial services (% of commercial service exports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.INSF.ZS.WT")
+
+    member ``Insurance and financial services (% of commercial service imports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.INSF.ZS.WT")
+
+    member ``Insurance and financial services (% of commercial service imports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.INSF.ZS.WT")
 
     member ``Insurance and financial services (% of service exports, BoP)``: FDR.WorldBank.IndicatorDescription with get
@@ -7291,31 +7729,61 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``International tourism, expenditures (% of total imports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("ST.INT.XPND.MP.ZS")
 
-    member International tourism, expenditures (current US$): FDR.WorldBank.IndicatorDescription with get
+    member ``International tourism, expenditures (% of total imports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("ST.INT.XPND.MP.ZS")
+
+    member ``International tourism, expenditures (current US$)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("ST.INT.XPND.CD")
 
-    member International tourism, expenditures for passenger transport items (current US$): FDR.WorldBank.IndicatorDescription with get
+    member ``International tourism, expenditures (current US$)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("ST.INT.XPND.CD")
+
+    member ``International tourism, expenditures for passenger transport items (current US$)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("ST.INT.TRNX.CD")
+
+    member ``International tourism, expenditures for passenger transport items (current US$)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("ST.INT.TRNX.CD")
 
     member ``International tourism, expenditures for travel items (current US$)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("ST.INT.TVLX.CD")
 
-    member International tourism, number of arrivals: FDR.WorldBank.IndicatorDescription with get
+    member ``International tourism, expenditures for travel items (current US$)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("ST.INT.TVLX.CD")
+
+    member ``International tourism, number of arrivals``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("ST.INT.ARVL")
+
+    member ``International tourism, number of arrivals``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("ST.INT.ARVL")
 
     member ``International tourism, number of departures``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("ST.INT.DPRT")
 
-    member International tourism, receipts (% of total exports): FDR.WorldBank.IndicatorDescription with get
+    member ``International tourism, number of departures``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("ST.INT.DPRT")
+
+    member ``International tourism, receipts (% of total exports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("ST.INT.RCPT.XP.ZS")
 
-    member International tourism, receipts (current US$): FDR.WorldBank.IndicatorDescription with get
+    member ``International tourism, receipts (% of total exports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("ST.INT.RCPT.XP.ZS")
+
+    member ``International tourism, receipts (current US$)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("ST.INT.RCPT.CD")
+
+    member ``International tourism, receipts (current US$)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("ST.INT.RCPT.CD")
 
     member ``International tourism, receipts for passenger transport items (current US$)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("ST.INT.TRNR.CD")
 
-    member International tourism, receipts for travel items (current US$): FDR.WorldBank.IndicatorDescription with get
+    member ``International tourism, receipts for passenger transport items (current US$)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("ST.INT.TRNR.CD")
+
+    member ``International tourism, receipts for travel items (current US$)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("ST.INT.TVLR.CD")
+
+    member ``International tourism, receipts for travel items (current US$)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("ST.INT.TVLR.CD")
 
     member ``Internationally-recognized quality certification (% of firms)``: FDR.WorldBank.IndicatorDescription with get
@@ -7600,7 +8068,13 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Manufactures exports (% of merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MANF.ZS.UN")
 
-    member Manufactures imports (% of merchandise imports): FDR.WorldBank.IndicatorDescription with get
+    member ``Manufactures exports (% of merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MANF.ZS.UN")
+
+    member ``Manufactures imports (% of merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MANF.ZS.UN")
+
+    member ``Manufactures imports (% of merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MANF.ZS.UN")
 
     member ``Manufacturing, value added (% of GDP)``: FDR.WorldBank.IndicatorDescription with get
@@ -7642,82 +8116,163 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Merchandise exports (current US$)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.CD.WT")
 
-    member Merchandise exports by the reporting economy (current US$): FDR.WorldBank.IndicatorDescription with get
+    member ``Merchandise exports (current US$)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.CD.WT")
+
+    member ``Merchandise exports by the reporting economy (current US$)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.WL.CD")
+
+    member ``Merchandise exports by the reporting economy (current US$)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.WL.CD")
 
     member ``Merchandise exports by the reporting economy, residual (% of total merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.RS.ZS")
 
-    member Merchandise exports to developing economies in East Asia & Pacific (% of total merchandise exports): FDR.WorldBank.IndicatorDescription with get
+    member ``Merchandise exports by the reporting economy, residual (% of total merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.RS.ZS")
+
+    member ``Merchandise exports to developing economies in East Asia & Pacific (% of total merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.R1.ZS")
 
-    member Merchandise exports to developing economies in Europe & Central Asia (% of total merchandise exports): FDR.WorldBank.IndicatorDescription with get
+    member ``Merchandise exports to developing economies in East Asia & Pacific (% of total merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.R1.ZS")
+
+    member ``Merchandise exports to developing economies in Europe & Central Asia (% of total merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.R2.ZS")
+
+    member ``Merchandise exports to developing economies in Europe & Central Asia (% of total merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.R2.ZS")
 
     member ``Merchandise exports to developing economies in Latin America & the Caribbean (% of total merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.R3.ZS")
 
-    member Merchandise exports to developing economies in Middle East & North Africa (% of total merchandise exports): FDR.WorldBank.IndicatorDescription with get
+    member ``Merchandise exports to developing economies in Latin America & the Caribbean (% of total merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.R3.ZS")
+
+    member ``Merchandise exports to developing economies in Middle East & North Africa (% of total merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.R4.ZS")
 
-    member Merchandise exports to developing economies in South Asia (% of total merchandise exports): FDR.WorldBank.IndicatorDescription with get
+    member ``Merchandise exports to developing economies in Middle East & North Africa (% of total merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.R4.ZS")
+
+    member ``Merchandise exports to developing economies in South Asia (% of total merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.R5.ZS")
+
+    member ``Merchandise exports to developing economies in South Asia (% of total merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.R5.ZS")
 
     member ``Merchandise exports to developing economies in Sub-Saharan Africa (% of total merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.R6.ZS")
 
-    member Merchandise exports to developing economies outside region (% of total merchandise exports): FDR.WorldBank.IndicatorDescription with get
+    member ``Merchandise exports to developing economies in Sub-Saharan Africa (% of total merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.R6.ZS")
+
+    member ``Merchandise exports to developing economies outside region (% of total merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.OR.ZS")
+
+    member ``Merchandise exports to developing economies outside region (% of total merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.OR.ZS")
 
     member ``Merchandise exports to developing economies within region (% of total merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.WR.ZS")
 
-    member Merchandise exports to economies in the Arab World (% of total merchandise exports): FDR.WorldBank.IndicatorDescription with get
+    member ``Merchandise exports to developing economies within region (% of total merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.WR.ZS")
+
+    member ``Merchandise exports to economies in the Arab World (% of total merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.AL.ZS")
 
-    member Merchandise exports to high-income economies (% of total merchandise exports): FDR.WorldBank.IndicatorDescription with get
+    member ``Merchandise exports to economies in the Arab World (% of total merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.AL.ZS")
+
+    member ``Merchandise exports to high-income economies (% of total merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.HI.ZS")
+
+    member ``Merchandise exports to high-income economies (% of total merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MRCH.HI.ZS")
 
     member ``Merchandise imports (current US$)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.CD.WT")
 
-    member Merchandise imports by the reporting economy (current US$): FDR.WorldBank.IndicatorDescription with get
+    member ``Merchandise imports (current US$)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.CD.WT")
+
+    member ``Merchandise imports by the reporting economy (current US$)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.WL.CD")
+
+    member ``Merchandise imports by the reporting economy (current US$)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.WL.CD")
 
     member ``Merchandise imports by the reporting economy, residual (% of total merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.RS.ZS")
 
-    member Merchandise imports from developing economies in East Asia & Pacific (% of total merchandise imports): FDR.WorldBank.IndicatorDescription with get
+    member ``Merchandise imports by the reporting economy, residual (% of total merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.RS.ZS")
+
+    member ``Merchandise imports from developing economies in East Asia & Pacific (% of total merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.R1.ZS")
 
-    member Merchandise imports from developing economies in Europe & Central Asia (% of total merchandise imports): FDR.WorldBank.IndicatorDescription with get
+    member ``Merchandise imports from developing economies in East Asia & Pacific (% of total merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.R1.ZS")
+
+    member ``Merchandise imports from developing economies in Europe & Central Asia (% of total merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.R2.ZS")
+
+    member ``Merchandise imports from developing economies in Europe & Central Asia (% of total merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.R2.ZS")
 
     member ``Merchandise imports from developing economies in Latin America & the Caribbean (% of total merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.R3.ZS")
 
-    member Merchandise imports from developing economies in Middle East & North Africa (% of total merchandise imports): FDR.WorldBank.IndicatorDescription with get
+    member ``Merchandise imports from developing economies in Latin America & the Caribbean (% of total merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.R3.ZS")
+
+    member ``Merchandise imports from developing economies in Middle East & North Africa (% of total merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.R4.ZS")
+
+    member ``Merchandise imports from developing economies in Middle East & North Africa (% of total merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.R4.ZS")
 
     member ``Merchandise imports from developing economies in South Asia (% of total merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.R5.ZS")
 
-    member Merchandise imports from developing economies in Sub-Saharan Africa (% of total merchandise imports): FDR.WorldBank.IndicatorDescription with get
+    member ``Merchandise imports from developing economies in South Asia (% of total merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.R5.ZS")
+
+    member ``Merchandise imports from developing economies in Sub-Saharan Africa (% of total merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.R6.ZS")
+
+    member ``Merchandise imports from developing economies in Sub-Saharan Africa (% of total merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.R6.ZS")
 
     member ``Merchandise imports from developing economies outside region (% of total merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.OR.ZS")
 
-    member Merchandise imports from developing economies within region (% of total merchandise imports): FDR.WorldBank.IndicatorDescription with get
+    member ``Merchandise imports from developing economies outside region (% of total merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.OR.ZS")
+
+    member ``Merchandise imports from developing economies within region (% of total merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.WR.ZS")
 
-    member Merchandise imports from economies in the Arab World (% of total merchandise imports): FDR.WorldBank.IndicatorDescription with get
+    member ``Merchandise imports from developing economies within region (% of total merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.WR.ZS")
+
+    member ``Merchandise imports from economies in the Arab World (% of total merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.AL.ZS")
+
+    member ``Merchandise imports from economies in the Arab World (% of total merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.AL.ZS")
 
     member ``Merchandise imports from high-income economies (% of total merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.HI.ZS")
 
-    member Merchandise trade (% of GDP): FDR.WorldBank.IndicatorDescription with get
+    member ``Merchandise imports from high-income economies (% of total merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MRCH.HI.ZS")
+
+    member ``Merchandise trade (% of GDP)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TG.VAL.TOTL.GD.ZS")
+
+    member ``Merchandise trade (% of GDP)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TG.VAL.TOTL.GD.ZS")
 
     member ``Methane emissions (kt of CO2 equivalent)``: FDR.WorldBank.IndicatorDescription with get
@@ -7828,7 +8383,10 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Net barter terms of trade index (2000 = 100)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TT.PRI.MRCH.XD.WD")
 
-    member Net bilateral aid flows from DAC donors, Australia (current US$): FDR.WorldBank.IndicatorDescription with get
+    member ``Net barter terms of trade index (2000 = 100)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TT.PRI.MRCH.XD.WD")
+
+    member ``Net bilateral aid flows from DAC donors, Australia (current US$)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("DC.DAC.AUSL.CD")
 
     member ``Net bilateral aid flows from DAC donors, Austria (current US$)``: FDR.WorldBank.IndicatorDescription with get
@@ -8158,7 +8716,13 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Ores and metals exports (% of merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MMTL.ZS.UN")
 
-    member Ores and metals imports (% of merchandise imports): FDR.WorldBank.IndicatorDescription with get
+    member ``Ores and metals exports (% of merchandise exports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.MMTL.ZS.UN")
+
+    member ``Ores and metals imports (% of merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MMTL.ZS.UN")
+
+    member ``Ores and metals imports (% of merchandise imports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MMTL.ZS.UN")
 
     member ``Organic water pollutant (BOD) emissions (kg per day per worker)``: FDR.WorldBank.IndicatorDescription with get
@@ -8548,7 +9112,10 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Population (Total)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.POP.TOTL")
 
-    member Population ages 0-14 (% of total): FDR.WorldBank.IndicatorDescription with get
+    member ``Population (Total)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SP.POP.TOTL")
+
+    member ``Population ages 0-14 (% of total)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.POP.0014.TO.ZS")
 
     member ``Population ages 15-64 (% of total)``: FDR.WorldBank.IndicatorDescription with get
@@ -8563,7 +9130,10 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Population growth (annual %)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.POP.GROW")
 
-    member Population in largest city: FDR.WorldBank.IndicatorDescription with get
+    member ``Population growth (annual %)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SP.POP.GROW")
+
+    member ``Population in largest city``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("EN.URB.LCTY")
 
     member ``Population in the largest city (% of urban population)``: FDR.WorldBank.IndicatorDescription with get
@@ -8581,7 +9151,10 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Population, female (% of total)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.POP.TOTL.FE.ZS")
 
-    member Portfolio Investment, net (BoP, current US$): FDR.WorldBank.IndicatorDescription with get
+    member ``Population, female (% of total)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SP.POP.TOTL.FE.ZS")
+
+    member ``Portfolio Investment, net (BoP, current US$)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("BN.KLT.PTXL.CD")
 
     member ``Portfolio equity, net inflows (BoP, current US$)``: FDR.WorldBank.IndicatorDescription with get
@@ -8899,7 +9472,10 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Researchers in R&D (per million people)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.POP.SCIE.RD.P6")
 
-    member Reserves and related items (BoP, current US$): FDR.WorldBank.IndicatorDescription with get
+    member ``Researchers in R&D (per million people)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SP.POP.SCIE.RD.P6")
+
+    member ``Reserves and related items (BoP, current US$)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("BN.RES.INCL.CD")
 
     member ``Residual, debt stock-flow reconciliation (current US$)``: FDR.WorldBank.IndicatorDescription with get
@@ -8953,10 +9529,19 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Rural population``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.RUR.TOTL")
 
-    member Rural population (% of total population): FDR.WorldBank.IndicatorDescription with get
+    member ``Rural population``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SP.RUR.TOTL")
+
+    member ``Rural population (% of total population)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.RUR.TOTL.ZS")
 
-    member Rural population growth (annual %): FDR.WorldBank.IndicatorDescription with get
+    member ``Rural population (% of total population)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SP.RUR.TOTL.ZS")
+
+    member ``Rural population growth (annual %)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SP.RUR.TOTL.ZG")
+
+    member ``Rural population growth (annual %)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.RUR.TOTL.ZG")
 
     member ``S&P Global Equity Indices (annual % change)``: FDR.WorldBank.IndicatorDescription with get
@@ -9118,22 +9703,40 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Share of tariff lines with international peaks, all products (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MRCH.IP.ZS")
 
-    member Share of tariff lines with international peaks, manufactured products (%): FDR.WorldBank.IndicatorDescription with get
+    member ``Share of tariff lines with international peaks, all products (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MRCH.IP.ZS")
+
+    member ``Share of tariff lines with international peaks, manufactured products (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MANF.IP.ZS")
+
+    member ``Share of tariff lines with international peaks, manufactured products (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MANF.IP.ZS")
 
     member ``Share of tariff lines with international peaks, primary products (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.TCOM.IP.ZS")
 
-    member Share of tariff lines with specific rates, all products (%): FDR.WorldBank.IndicatorDescription with get
+    member ``Share of tariff lines with international peaks, primary products (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.TCOM.IP.ZS")
+
+    member ``Share of tariff lines with specific rates, all products (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MRCH.SR.ZS")
 
-    member Share of tariff lines with specific rates, manufactured products (%): FDR.WorldBank.IndicatorDescription with get
+    member ``Share of tariff lines with specific rates, all products (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MRCH.SR.ZS")
+
+    member ``Share of tariff lines with specific rates, manufactured products (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MANF.SR.ZS")
+
+    member ``Share of tariff lines with specific rates, manufactured products (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MANF.SR.ZS")
 
     member ``Share of tariff lines with specific rates, primary products (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.TCOM.SR.ZS")
 
-    member Share of women employed in the nonagricultural sector (% of total nonagricultural employment): FDR.WorldBank.IndicatorDescription with get
+    member ``Share of tariff lines with specific rates, primary products (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.TCOM.SR.ZS")
+
+    member ``Share of women employed in the nonagricultural sector (% of total nonagricultural employment)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SL.EMP.INSV.FE.ZS")
 
     member ``Short-term debt (% of exports of goods, services and primary income)``: FDR.WorldBank.IndicatorDescription with get
@@ -9208,40 +9811,76 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Tariff rate, applied, simple mean, all products (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MRCH.SM.AR.ZS")
 
-    member Tariff rate, applied, simple mean, manufactured products (%): FDR.WorldBank.IndicatorDescription with get
+    member ``Tariff rate, applied, simple mean, all products (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MRCH.SM.AR.ZS")
+
+    member ``Tariff rate, applied, simple mean, manufactured products (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MANF.SM.AR.ZS")
 
-    member Tariff rate, applied, simple mean, primary products (%): FDR.WorldBank.IndicatorDescription with get
+    member ``Tariff rate, applied, simple mean, manufactured products (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MANF.SM.AR.ZS")
+
+    member ``Tariff rate, applied, simple mean, primary products (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.TCOM.SM.AR.ZS")
+
+    member ``Tariff rate, applied, simple mean, primary products (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.TCOM.SM.AR.ZS")
 
     member ``Tariff rate, applied, weighted mean, all products (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MRCH.WM.AR.ZS")
 
-    member Tariff rate, applied, weighted mean, manufactured products (%): FDR.WorldBank.IndicatorDescription with get
+    member ``Tariff rate, applied, weighted mean, all products (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MRCH.WM.AR.ZS")
+
+    member ``Tariff rate, applied, weighted mean, manufactured products (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MANF.WM.AR.ZS")
 
-    member Tariff rate, applied, weighted mean, primary products (%): FDR.WorldBank.IndicatorDescription with get
+    member ``Tariff rate, applied, weighted mean, manufactured products (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MANF.WM.AR.ZS")
+
+    member ``Tariff rate, applied, weighted mean, primary products (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.TCOM.WM.AR.ZS")
+
+    member ``Tariff rate, applied, weighted mean, primary products (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.TCOM.WM.AR.ZS")
 
     member ``Tariff rate, most favored nation, simple mean, all products (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MRCH.SM.FN.ZS")
 
-    member Tariff rate, most favored nation, simple mean, manufactured products (%): FDR.WorldBank.IndicatorDescription with get
+    member ``Tariff rate, most favored nation, simple mean, all products (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MRCH.SM.FN.ZS")
+
+    member ``Tariff rate, most favored nation, simple mean, manufactured products (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MANF.SM.FN.ZS")
+
+    member ``Tariff rate, most favored nation, simple mean, manufactured products (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MANF.SM.FN.ZS")
 
     member ``Tariff rate, most favored nation, simple mean, primary products (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.TCOM.SM.FN.ZS")
 
-    member Tariff rate, most favored nation, weighted mean, all products (%): FDR.WorldBank.IndicatorDescription with get
+    member ``Tariff rate, most favored nation, simple mean, primary products (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.TCOM.SM.FN.ZS")
+
+    member ``Tariff rate, most favored nation, weighted mean, all products (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MRCH.WM.FN.ZS")
 
-    member Tariff rate, most favored nation, weighted mean, manufactured products (%): FDR.WorldBank.IndicatorDescription with get
+    member ``Tariff rate, most favored nation, weighted mean, all products (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MRCH.WM.FN.ZS")
+
+    member ``Tariff rate, most favored nation, weighted mean, manufactured products (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MANF.WM.FN.ZS")
+
+    member ``Tariff rate, most favored nation, weighted mean, manufactured products (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MANF.WM.FN.ZS")
 
     member ``Tariff rate, most favored nation, weighted mean, primary products (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.TCOM.WM.FN.ZS")
 
-    member Tax payments (number): FDR.WorldBank.IndicatorDescription with get
+    member ``Tariff rate, most favored nation, weighted mean, primary products (%)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.TCOM.WM.FN.ZS")
+
+    member ``Tax payments (number)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("IC.TAX.PAYM")
 
     member ``Tax revenue (% of GDP)``: FDR.WorldBank.IndicatorDescription with get
@@ -9286,7 +9925,10 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Technicians in R&D (per million people)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.POP.TECH.RD.P6")
 
-    member Teenage mothers (% of women ages 15-19 who have had children or are currently pregnant): FDR.WorldBank.IndicatorDescription with get
+    member ``Technicians in R&D (per million people)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SP.POP.TECH.RD.P6")
+
+    member ``Teenage mothers (% of women ages 15-19 who have had children or are currently pregnant)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.MTR.1519.ZS")
 
     member ``Telephone lines``: FDR.WorldBank.IndicatorDescription with get
@@ -9409,7 +10051,13 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Transport services (% of commercial service exports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.TRAN.ZS.WT")
 
-    member Transport services (% of commercial service imports): FDR.WorldBank.IndicatorDescription with get
+    member ``Transport services (% of commercial service exports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.TRAN.ZS.WT")
+
+    member ``Transport services (% of commercial service imports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.TRAN.ZS.WT")
+
+    member ``Transport services (% of commercial service imports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.TRAN.ZS.WT")
 
     member ``Transport services (% of service exports, BoP)``: FDR.WorldBank.IndicatorDescription with get
@@ -9421,7 +10069,13 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Travel services (% of commercial service exports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.TRVL.ZS.WT")
 
-    member Travel services (% of commercial service imports): FDR.WorldBank.IndicatorDescription with get
+    member ``Travel services (% of commercial service exports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TX.VAL.TRVL.ZS.WT")
+
+    member ``Travel services (% of commercial service imports)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.TRVL.ZS.WT")
+
+    member ``Travel services (% of commercial service imports)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.TRVL.ZS.WT")
 
     member ``Travel services (% of service exports, BoP)``: FDR.WorldBank.IndicatorDescription with get
@@ -9511,16 +10165,28 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Unmet need for contraception (% of married women ages 15-49)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.UWT.TFRT")
 
-    member Urban population: FDR.WorldBank.IndicatorDescription with get
+    member ``Unmet need for contraception (% of married women ages 15-49)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SP.UWT.TFRT")
+
+    member ``Urban population``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.URB.TOTL")
 
-    member Urban population (% of total): FDR.WorldBank.IndicatorDescription with get
+    member ``Urban population``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SP.URB.TOTL")
+
+    member ``Urban population (% of total)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SP.URB.TOTL.IN.ZS")
+
+    member ``Urban population (% of total)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.URB.TOTL.IN.ZS")
 
     member ``Urban population growth (annual %)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.URB.GROW")
 
-    member Use of IMF credit (DOD, current US$): FDR.WorldBank.IndicatorDescription with get
+    member ``Urban population growth (annual %)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SP.URB.GROW")
+
+    member ``Use of IMF credit (DOD, current US$)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("DT.DOD.DIMF.CD")
 
     member ``Use of insecticide-treated bed nets (% of under-5 population)``: FDR.WorldBank.IndicatorDescription with get

--- a/tests/FSharp.Data.Tests/HtmlOperations.fs
+++ b/tests/FSharp.Data.Tests/HtmlOperations.fs
@@ -43,7 +43,7 @@ let ``If tryParse HtmlAttribute failes it should return the defaultValue``() =
 let htmlFragment = 
     createElement "div" ["id", "my_div"; "class", "my_class"] [
         createText "Hello World!"
-    ] (ref None)
+    ]
 
 [<Test>]
 let ``Can get the name of a HtmlElement``() =
@@ -51,20 +51,15 @@ let ``Can get the name of a HtmlElement``() =
 
 [<Test>]
 let ``Name of a content element is an Empty string``() = 
-    HtmlNode.name (createText "Hello" (ref None)) |> should equal String.Empty
+    HtmlNode.name (createText "Hello") |> should equal String.Empty
 
 [<Test>]
 let ``The children of a content node is an empty list``() =
-    HtmlNode.children (createText "Hello" (ref None)) |> should equal []
+    HtmlNode.children (createText "Hello") |> should equal []
 
 [<Test>]
 let ``Can get the children of a node``() =
-    HtmlNode.children htmlFragment |> should equal [createText "Hello World!" (ref None)]
-
-[<Test>]
-let ``Can get the parent of a node``() =
-    let child = HtmlNode.children htmlFragment |> List.head
-    HtmlNode.parent child |> should equal (Some htmlFragment)
+    HtmlNode.children htmlFragment |> should equal [createText "Hello World!"]
 
 let doc = 
     """<html>
@@ -87,13 +82,13 @@ let doc =
 [<Test>]
 let ``Can get descendants of a node that matches a predicate``() =
     let result = doc |> HtmlNode.descendants false (HtmlNode.name >> (=) "link")
-    let expected = createElement "link" ["rel", "stylesheet"; "type", "text/css"; "href", "/bwx_style.css"] [] (ref None)
+    let expected = createElement "link" ["rel", "stylesheet"; "type", "text/css"; "href", "/bwx_style.css"] []
     result |> should equal [expected]
 
 [<Test>]
 let ``Can get all of the descendants that match the given set of names``() =
     let result = doc |> HtmlNode.descendantsNamed false ["link"]
-    let expected = createElement "link" ["rel", "stylesheet"; "type", "text/css"; "href", "/bwx_style.css"] [] (ref None)
+    let expected = createElement "link" ["rel", "stylesheet"; "type", "text/css"; "href", "/bwx_style.css"] []
     result |> should equal [expected]
 
 [<Test>]
@@ -114,7 +109,7 @@ let ``Can get all elements of a node that matches a predicate``() =
         |> HtmlNode.Parse
         |> List.head
         |> HtmlNode.elements (HtmlNode.name >> (=) "img")
-    let expected = createElement "img" ["src", "myimg.jpg"] [] (ref None)
+    let expected = createElement "img" ["src", "myimg.jpg"] []
     result |> should equal [expected]
 
 [<Test>]
@@ -132,8 +127,8 @@ let ``Can get all elements of a node that matches a set of names``() =
         |> List.head
         |> HtmlNode.elementsNamed ["img"; "div"]
     let expected = [
-            createElement "img" ["src", "myimg.jpg"] [] (ref None)
-            createElement "div" [] [createText "Hello World"] (ref None)
+            createElement "img" ["src", "myimg.jpg"] []
+            createElement "div" [] [createText "Hello World"]
         ]
     result |> should equal expected
 
@@ -163,42 +158,15 @@ let ``Can extract the inner text from a node``() =
 
 [<Test>]
 let ``Inner text on a comment should be String.Empty``() = 
-    let comment = createComment "Hello World" (ref None)
+    let comment = createComment "Hello World"
     HtmlNode.innerText comment |> should equal String.Empty
 
 [<Test>]
 let ``Inner text on a style should be String.Empty``() = 
-    let comment = createElement "style" [] [createText "Hello World"] (ref None)
+    let comment = createElement "style" [] [createText "Hello World"]
     HtmlNode.innerText comment |> should equal String.Empty
 
 [<Test>]
 let ``Inner text on a script should be String.Empty``() = 
-    let comment = createElement "script" [] [createText "Hello World"] (ref None)
+    let comment = createElement "script" [] [createText "Hello World"]
     HtmlNode.innerText comment |> should equal String.Empty
-
-[<Test>]
-let ``Can get to siblings of a node``() =
-    let result = 
-        doc.Descendants(["table"]) 
-        |> List.head
-        |> HtmlNode.siblings
-    let expected = createElement "img" ["src", "myimg.jpg"] [] (ref None)
-    result |> should equal [expected]
-
-[<Test>]
-let ``Can find the nearest node that matches a predicate before the current node``() =
-    let doc = 
-        HtmlNode.ParseRooted("html", """<body>
-                <div>
-                    <h3>Heading</h3>
-                </div>
-                <div>
-                    <table title="table">
-                        <tr><th>Column 1</th><th>Column 2</th></tr>
-                        <tr><td>1</td><td>yes</td></tr>
-                    </table>
-                </div>
-            </body>""")
-    let table = HtmlNode.descendantsNamed false ["table"] doc |> List.head
-    let result = HtmlNode.tryFindPrevious (HtmlNode.name >> (=) "h3") table
-    result |> should equal (Some (createElement "h3" [] [createText "Heading"] (ref None)))


### PR DESCRIPTION
The parent member was not looking that good. We can add a zipper later to cover these cases.
The problem is that now the algorithm to get the able to get table name is not as good, but it still gets the "VersionHistory" name correctly for the NuGet table and "Top 250" for IMDB, only wikipedia is slightly worse.
