### PR TITLE
Bug: Http - writeBody called before call to customizeHttpRequest

### DIFF
--- a/src/Net/Http.fs
+++ b/src/Net/Http.fs
@@ -635,15 +635,15 @@ type Http private() =
 
         // Send the request and get the response
         augmentWebExceptionsWithDetails <| fun () -> async {
-   
-            match body with
-            | Some body -> do! writeBody req body
-            | None -> ()
 
             let req = 
                 match customizeHttpRequest with
                 | Some customizeHttpRequest -> customizeHttpRequest req
                 | None -> req
+   
+            match body with
+            | Some body -> do! writeBody req body
+            | None -> ()
 
             let! resp = getResponse req silentHttpErrors
 


### PR DESCRIPTION
`writeBody` is called before call to `customizeHttpRequest` and it caused exception in `customizeHttpRequest`.

The details can be found here http://stackoverflow.com/questions/24963466/this-operation-cannot-be-performed-after-the-request-has-been-submitted/24965885#24965885.
