### PR TITLE
Accept any MIME type in HTTP requests

### DIFF
--- a/src/CommonRuntime/IO.fs
+++ b/src/CommonRuntime/IO.fs
@@ -201,13 +201,15 @@ let internal asyncReadText (_tp:(IDisposableTypeProvider*string) option) (uriRes
   let uri, isWeb = uriResolver.Resolve uri
   if isWeb then
     async {
-        let headers = [ HttpRequestHeaders.UserAgent ("F# Data " + formatName + " Type Provider") ]
-        let headers = 
+        let contentTypes =
             match formatName with
-            | "JSON" -> HttpRequestHeaders.Accept HttpContentTypes.Json :: headers
-            | "XML" -> HttpRequestHeaders.Accept HttpContentTypes.Xml :: headers
-            | "CSV" -> HttpRequestHeaders.Accept HttpContentTypes.Csv :: headers 
-            | _ -> headers
+            | "JSON" -> [ HttpContentTypes.Json ]
+            | "XML" -> [ HttpContentTypes.Xml ]
+            | "CSV" -> [ HttpContentTypes.Csv ]
+            | _ -> []
+            @ [ HttpContentTypes.Any ]
+        let headers = [ HttpRequestHeaders.UserAgent ("F# Data " + formatName + " Type Provider") 
+                        HttpRequestHeaders.Accept (String.concat ", " contentTypes) ]
         return! Http.AsyncRequestString(uri.OriginalString, headers = headers, responseEncodingOverride = encodingStr)
     }
   else

--- a/src/Net/Http.fs
+++ b/src/Net/Http.fs
@@ -224,6 +224,8 @@ type HttpResponseWithStream =
 
 /// Constants for common HTTP content types
 module HttpContentTypes =
+    /// */*
+    let [<Literal>] Any = "*/*"
     /// plain/text
     let [<Literal>] Text = "plain/text"
     /// application/octet-stream


### PR DESCRIPTION
Currently when reading text from a URL, the MIME type is set to the
specific format being requested, e.g. application/xml for XML. This
will cause the request to fail with HTTP error 406 if the resource
has a different MIME type, such as text/plain or application/atom+xml.
This commit modifies it to prefer specific types, followed by _/_ so
that any MIME type is accepted.

I don't have any public URL that exhibits this problem, but it occurred when trying to parse the ATOM feed of TeamCity's built-in NuGet server, as it insists the MIME type of the XML is text/plain.
