### PR TITLE
Corrected memory leak

### DIFF
--- a/src/CommonProviderImplementation/Helpers.fs
+++ b/src/CommonProviderImplementation/Helpers.fs
@@ -102,8 +102,8 @@ type DisposableTypeProviderForNamespaces() as x =
         for typeName in Seq.toArray disposeActionsByTypeName.Keys do
             dispose typeName
 
-    interface IDisposable with 
-        member __.Dispose() = disposeAll()
+    do
+        x.Disposing.Add(fun _ -> disposeAll())
               
     interface IDisposableTypeProvider with
         member __.Invalidate typeName = dispose typeName; ``base``.Invalidate()

--- a/src/CommonProviderImplementation/ProvidedTypes.fsi
+++ b/src/CommonProviderImplementation/ProvidedTypes.fsi
@@ -427,4 +427,7 @@ type TypeProviderForNamespaces =
     member RegisterRuntimeAssemblyLocationAsProbingFolder : cfg : Core.CompilerServices.TypeProviderConfig -> unit
 #endif
 
+    [<CLIEvent>]
+    member Disposing : IEvent<EventHandler,EventArgs>
+
     interface ITypeProvider


### PR DESCRIPTION
All type providers were implementing `DisposableTypeProviderForNamespaces`, which re-implemented `IDisposable` even though the base `TypeProviderForNamespaces` class already implemented `IDisposable`, which effectively hides the base class Dispose() method call.  This causes a leak as the AppDomain `AssemblyResolve` handler was never unsubscribed.

This request performs addresses this issue via the same edit and technique as the PR on the TypeProviderStarterPack here: https://github.com/fsprojects/FSharp.TypeProviders.StarterPack/pull/23
