### PR TITLE
capitalizeFirstLetter handle empty and one char strings correctly - issue 746.

### DIFF
--- a/src/CommonRuntime/NameUtils.fs
+++ b/src/CommonRuntime/NameUtils.fs
@@ -93,9 +93,10 @@ let uniqueGenerator niceName =
     set.Add name |> ignore
     name
 
-let capitalizeFirstLetter (s:string) =
-    match s with
-        | null | "" -> s
+let capitalizeFirstLetter (s:string) =    
+    match s.Length with
+        | 0 -> ""
+        | 1 -> (Char.ToUpperInvariant s.[0]).ToString()                
         | _ -> (Char.ToUpperInvariant s.[0]).ToString() + s.Substring(1)
 
 /// Trim HTML tags from a given string and replace all of them with spaces


### PR DESCRIPTION
Fix an error in capitalizeFirstLetter in NameUtil.fs.  The current implementation breaks If s is an empty or null string - see issue 746. Please consider adding a null check if necessary - I did not to keep the code clean.
