### PR TITLE
Fix for issue #688

### DIFF
--- a/tests/FSharp.Data.Tests/CsvProvider.fs
+++ b/tests/FSharp.Data.Tests/CsvProvider.fs
@@ -149,6 +149,8 @@ let ``Header with trailing empty column that doesn't appear in data rows``()=
   let csv = CsvProvider<csvWithSpuriousTrailingEmptyHeaderColumn>.GetSample()
   let row = csv.Rows |> Seq.head
   row |> should equal (1,2,3)
+  let row = csv.Rows |> Seq.skip 1 |> Seq.head
+  row |> should equal (4,5,6)
 
 [<Literal>]
 let csvWithLegitimateTrailingEmptyColumn = """A,B,C,
@@ -160,6 +162,8 @@ let ``Header with trailing empty column that does appear in data rows``() =
   let csv = CsvProvider<csvWithLegitimateTrailingEmptyColumn>.GetSample()
   let row = csv.Rows |> Seq.head
   row |> should equal (1,2,3,4)
+  let row = csv.Rows |> Seq.skip 1 |> Seq.head
+  row |> should equal (5,6,7,8)
   
 let [<Literal>] simpleCsvNoHeaders = """
 TRUE,no,3


### PR DESCRIPTION
Added a fix for issue #688 in which a header has a spurious empty
trailing column that doesn't appear in the following rows.  If a header
is present and the final header column has zero length, the next row is
checked.  If it has one less column than the header, the extra empty
header column is treated as spurious and removed.  Otherwise, the column
is retained.  Two added tests: one for the case where the empty trailing
header column is spurious and should be ignored, and one case where it
is legitimate and should not be ignored.
