### PR TITLE
Fixes for Mono build

### DIFF
--- a/src/FSharp.Data.Portable47.fsproj
+++ b/src/FSharp.Data.Portable47.fsproj
@@ -98,7 +98,8 @@
   </Target> -->
   <Target Name="AfterBuild">
     <Copy SourceFiles="$(ProjectDir)$(OutDir)$(TargetName)$(TargetExt)" DestinationFolder="$(SolutionDir)bin\portable47" />
-    <Copy SourceFiles="$(ProjectDir)$(OutDir)$(TargetName).pdb" DestinationFolder="$(SolutionDir)bin\portable47" />
+    <Copy Condition="Exists('$(ProjectDir)$(OutDir)$(TargetName).pdb')" SourceFiles="$(ProjectDir)$(OutDir)$(TargetName).pdb" DestinationFolder="$(SolutionDir)bin\portable47" />
+    <Copy Condition="Exists('$(ProjectDir)$(OutDir)$(TargetName).mdb')" SourceFiles="$(ProjectDir)$(OutDir)$(TargetName).mdb" DestinationFolder="$(SolutionDir)bin\portable47" />
     <Copy SourceFiles="$(ProjectDir)$(OutDir)$(TargetName).xml" DestinationFolder="$(SolutionDir)bin\portable47" />
   </Target>
   <Import Project="$(SolutionDir)\.paket\paket.targets" />

--- a/tests/FSharp.Data.Tests/CsvProvider.fs
+++ b/tests/FSharp.Data.Tests/CsvProvider.fs
@@ -249,7 +249,7 @@ let ``Currency symbols on decimal columns should work``() =
 let ``AssumeMissingValues works when inferRows limit is reached``() = 
     let errorMessage =
         try
-            (CsvProvider<"Data/AdWords.csv", InferRows=4>.GetSample().Rows
+            (CsvProvider<"Data/Adwords.csv", InferRows=4>.GetSample().Rows
              |> Seq.skip 4 |> Seq.head).``Parent ID``.ToString()
         with e -> e.Message
     errorMessage |> should equal "Couldn't parse row 5 according to schema: Parent ID is missing"
@@ -284,8 +284,8 @@ let ``Csv without sample``() =
     row.id |> should equal "2"
     row.timestamp |> should equal "3"
 
-type UTF8 = CsvProvider<"data/cp932.csv", Culture = "ja-JP", HasHeaders = true, MissingValues = "NaN (非数値)">
-type CP932 = CsvProvider<"data/cp932.csv", Culture = "ja-JP", Encoding = "932", HasHeaders = true, MissingValues = "NaN (非数値)">
+type UTF8 = CsvProvider<"Data/cp932.csv", Culture = "ja-JP", HasHeaders = true, MissingValues = "NaN (非数値)">
+type CP932 = CsvProvider<"Data/cp932.csv", Culture = "ja-JP", Encoding = "932", HasHeaders = true, MissingValues = "NaN (非数値)">
 
 [<Test>]
 let ``Uses UTF8 for sample file when encoding not specified``() =

--- a/tests/FSharp.Data.Tests/JsonProvider.fs
+++ b/tests/FSharp.Data.Tests/JsonProvider.fs
@@ -521,7 +521,7 @@ let normalize (str:string) =
   str.Replace("\r\n", "\n")
      .Replace("\r", "\n")
 
-type GitHub = JsonProvider<"Data/github.json", RootName="Issue">
+type GitHub = JsonProvider<"Data/GitHub.json", RootName="Issue">
 
 [<Test>]
 let ``Can construct complex objects``() =
@@ -613,7 +613,7 @@ let ``Can construct heterogeneous arrays with optionals``() =
 
 [<Test>]
 let ``Weird UnitSystem case``() =
-    let comments = JsonProvider<"data/reddit.json">.GetSample()
+    let comments = JsonProvider<"Data/reddit.json">.GetSample()
     let data = comments.Data.Children.[0].Data
     data.LinkId |> shouldEqual "t3_2424px"
 

--- a/tests/FSharp.Data.Tests/XmlProvider.fs
+++ b/tests/FSharp.Data.Tests/XmlProvider.fs
@@ -69,7 +69,7 @@ let ``Jim should have an age of 24``() =
 
 [<Test>]
 let ``Type of attribute with empty value is string`` = 
-  XmlProvider<"data/emptyValue.xml">.GetSample().A |> shouldEqual ""
+  XmlProvider<"Data/emptyValue.xml">.GetSample().A |> shouldEqual ""
 
 [<Test>]
 let ``Xml with namespaces``() = 
@@ -79,7 +79,7 @@ let ``Xml with namespaces``() =
 
 [<Test>]
 let ``Can read config with heterogeneous attribute types``() =
-  let config = XmlProvider<"data/heterogeneous.xml">.GetSample()
+  let config = XmlProvider<"Data/heterogeneous.xml">.GetSample()
   let opts = 
     [ for opt in config.Options -> 
         let set = opt.Node.Set in set.Boolean, set.Number, set.String ]
@@ -182,7 +182,7 @@ let ``XML elements with same name in different namespaces``() =
 [<Test>]
 let ``Optionality inferred correctly for child elements``() =
 
-    let items = XmlProvider<"data/missingInnerValue.xml", SampleIsList=true>.GetSamples()
+    let items = XmlProvider<"Data/missingInnerValue.xml", SampleIsList=true>.GetSamples()
     
     items.Length |> should equal 2
     let child1 = items.[0]
@@ -201,7 +201,7 @@ let ``Optionality inferred correctly for child elements``() =
 [<Test>]
 let ``Global inference with empty elements doesn't crash``() =
 
-    let items = XmlProvider<"data/missingInnerValue.xml", SampleIsList=true, Global=true>.GetSamples()
+    let items = XmlProvider<"Data/missingInnerValue.xml", SampleIsList=true, Global=true>.GetSamples()
     
     items.Length |> should equal 2
     let child1 = items.[0]
@@ -246,21 +246,21 @@ let ``Infers type and reads mixed RSS/Atom feed document`` () =
 
 [<Test>]
 let ``Optional value elements should work at runtime when attribute is missing`` () =
-    let samples = XmlProvider<"data/optionals1.xml", SampleIsList=true>.GetSamples()
+    let samples = XmlProvider<"Data/optionals1.xml", SampleIsList=true>.GetSamples()
     samples.[0].Description |> should equal (Some "B")
     samples.[1].Description |> should equal None
     samples.[2].Description |> should equal None
 
 [<Test>]
 let ``Optional value elements should work at runtime when element is missing`` () =
-    let samples = XmlProvider<"data/optionals2.xml", SampleIsList=true>.GetSamples()
+    let samples = XmlProvider<"Data/optionals2.xml", SampleIsList=true>.GetSamples()
     samples.[0].Channel.Items.[0].Description |> should equal None
     samples.[0].Channel.Items.[1].Description |> should equal (Some "A")
     samples.[1].Channel.Items.[0].Description |> should equal None
 
 [<Test>]
 let ``Optional value elements should work at runtime when element is missing 2`` () =
-    let samples = XmlProvider<"data/optionals3.xml", SampleIsList=true>.GetSamples()
+    let samples = XmlProvider<"Data/optionals3.xml", SampleIsList=true>.GetSamples()
     samples.[0].Channel.Items.[0].Title |> should equal (Some "A")
     samples.[1].Channel.Items.[0].Title |> should equal None
     samples.[1].Channel.Items.[1].Title |> should equal (Some "B")
@@ -281,7 +281,7 @@ let ``Collections are collapsed into just one element 2``() =
     x.Locations.[0].AvailableServices |> should equal ["Compute"; "Storage"]
     x.Locations.[1].AvailableServices |> should equal ["Compute"; "Storage"; "PersistentVMRole"; "HighMemory"]
 
-type JsonInXml = XmlProvider<"data/JsonInXml.xml", SampleIsList=true>
+type JsonInXml = XmlProvider<"Data/JsonInXml.xml", SampleIsList=true>
 
 [<Test>]
 let ``Json inside Xml``() =


### PR DESCRIPTION
1. Adjust debug extension for mono (.mdb) on profile 47
2. Test paths need to be case-sensitive
