### PR TITLE
Don't infer types twice for headerless HTML tables

### DIFF
--- a/src/Html/HtmlInference.fs
+++ b/src/Html/HtmlInference.fs
@@ -13,17 +13,22 @@ let inferColumns preferOptionals missingValues cultureInfo (headerNamesAndUnits:
 
     CsvInference.inferColumnTypes headerNamesAndUnits schema rows inferRows missingValues cultureInfo assumeMissingValues preferOptionals
 
-let inferHeaders missingValues cultureInfo (rows : string [][]) =
+let inferHeaders missingValues cultureInfo unitsOfMeasureProvider preferOptionals (rows : string [][]) =
     if rows.Length <= 2
-    then 0, None, None //Not enough info to infer anything, assume first row data
+    then 0, None, None, None //Not enough info to infer anything, assume first row data
     else
-      let preferOptionals = false // it's irrelevant for this step
+      let headersAndUnits, _ = CsvInference.parseHeaders (Some rows.[0]) rows.[0].Length "" unitsOfMeasureProvider
+      let headerNames = headersAndUnits |> Array.map fst
+      let headerUnits = headersAndUnits |> Array.map snd
       let computeRowType row = 
+          // Zip units and values to infer cell types
           let cellTypes =
             row
-            |> Array.map (CsvInference.inferCellType preferOptionals missingValues cultureInfo None)
-          let props = // Zip headers and types to build properly named InferedTypes
-            Array.zip rows.[0] cellTypes 
+            |> Array.zip headerUnits
+            |> Array.map (fun p -> CsvInference.inferCellType preferOptionals missingValues cultureInfo (fst p) (snd p))
+          // Zip headers and types to build InferedTypes with proper names
+          let props = 
+            Array.zip headerNames cellTypes 
             |> Array.map (fun p -> {Name = fst p; Type = snd p})
             |> List.ofArray
           InferedType.Record(None, props, false)
@@ -33,7 +38,7 @@ let inferHeaders missingValues cultureInfo (rows : string [][]) =
       let dataRow =
         rows.[1..]
         |> Array.map computeRowType
-        |> Array.reduce (subtypeInfered preferOptionals)
+        |> Array.reduce (subtypeInfered (not preferOptionals))
       if headerRow = dataRow
-      then 0, None, Some dataRow
-      else 1, Some rows.[0], Some dataRow
+      then 0, None, None, Some dataRow
+      else 1, Some headerNames, Some headerUnits, Some dataRow

--- a/src/Html/HtmlProvider.fs
+++ b/src/Html/HtmlProvider.fs
@@ -40,7 +40,7 @@ type public HtmlProvider(cfg:TypeProviderConfig) as this =
                 let missingValues = TextRuntime.GetMissingValues missingValuesStr
                 let cultureInfo = TextRuntime.GetCulture cultureStr
                 doc
-                |> HtmlRuntime.getTables includeLayoutTables missingValues cultureInfo (Some ProviderHelpers.unitsOfMeasureProvider)
+                |> HtmlRuntime.getTables includeLayoutTables missingValues cultureInfo (Some ProviderHelpers.unitsOfMeasureProvider) preferOptionals
                 |> List.map (fun table -> table.Name,
                                           match table.InferedType with //Type may already be inferred
                                           | Some typ -> CsvInference.getFields
@@ -59,7 +59,7 @@ type public HtmlProvider(cfg:TypeProviderConfig) as this =
 
             { GeneratedType = htmlType
               RepresentationType = htmlType
-              CreateFromTextReader = fun reader -> replacer.ToRuntime <@@ TypedHtmlDocument.Create(includeLayoutTables, missingValuesStr, cultureStr, %reader) @@>                    
+              CreateFromTextReader = fun reader -> replacer.ToRuntime <@@ TypedHtmlDocument.Create(includeLayoutTables, missingValuesStr, cultureStr, preferOptionals, %reader) @@>                    
               CreateFromTextReaderForSampleList = fun _ -> failwith "Not Applicable" }
 
         generateType "HTML" sample (*sampleIsList*)false (fun _ -> HtmlDocument.Parse) (fun _ _ -> failwith "Not Applicable")

--- a/src/Html/HtmlRuntime.fs
+++ b/src/Html/HtmlRuntime.fs
@@ -103,7 +103,7 @@ module HtmlRuntime =
                      | _ -> defaultName
                 | h :: _ -> h.InnerText()
                 
-    let private parseTable includeLayoutTables missingValues cultureInfo unitsOfMeasureProvider makeUnique index (table:HtmlNode, parents:HtmlNode list)= 
+    let private parseTable includeLayoutTables missingValues cultureInfo unitsOfMeasureProvider preferOptionals makeUnique index (table:HtmlNode, parents:HtmlNode list) = 
 
         let rows = table.Descendants(["tr"], true, false) |> List.mapi (fun i r -> i,r)
         
@@ -135,12 +135,18 @@ module HtmlRuntime =
                         if i < rows.Length && j < numberOfColumns
                         then res.[i].[j] <- data
 
-        let startIndex, headers, inferedType = 
+        let startIndex, headers, units, inferedType = 
             if res.[0] |> Array.forall (fun r -> r.IsHeader) 
-            then 1, res.[0] |> Array.map (fun x -> x.Data) |> Some, None
-            else res |> Array.map (Array.map (fun x -> x.Data)) |> HtmlInference.inferHeaders missingValues cultureInfo
-            
-        let headerNamesAndUnits, _ = CsvInference.parseHeaders headers numberOfColumns "" unitsOfMeasureProvider
+            then 1, res.[0] |> Array.map (fun x -> x.Data) |> Some, None, None
+            else res
+                  |> Array.map (Array.map (fun x -> x.Data))
+                  |> HtmlInference.inferHeaders missingValues cultureInfo unitsOfMeasureProvider preferOptionals
+        
+        // headers and units may already be parsed in inferHeaders
+        let headerNamesAndUnits =
+          match (headers, units) with
+          | Some h, Some u -> Array.zip h u
+          | _, _ -> CsvInference.parseHeaders headers numberOfColumns "" unitsOfMeasureProvider |> fst
 
         let tableName = makeUnique (getTableName (sprintf "Table%d" (index + 1)) table parents)
         let rows = res.[startIndex..] |> Array.map (Array.map (fun x -> x.Data))
@@ -151,7 +157,7 @@ module HtmlRuntime =
                Rows = rows 
                Html = table }
 
-    let getTables includeLayoutTables missingValues cultureInfo unitsOfMeasureProvider (doc:HtmlDocument) =
+    let getTables includeLayoutTables missingValues cultureInfo unitsOfMeasureProvider preferOptionals (doc:HtmlDocument) =
 
         let tableElements = 
             [ doc.Elements ["table"]
@@ -170,7 +176,7 @@ module HtmlRuntime =
                 )
         
         tableElements
-        |> List.mapi (parseTable includeLayoutTables missingValues cultureInfo unitsOfMeasureProvider (NameUtils.uniqueGenerator id))
+        |> List.mapi (parseTable includeLayoutTables missingValues cultureInfo unitsOfMeasureProvider preferOptionals (NameUtils.uniqueGenerator id))
         |> List.choose id
 
 type TypedHtmlDocument internal (doc:HtmlDocument, tables:Map<string,HtmlTable>) =
@@ -180,7 +186,7 @@ type TypedHtmlDocument internal (doc:HtmlDocument, tables:Map<string,HtmlTable>)
     /// [omit]
     [<EditorBrowsableAttribute(EditorBrowsableState.Never)>]
     [<CompilerMessageAttribute("This method is intended for use in generated code only.", 10001, IsHidden=true, IsError=false)>]
-    static member Create(includeLayoutTables, missingValuesStr, cultureStr, reader:TextReader) =
+    static member Create(includeLayoutTables, missingValuesStr, cultureStr, preferOptionals, reader:TextReader) =
         let missingValues = TextRuntime.GetMissingValues missingValuesStr
         let cultureInfo = TextRuntime.GetCulture cultureStr
         let doc = 
@@ -188,7 +194,7 @@ type TypedHtmlDocument internal (doc:HtmlDocument, tables:Map<string,HtmlTable>)
             |> HtmlDocument.Load
         let tables = 
             doc
-            |> HtmlRuntime.getTables includeLayoutTables missingValues cultureInfo None
+            |> HtmlRuntime.getTables includeLayoutTables missingValues cultureInfo None preferOptionals
             |> List.map (fun table -> table.Name, table) 
             |> Map.ofList
         TypedHtmlDocument(doc, tables)

--- a/src/Test.fsx
+++ b/src/Test.fsx
@@ -99,7 +99,7 @@ printParsed """<a href="/url?q=http://fsharp.github.io/FSharp.Data/&amp;sa=U&amp
 let printTables includeLayout (url:string) = 
     url
     |> HtmlDocument.Load
-    |> HtmlRuntime.getTables includeLayout TextConversions.DefaultMissingValues CultureInfo.InvariantCulture (Some ProviderHelpers.unitsOfMeasureProvider)
+    |> HtmlRuntime.getTables includeLayout TextConversions.DefaultMissingValues CultureInfo.InvariantCulture (Some ProviderHelpers.unitsOfMeasureProvider) false
     |> List.iter (printfn "+++++++++++++++++++++++++++++++++++++\n%O")
 
 printTables false "http://en.wikipedia.org/wiki/List_of_Presidents_of_the_United_States"

--- a/tests/FSharp.Data.Tests/HtmlParser.fs
+++ b/tests/FSharp.Data.Tests/HtmlParser.fs
@@ -15,7 +15,7 @@ open FSharp.Data.HtmlDocument
 open FSharp.Data.HtmlNode
 
 let getTables includeLayoutTables = 
-    HtmlRuntime.getTables includeLayoutTables TextConversions.DefaultMissingValues CultureInfo.InvariantCulture (Some StructuralInference.defaultUnitsOfMeasureProvider)
+    HtmlRuntime.getTables includeLayoutTables TextConversions.DefaultMissingValues CultureInfo.InvariantCulture (Some StructuralInference.defaultUnitsOfMeasureProvider) false
 
 [<Test>]
 let ``Can handle unclosed tags correctly``() = 

--- a/tests/FSharp.Data.Tests/HtmlProvider.fs
+++ b/tests/FSharp.Data.Tests/HtmlProvider.fs
@@ -127,6 +127,7 @@ let ``Should parse units from inferred table headers``() =
                         <table>
                             <tr><td>Date</td><td>Distance (m)</td><td>Time (s)</td><td>Column 3</td><td>Column 4</td></tr>
                             <tr><td>01/01/2013 12:00</td><td>1.5</td><td>30.5</td><td>2</td><td>2</td></tr>
+                            <tr><td>01/01/2013 12:00</td><td>1.5</td><td>30.5</td><td>2</td><td>2</td></tr>
                         </table>
                     </body>
                 </html>""">.GetSample().Tables.Table1


### PR DESCRIPTION
Return type inference result from HtmlInference.inferHeaders for later reuse in HtmlProvider. This might resolve #705.

I also noticed HtmlTable.HeaderNamesAndUnits would seemingly never have any units because there is no "schema" provided, but I'm not sure it makes sense to refactor or if it's there for CsvInference compatibility, etc.
