### PR TITLE
Recognise media types application/*+json as text

### DIFF
--- a/src/Net/Http.fs
+++ b/src/Net/Http.fs
@@ -553,7 +553,8 @@ module private HttpHelpers =
                 mimeType = HttpContentTypes.JavaScript ||
                 mimeType = "application/ecmascript" ||
                 mimeType = "application/xml-dtd" ||
-                mimeType.StartsWith "application/" && mimeType.EndsWith "+xml"
+                mimeType.StartsWith "application/" && mimeType.EndsWith "+xml" ||
+                mimeType.StartsWith "application/" && mimeType.EndsWith "+json"
             mimeType.Split([| ';' |], StringSplitOptions.RemoveEmptyEntries)
             |> Array.exists isText
 


### PR DESCRIPTION
I'm working with a domain specific REST API which indicates that the underlying representation uses JSON by putting +json at the end. I've added a case to recognise these as text in the same way as xml is currently.
