### PR TITLE
Csv write API.

### DIFF
--- a/src/CommonProviderImplementation/Debug.fs
+++ b/src/CommonProviderImplementation/Debug.fs
@@ -403,16 +403,23 @@ module Debug =
                 print str
                 println()
 
+            // Translate parameter type to erased types - work around EraseType trying to instantiate UoM as generic type
+            let matchGeneric = function | SymbolKind.Generic td when not td.IsGenericTypeDefinition -> true | _ -> false
+            let transParamType (t : Type) =
+                match t with
+                | :? ProvidedSymbolType as sym when matchGeneric sym.Kind -> t
+                | _ -> ProvidedTypeDefinition.EraseType t
+
             let getMethodBody (m: ProvidedMethod) = 
-                seq { if not m.IsStatic then yield (ProvidedTypeDefinition.EraseType m.DeclaringType)
-                      for param in m.GetParameters() do yield (ProvidedTypeDefinition.EraseType param.ParameterType) }
+                seq { if not m.IsStatic then yield (transParamType m.DeclaringType)
+                      for param in m.GetParameters() do yield (transParamType param.ParameterType) }
                 |> Seq.map (fun typ -> Expr.Value(null, typ))
                 |> Array.ofSeq
                 |> m.GetInvokeCodeInternal false
 
             let getConstructorBody (c: ProvidedConstructor) = 
                 if c.IsImplicitCtor then Expr.Value(()) else
-                seq { for param in c.GetParameters() do yield (ProvidedTypeDefinition.EraseType param.ParameterType) }
+                seq { for param in c.GetParameters() do yield (transParamType param.ParameterType) }
                 |> Seq.map (fun typ -> Expr.Value(null, typ))
                 |> Array.ofSeq
                 |> c.GetInvokeCodeInternal false

--- a/src/CommonProviderImplementation/ProvidedTypes.fs
+++ b/src/CommonProviderImplementation/ProvidedTypes.fs
@@ -1290,9 +1290,6 @@ type ProvidedTypeDefinition(container:TypeContainer,className : string, baseType
             | SymbolKind.SDArray, [typ] -> 
                 let (t:Type) = ProvidedTypeDefinition.EraseType typ
                 t.MakeArrayType()
-            | SymbolKind.Generic genericTypeDefinition, _ when not genericTypeDefinition.IsGenericTypeDefinition -> 
-                // Unit of measure parameters can match here, but not really generic types.
-                genericTypeDefinition.UnderlyingSystemType
             | SymbolKind.Generic genericTypeDefinition, typeArgs ->
                 let genericArguments =
                   typeArgs

--- a/src/CommonProviderImplementation/ProvidedTypes.fs
+++ b/src/CommonProviderImplementation/ProvidedTypes.fs
@@ -1290,6 +1290,9 @@ type ProvidedTypeDefinition(container:TypeContainer,className : string, baseType
             | SymbolKind.SDArray, [typ] -> 
                 let (t:Type) = ProvidedTypeDefinition.EraseType typ
                 t.MakeArrayType()
+            | SymbolKind.Generic genericTypeDefinition, _ when not genericTypeDefinition.IsGenericTypeDefinition -> 
+                // Unit of measure parameters can match here, but not really generic types.
+                genericTypeDefinition.UnderlyingSystemType
             | SymbolKind.Generic genericTypeDefinition, typeArgs ->
                 let genericArguments =
                   typeArgs

--- a/src/Csv/CsvGenerator.fs
+++ b/src/Csv/CsvGenerator.fs
@@ -18,7 +18,8 @@ module internal CsvTypeBuilder =
     { TypeForTuple : Type
       Property : ProvidedProperty
       Convert: Expr -> Expr
-      ConvertBack: Expr -> Expr }
+      ConvertBack: Expr -> Expr
+      Param : ProvidedParameter }
 
   let generateTypes asm ns typeName (missingValuesStr, cultureStr) replacer inferredFields =
     
@@ -28,7 +29,8 @@ module internal CsvTypeBuilder =
       { TypeForTuple = typWithoutMeasure
         Property = ProvidedProperty(propertyName, typ, GetterCode = fun (Singleton row) -> Expr.TupleGet(row, index))
         Convert = fun rowVarExpr -> conv <@ TextConversions.AsString((%%rowVarExpr:string[]).[index]) @>
-        ConvertBack = fun rowVarExpr -> convBack (Expr.TupleGet(rowVarExpr, index)) } )
+        ConvertBack = fun rowVarExpr -> convBack (Expr.TupleGet(rowVarExpr, index))
+        Param = ProvidedParameter(propertyName, typ) } )
 
     // The erased row type will be a tuple of all the field types (without the units of measure)
     let rowErasedType = 
@@ -36,6 +38,9 @@ module internal CsvTypeBuilder =
       |> replacer.ToRuntime
     
     let rowType = ProvidedTypeDefinition("Row", Some rowErasedType, HideObjectMethods = true)
+
+    let ctor = ProvidedConstructor([ for field in fields -> field.Param ], InvokeCode = (fun args -> Expr.NewTuple(args) ))
+    rowType.AddMember ctor
     
     // Each property of the generated row type will simply be a tuple get
     for field in fields do
@@ -76,4 +81,4 @@ module internal CsvTypeBuilder =
 
       Expr.NewDelegate(delegateType, [rowVar], body)
 
-    csvType, csvErasedTypeWithRowErasedType, stringArrayToRow, rowToStringArray
+    csvType, csvErasedTypeWithRowErasedType, rowType, stringArrayToRow, rowToStringArray

--- a/src/Csv/CsvGenerator.fs
+++ b/src/Csv/CsvGenerator.fs
@@ -30,7 +30,7 @@ module internal CsvTypeBuilder =
         Property = ProvidedProperty(propertyName, typ, GetterCode = fun (Singleton row) -> Expr.TupleGet(row, index))
         Convert = fun rowVarExpr -> conv <@ TextConversions.AsString((%%rowVarExpr:string[]).[index]) @>
         ConvertBack = fun rowVarExpr -> convBack (Expr.TupleGet(rowVarExpr, index))
-        Param = ProvidedParameter(propertyName, typ) } )
+        Param = ProvidedParameter(NameUtils.niceCamelName propertyName, typ) } )
 
     // The erased row type will be a tuple of all the field types (without the units of measure)
     let rowErasedType = 

--- a/src/Csv/CsvProvider.fs
+++ b/src/Csv/CsvProvider.fs
@@ -75,15 +75,26 @@ type public CsvProvider(cfg:TypeProviderConfig) as this =
 
       using (IO.logTime "TypeGeneration" sample) <| fun _ ->
 
-      let csvType, csvErasedType, stringArrayToRow, rowToStringArray = 
+      let csvType, csvErasedType, rowType, stringArrayToRow, rowToStringArray = 
         inferredFields 
         |> CsvTypeBuilder.generateTypes asm ns typeName (missingValuesStr, cultureStr) replacer 
-  
+
+
+      let stringArrayToRowVar = Var("stringArrayToRow", stringArrayToRow.Type)
+      let rowToStringArrayVar = Var("rowToStringArray", rowToStringArray.Type)
+      
+      let paramType = (replacer.ToRuntime typedefof<seq<_>>).MakeGenericType(rowType)
+      let headers = match sampleCsv.Headers with 
+            | None -> <@@ None: string[] option @@> 
+            | Some headers -> Expr.NewArray(typeof<string>, headers |> Array.map (fun h -> Expr.Value(h)) |> List.ofArray) |> (fun x-> <@@ Some (%%x : string[]) @@>)
+      let newfn = ProvidedMethod("New", [ ProvidedParameter("rows", paramType) ], csvType, IsStaticMethod = true, InvokeCode = (fun (Singleton paramValue) ->
+        let body = csvErasedType?CreateEmpty () (Expr.Var rowToStringArrayVar, paramValue, replacer.ToRuntime headers,  sampleCsv.NumberOfColumns, separators, quote)
+        Expr.Let(rowToStringArrayVar, rowToStringArray, body)))
+      csvType.AddMember(newfn) 
+       
       { GeneratedType = csvType
         RepresentationType = csvType
         CreateFromTextReader = fun reader ->
-          let stringArrayToRowVar = Var("stringArrayToRow", stringArrayToRow.Type)
-          let rowToStringArrayVar = Var("rowToStringArray", rowToStringArray.Type)
           let body = 
             csvErasedType?Create () (Expr.Var stringArrayToRowVar, Expr.Var rowToStringArrayVar, replacer.ToRuntime reader, 
                                               separators, quote, hasHeaders, ignoreErrors, skipRows, cacheRows)

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Csv,AirQuality.csv,;,,True,False,False,,,.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Csv,AirQuality.csv,;,,True,False,False,,,.expected
@@ -1,4 +1,19 @@
 class CsvProvider : FDR.CsvFile<CsvProvider+Row>
+    new : rows:CsvProvider+Row seq -> CsvProvider
+    let rowToStringArray = new Func<_,_>(fun (row:_ * _ * _ * _ * _ * _) -> 
+                                            [| TextRuntime.ConvertFloatBack("", "", Some (let t1,_,_,_,_,_ = row in t1))
+                                               TextRuntime.ConvertFloatBack("", "", Some (let _,t2,_,_,_,_ = row in t2))
+                                               TextRuntime.ConvertDecimalBack("", Some (let _,_,t3,_,_,_ = row in t3))
+                                               TextRuntime.ConvertIntegerBack("", Some (let _,_,_,t4,_,_ = row in t4))
+                                               TextRuntime.ConvertIntegerBack("", Some (let _,_,_,_,t5,_ = row in t5))
+                                               TextRuntime.ConvertIntegerBack("", Some (let _,_,_,_,_,t6 = row in t6)) |])
+    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "Ozone"
+                                                           "Solar.R"
+                                                           "Wind"
+                                                           "Temp"
+                                                           "Month"
+                                                           "Day" |], 6, ";", '"')
+
     new : () -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -164,21 +179,6 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
                                                TextRuntime.ConvertIntegerBack("", Some (let _,_,_,_,_,t6 = row in t6)) |])
     CsvFile<_>.Create(stringArrayToRow, rowToStringArray, FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false @"<RESOLUTION_FOLDER>" "" "CSV" "" uri)), ";", '"', true, false, 0, false)
 
-    static member New: rows:CsvProvider+Row seq -> CsvProvider
-    let rowToStringArray = new Func<_,_>(fun (row:_ * _ * _ * _ * _ * _) -> 
-                                            [| TextRuntime.ConvertFloatBack("", "", Some (let t1,_,_,_,_,_ = row in t1))
-                                               TextRuntime.ConvertFloatBack("", "", Some (let _,t2,_,_,_,_ = row in t2))
-                                               TextRuntime.ConvertDecimalBack("", Some (let _,_,t3,_,_,_ = row in t3))
-                                               TextRuntime.ConvertIntegerBack("", Some (let _,_,_,t4,_,_ = row in t4))
-                                               TextRuntime.ConvertIntegerBack("", Some (let _,_,_,_,t5,_ = row in t5))
-                                               TextRuntime.ConvertIntegerBack("", Some (let _,_,_,_,_,t6 = row in t6)) |])
-    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "Ozone"
-                                                           "Solar.R"
-                                                           "Wind"
-                                                           "Temp"
-                                                           "Month"
-                                                           "Day" |], 6, ";", '"')
-
     static member Parse: text:string -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -204,13 +204,13 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
 
 
 class CsvProvider+Row : float * float * decimal * int * int * int
-    new : Ozone:float -> Solar.R:float -> Wind:decimal -> Temp:int -> Month:int -> Day:int -> CsvProvider+Row
-    Ozone,
-    Solar.R,
-    Wind,
-    Temp,
-    Month,
-    Day
+    new : ozone:float -> solarR:float -> wind:decimal -> temp:int -> month:int -> day:int -> CsvProvider+Row
+    ozone,
+    solarR,
+    wind,
+    temp,
+    month,
+    day
 
     member Day: int with get
     (let _,_,_,_,_,t6 = this in t6)

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Csv,AirQuality.csv,;,,True,False,False,,,.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Csv,AirQuality.csv,;,,True,False,False,,,.expected
@@ -164,6 +164,21 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
                                                TextRuntime.ConvertIntegerBack("", Some (let _,_,_,_,_,t6 = row in t6)) |])
     CsvFile<_>.Create(stringArrayToRow, rowToStringArray, FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false @"<RESOLUTION_FOLDER>" "" "CSV" "" uri)), ";", '"', true, false, 0, false)
 
+    static member New: rows:CsvProvider+Row seq -> CsvProvider
+    let rowToStringArray = new Func<_,_>(fun (row:_ * _ * _ * _ * _ * _) -> 
+                                            [| TextRuntime.ConvertFloatBack("", "", Some (let t1,_,_,_,_,_ = row in t1))
+                                               TextRuntime.ConvertFloatBack("", "", Some (let _,t2,_,_,_,_ = row in t2))
+                                               TextRuntime.ConvertDecimalBack("", Some (let _,_,t3,_,_,_ = row in t3))
+                                               TextRuntime.ConvertIntegerBack("", Some (let _,_,_,t4,_,_ = row in t4))
+                                               TextRuntime.ConvertIntegerBack("", Some (let _,_,_,_,t5,_ = row in t5))
+                                               TextRuntime.ConvertIntegerBack("", Some (let _,_,_,_,_,t6 = row in t6)) |])
+    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "Ozone"
+                                                           "Solar.R"
+                                                           "Wind"
+                                                           "Temp"
+                                                           "Month"
+                                                           "Day" |], 6, ";", '"')
+
     static member Parse: text:string -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -189,6 +204,14 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
 
 
 class CsvProvider+Row : float * float * decimal * int * int * int
+    new : Ozone:float -> Solar.R:float -> Wind:decimal -> Temp:int -> Month:int -> Day:int -> CsvProvider+Row
+    Ozone,
+    Solar.R,
+    Wind,
+    Temp,
+    Month,
+    Day
+
     member Day: int with get
     (let _,_,_,_,_,t6 = this in t6)
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Csv,DnbHistoriskeKurser.csv,,,True,False,False,,nb-NO,.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Csv,DnbHistoriskeKurser.csv,,,True,False,False,,nb-NO,.expected
@@ -1,4 +1,29 @@
 class CsvProvider : FDR.CsvFile<CsvProvider+Row>
+    new : rows:CsvProvider+Row seq -> CsvProvider
+    let rowToStringArray = new Func<_,_>(fun (row:_ * _ * _ * _ * _ * _ * _ * _) -> 
+                                            [| TextRuntime.ConvertDateTimeBack("nb-NO", Some (let t1,_,_,_,_,_,_,_,_,_,_ = row in t1))
+                                               TextRuntime.ConvertStringBack(Some (let _,t2,_,_,_,_,_,_,_,_,_ = row in t2))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,t3,_,_,_,_,_,_,_,_ = row in t3))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,t4,_,_,_,_,_,_,_ = row in t4))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,t5,_,_,_,_,_,_ = row in t5))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,t6,_,_,_,_,_ = row in t6))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,t7,_,_,_,_ = row in t7))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,t8,_,_,_ = row in t8))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,t9,_,_ = row in t9))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,_,t10,_ = row in t10))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,_,_,t11 = row in t11)) |])
+    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "Dato"
+                                                           "USD"
+                                                           "EUR"
+                                                           "SEK"
+                                                           "DKK"
+                                                           "GBP"
+                                                           "CHF"
+                                                           "JPY"
+                                                           "CAD"
+                                                           "ISK"
+                                                           "AUD" |], 11, ",", '"')
+
     new : () -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -269,31 +294,6 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
                                                TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,_,_,t11 = row in t11)) |])
     CsvFile<_>.Create(stringArrayToRow, rowToStringArray, FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false @"<RESOLUTION_FOLDER>" "" "CSV" "" uri)), ",", '"', true, false, 0, false)
 
-    static member New: rows:CsvProvider+Row seq -> CsvProvider
-    let rowToStringArray = new Func<_,_>(fun (row:_ * _ * _ * _ * _ * _ * _ * _) -> 
-                                            [| TextRuntime.ConvertDateTimeBack("nb-NO", Some (let t1,_,_,_,_,_,_,_,_,_,_ = row in t1))
-                                               TextRuntime.ConvertStringBack(Some (let _,t2,_,_,_,_,_,_,_,_,_ = row in t2))
-                                               TextRuntime.ConvertStringBack(Some (let _,_,t3,_,_,_,_,_,_,_,_ = row in t3))
-                                               TextRuntime.ConvertStringBack(Some (let _,_,_,t4,_,_,_,_,_,_,_ = row in t4))
-                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,t5,_,_,_,_,_,_ = row in t5))
-                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,t6,_,_,_,_,_ = row in t6))
-                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,t7,_,_,_,_ = row in t7))
-                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,t8,_,_,_ = row in t8))
-                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,t9,_,_ = row in t9))
-                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,_,t10,_ = row in t10))
-                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,_,_,t11 = row in t11)) |])
-    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "Dato"
-                                                           "USD"
-                                                           "EUR"
-                                                           "SEK"
-                                                           "DKK"
-                                                           "GBP"
-                                                           "CHF"
-                                                           "JPY"
-                                                           "CAD"
-                                                           "ISK"
-                                                           "AUD" |], 11, ",", '"')
-
     static member Parse: text:string -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -334,18 +334,18 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
 
 
 class CsvProvider+Row : System.DateTime * string * string * string * string * string * string * string * string * string * string
-    new : Dato:System.DateTime -> USD:string -> EUR:string -> SEK:string -> DKK:string -> GBP:string -> CHF:string -> JPY:string -> CAD:string -> ISK:string -> AUD:string -> CsvProvider+Row
-    Dato,
-    USD,
-    EUR,
-    SEK,
-    DKK,
-    GBP,
-    CHF,
-    JPY,
-    CAD,
-    ISK,
-    AUD
+    new : dato:System.DateTime -> usd:string -> eur:string -> sek:string -> dkk:string -> gbp:string -> chf:string -> jpy:string -> cad:string -> isk:string -> aud:string -> CsvProvider+Row
+    dato,
+    usd,
+    eur,
+    sek,
+    dkk,
+    gbp,
+    chf,
+    jpy,
+    cad,
+    isk,
+    aud
 
     member AUD: string with get
     (let _,_,_,_,_,_,_,_,_,_,t11 = this in t11)

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Csv,DnbHistoriskeKurser.csv,,,True,False,False,,nb-NO,.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Csv,DnbHistoriskeKurser.csv,,,True,False,False,,nb-NO,.expected
@@ -269,6 +269,31 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
                                                TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,_,_,t11 = row in t11)) |])
     CsvFile<_>.Create(stringArrayToRow, rowToStringArray, FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false @"<RESOLUTION_FOLDER>" "" "CSV" "" uri)), ",", '"', true, false, 0, false)
 
+    static member New: rows:CsvProvider+Row seq -> CsvProvider
+    let rowToStringArray = new Func<_,_>(fun (row:_ * _ * _ * _ * _ * _ * _ * _) -> 
+                                            [| TextRuntime.ConvertDateTimeBack("nb-NO", Some (let t1,_,_,_,_,_,_,_,_,_,_ = row in t1))
+                                               TextRuntime.ConvertStringBack(Some (let _,t2,_,_,_,_,_,_,_,_,_ = row in t2))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,t3,_,_,_,_,_,_,_,_ = row in t3))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,t4,_,_,_,_,_,_,_ = row in t4))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,t5,_,_,_,_,_,_ = row in t5))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,t6,_,_,_,_,_ = row in t6))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,t7,_,_,_,_ = row in t7))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,t8,_,_,_ = row in t8))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,t9,_,_ = row in t9))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,_,t10,_ = row in t10))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,_,_,t11 = row in t11)) |])
+    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "Dato"
+                                                           "USD"
+                                                           "EUR"
+                                                           "SEK"
+                                                           "DKK"
+                                                           "GBP"
+                                                           "CHF"
+                                                           "JPY"
+                                                           "CAD"
+                                                           "ISK"
+                                                           "AUD" |], 11, ",", '"')
+
     static member Parse: text:string -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -309,6 +334,19 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
 
 
 class CsvProvider+Row : System.DateTime * string * string * string * string * string * string * string * string * string * string
+    new : Dato:System.DateTime -> USD:string -> EUR:string -> SEK:string -> DKK:string -> GBP:string -> CHF:string -> JPY:string -> CAD:string -> ISK:string -> AUD:string -> CsvProvider+Row
+    Dato,
+    USD,
+    EUR,
+    SEK,
+    DKK,
+    GBP,
+    CHF,
+    JPY,
+    CAD,
+    ISK,
+    AUD
+
     member AUD: string with get
     (let _,_,_,_,_,_,_,_,_,_,t11 = this in t11)
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Csv,LastFM.tsv,,,False,False,False,,,.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Csv,LastFM.tsv,,,False,False,False,,,.expected
@@ -157,6 +157,16 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
                                                TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,t6 = row in t6)) |])
     CsvFile<_>.Create(stringArrayToRow, rowToStringArray, FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false @"<RESOLUTION_FOLDER>" "" "CSV" "" uri)), "	", '"', false, false, 0, false)
 
+    static member New: rows:CsvProvider+Row seq -> CsvProvider
+    let rowToStringArray = new Func<_,_>(fun (row:_ * _ * _ * _ * _ * _) -> 
+                                            [| TextRuntime.ConvertStringBack(Some (let t1,_,_,_,_,_ = row in t1))
+                                               TextRuntime.ConvertDateTimeBack("", Some (let _,t2,_,_,_,_ = row in t2))
+                                               TextRuntime.ConvertGuidBack((let _,_,t3,_,_,_ = row in t3))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,t4,_,_ = row in t4))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,t5,_ = row in t5))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,t6 = row in t6)) |])
+    CsvFile<_>.CreateEmpty(rowToStringArray, rows, None, 6, "	", '"')
+
     static member Parse: text:string -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -181,6 +191,14 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
 
 
 class CsvProvider+Row : string * System.DateTime * System.Guid option * string * string * string
+    new : Column1:string -> Column2:System.DateTime -> Column3:System.Guid option -> Column4:string -> Column5:string -> Column6:string -> CsvProvider+Row
+    Column1,
+    Column2,
+    Column3,
+    Column4,
+    Column5,
+    Column6
+
     member Column1: string with get
     (let t1,_,_,_,_,_ = this in t1)
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Csv,LastFM.tsv,,,False,False,False,,,.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Csv,LastFM.tsv,,,False,False,False,,,.expected
@@ -1,4 +1,14 @@
 class CsvProvider : FDR.CsvFile<CsvProvider+Row>
+    new : rows:CsvProvider+Row seq -> CsvProvider
+    let rowToStringArray = new Func<_,_>(fun (row:_ * _ * _ * _ * _ * _) -> 
+                                            [| TextRuntime.ConvertStringBack(Some (let t1,_,_,_,_,_ = row in t1))
+                                               TextRuntime.ConvertDateTimeBack("", Some (let _,t2,_,_,_,_ = row in t2))
+                                               TextRuntime.ConvertGuidBack((let _,_,t3,_,_,_ = row in t3))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,t4,_,_ = row in t4))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,t5,_ = row in t5))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,t6 = row in t6)) |])
+    CsvFile<_>.CreateEmpty(rowToStringArray, rows, None, 6, "	", '"')
+
     new : () -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -157,16 +167,6 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
                                                TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,t6 = row in t6)) |])
     CsvFile<_>.Create(stringArrayToRow, rowToStringArray, FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false @"<RESOLUTION_FOLDER>" "" "CSV" "" uri)), "	", '"', false, false, 0, false)
 
-    static member New: rows:CsvProvider+Row seq -> CsvProvider
-    let rowToStringArray = new Func<_,_>(fun (row:_ * _ * _ * _ * _ * _) -> 
-                                            [| TextRuntime.ConvertStringBack(Some (let t1,_,_,_,_,_ = row in t1))
-                                               TextRuntime.ConvertDateTimeBack("", Some (let _,t2,_,_,_,_ = row in t2))
-                                               TextRuntime.ConvertGuidBack((let _,_,t3,_,_,_ = row in t3))
-                                               TextRuntime.ConvertStringBack(Some (let _,_,_,t4,_,_ = row in t4))
-                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,t5,_ = row in t5))
-                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,t6 = row in t6)) |])
-    CsvFile<_>.CreateEmpty(rowToStringArray, rows, None, 6, "	", '"')
-
     static member Parse: text:string -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -191,13 +191,13 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
 
 
 class CsvProvider+Row : string * System.DateTime * System.Guid option * string * string * string
-    new : Column1:string -> Column2:System.DateTime -> Column3:System.Guid option -> Column4:string -> Column5:string -> Column6:string -> CsvProvider+Row
-    Column1,
-    Column2,
-    Column3,
-    Column4,
-    Column5,
-    Column6
+    new : column1:string -> column2:System.DateTime -> column3:System.Guid option -> column4:string -> column5:string -> column6:string -> CsvProvider+Row
+    column1,
+    column2,
+    column3,
+    column4,
+    column5,
+    column6
 
     member Column1: string with get
     (let t1,_,_,_,_,_ = this in t1)

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Csv,MSFT.csv,,,True,False,False,,,.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Csv,MSFT.csv,,,True,False,False,,,.expected
@@ -1,4 +1,21 @@
 class CsvProvider : FDR.CsvFile<CsvProvider+Row>
+    new : rows:CsvProvider+Row seq -> CsvProvider
+    let rowToStringArray = new Func<_,_>(fun (row:_ * _ * _ * _ * _ * _ * _) -> 
+                                            [| TextRuntime.ConvertDateTimeBack("", Some (let t1,_,_,_,_,_,_ = row in t1))
+                                               TextRuntime.ConvertDecimalBack("", Some (let _,t2,_,_,_,_,_ = row in t2))
+                                               TextRuntime.ConvertDecimalBack("", Some (let _,_,t3,_,_,_,_ = row in t3))
+                                               TextRuntime.ConvertDecimalBack("", Some (let _,_,_,t4,_,_,_ = row in t4))
+                                               TextRuntime.ConvertDecimalBack("", Some (let _,_,_,_,t5,_,_ = row in t5))
+                                               TextRuntime.ConvertIntegerBack("", Some (let _,_,_,_,_,t6,_ = row in t6))
+                                               TextRuntime.ConvertDecimalBack("", Some (let _,_,_,_,_,_,t7 = row in t7)) |])
+    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "Date"
+                                                           "Open"
+                                                           "High"
+                                                           "Low"
+                                                           "Close"
+                                                           "Volume"
+                                                           "Adj Close" |], 7, ",", '"')
+
     new : () -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -185,23 +202,6 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
                                                TextRuntime.ConvertDecimalBack("", Some (let _,_,_,_,_,_,t7 = row in t7)) |])
     CsvFile<_>.Create(stringArrayToRow, rowToStringArray, FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false @"<RESOLUTION_FOLDER>" "" "CSV" "" uri)), ",", '"', true, false, 0, false)
 
-    static member New: rows:CsvProvider+Row seq -> CsvProvider
-    let rowToStringArray = new Func<_,_>(fun (row:_ * _ * _ * _ * _ * _ * _) -> 
-                                            [| TextRuntime.ConvertDateTimeBack("", Some (let t1,_,_,_,_,_,_ = row in t1))
-                                               TextRuntime.ConvertDecimalBack("", Some (let _,t2,_,_,_,_,_ = row in t2))
-                                               TextRuntime.ConvertDecimalBack("", Some (let _,_,t3,_,_,_,_ = row in t3))
-                                               TextRuntime.ConvertDecimalBack("", Some (let _,_,_,t4,_,_,_ = row in t4))
-                                               TextRuntime.ConvertDecimalBack("", Some (let _,_,_,_,t5,_,_ = row in t5))
-                                               TextRuntime.ConvertIntegerBack("", Some (let _,_,_,_,_,t6,_ = row in t6))
-                                               TextRuntime.ConvertDecimalBack("", Some (let _,_,_,_,_,_,t7 = row in t7)) |])
-    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "Date"
-                                                           "Open"
-                                                           "High"
-                                                           "Low"
-                                                           "Close"
-                                                           "Volume"
-                                                           "Adj Close" |], 7, ",", '"')
-
     static member Parse: text:string -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -230,14 +230,14 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
 
 
 class CsvProvider+Row : System.DateTime * decimal * decimal * decimal * decimal * int * decimal
-    new : Date:System.DateTime -> Open:decimal -> High:decimal -> Low:decimal -> Close:decimal -> Volume:int -> Adj Close:decimal -> CsvProvider+Row
-    Date,
-    Open,
-    High,
-    Low,
-    Close,
-    Volume,
-    Adj Close
+    new : date:System.DateTime -> open:decimal -> high:decimal -> low:decimal -> close:decimal -> volume:int -> adjClose:decimal -> CsvProvider+Row
+    date,
+    open,
+    high,
+    low,
+    close,
+    volume,
+    adjClose
 
     member ``Adj Close``: decimal with get
     (let _,_,_,_,_,_,t7 = this in t7)

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Csv,MSFT.csv,,,True,False,False,,,.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Csv,MSFT.csv,,,True,False,False,,,.expected
@@ -185,6 +185,23 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
                                                TextRuntime.ConvertDecimalBack("", Some (let _,_,_,_,_,_,t7 = row in t7)) |])
     CsvFile<_>.Create(stringArrayToRow, rowToStringArray, FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false @"<RESOLUTION_FOLDER>" "" "CSV" "" uri)), ",", '"', true, false, 0, false)
 
+    static member New: rows:CsvProvider+Row seq -> CsvProvider
+    let rowToStringArray = new Func<_,_>(fun (row:_ * _ * _ * _ * _ * _ * _) -> 
+                                            [| TextRuntime.ConvertDateTimeBack("", Some (let t1,_,_,_,_,_,_ = row in t1))
+                                               TextRuntime.ConvertDecimalBack("", Some (let _,t2,_,_,_,_,_ = row in t2))
+                                               TextRuntime.ConvertDecimalBack("", Some (let _,_,t3,_,_,_,_ = row in t3))
+                                               TextRuntime.ConvertDecimalBack("", Some (let _,_,_,t4,_,_,_ = row in t4))
+                                               TextRuntime.ConvertDecimalBack("", Some (let _,_,_,_,t5,_,_ = row in t5))
+                                               TextRuntime.ConvertIntegerBack("", Some (let _,_,_,_,_,t6,_ = row in t6))
+                                               TextRuntime.ConvertDecimalBack("", Some (let _,_,_,_,_,_,t7 = row in t7)) |])
+    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "Date"
+                                                           "Open"
+                                                           "High"
+                                                           "Low"
+                                                           "Close"
+                                                           "Volume"
+                                                           "Adj Close" |], 7, ",", '"')
+
     static member Parse: text:string -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -213,6 +230,15 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
 
 
 class CsvProvider+Row : System.DateTime * decimal * decimal * decimal * decimal * int * decimal
+    new : Date:System.DateTime -> Open:decimal -> High:decimal -> Low:decimal -> Close:decimal -> Volume:int -> Adj Close:decimal -> CsvProvider+Row
+    Date,
+    Open,
+    High,
+    Low,
+    Close,
+    Volume,
+    Adj Close
+
     member ``Adj Close``: decimal with get
     (let _,_,_,_,_,_,t7 = this in t7)
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Csv,SmallTest.csv,,,True,False,False,,,.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Csv,SmallTest.csv,,,True,False,False,,,.expected
@@ -101,6 +101,15 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
                                                TextRuntime.ConvertDecimalBack("", Some (let _,_,t3 = row in t3)) |])
     CsvFile<_>.Create(stringArrayToRow, rowToStringArray, FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false @"<RESOLUTION_FOLDER>" "" "CSV" "" uri)), ",", '"', true, false, 0, false)
 
+    static member New: rows:CsvProvider+Row seq -> CsvProvider
+    let rowToStringArray = new Func<_,_>(fun (row:_ * _ * _) -> 
+                                            [| TextRuntime.ConvertStringBack(Some (let t1,_,_ = row in t1))
+                                               TextRuntime.ConvertDecimalBack("", Some (let _,t2,_ = row in t2))
+                                               TextRuntime.ConvertDecimalBack("", Some (let _,_,t3 = row in t3)) |])
+    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "Name"
+                                                           "Distance (metre)"
+                                                           "Time (s)" |], 3, ",", '"')
+
     static member Parse: text:string -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -117,6 +126,11 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
 
 
 class CsvProvider+Row : string * decimal * decimal
+    new : Name:string -> Distance:decimal<metre> -> Time:decimal<s> -> CsvProvider+Row
+    Name,
+    Distance,
+    Time
+
     member Distance: decimal<metre> with get
     (let _,t2,_ = this in t2)
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Csv,SmallTest.csv,,,True,False,False,,,.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Csv,SmallTest.csv,,,True,False,False,,,.expected
@@ -1,4 +1,13 @@
 class CsvProvider : FDR.CsvFile<CsvProvider+Row>
+    new : rows:CsvProvider+Row seq -> CsvProvider
+    let rowToStringArray = new Func<_,_>(fun (row:_ * _ * _) -> 
+                                            [| TextRuntime.ConvertStringBack(Some (let t1,_,_ = row in t1))
+                                               TextRuntime.ConvertDecimalBack("", Some (let _,t2,_ = row in t2))
+                                               TextRuntime.ConvertDecimalBack("", Some (let _,_,t3 = row in t3)) |])
+    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "Name"
+                                                           "Distance (metre)"
+                                                           "Time (s)" |], 3, ",", '"')
+
     new : () -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -101,15 +110,6 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
                                                TextRuntime.ConvertDecimalBack("", Some (let _,_,t3 = row in t3)) |])
     CsvFile<_>.Create(stringArrayToRow, rowToStringArray, FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false @"<RESOLUTION_FOLDER>" "" "CSV" "" uri)), ",", '"', true, false, 0, false)
 
-    static member New: rows:CsvProvider+Row seq -> CsvProvider
-    let rowToStringArray = new Func<_,_>(fun (row:_ * _ * _) -> 
-                                            [| TextRuntime.ConvertStringBack(Some (let t1,_,_ = row in t1))
-                                               TextRuntime.ConvertDecimalBack("", Some (let _,t2,_ = row in t2))
-                                               TextRuntime.ConvertDecimalBack("", Some (let _,_,t3 = row in t3)) |])
-    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "Name"
-                                                           "Distance (metre)"
-                                                           "Time (s)" |], 3, ",", '"')
-
     static member Parse: text:string -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -126,10 +126,10 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
 
 
 class CsvProvider+Row : string * decimal * decimal
-    new : Name:string -> Distance:decimal<metre> -> Time:decimal<s> -> CsvProvider+Row
-    Name,
-    Distance,
-    Time
+    new : name:string -> distance:decimal<metre> -> time:decimal<s> -> CsvProvider+Row
+    name,
+    distance,
+    time
 
     member Distance: decimal<metre> with get
     (let _,t2,_ = this in t2)

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Csv,Titanic.csv,,,True,False,False,,,.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Csv,Titanic.csv,,,True,False,False,,,.expected
@@ -290,6 +290,33 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
                                                TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,_,_,_,t12 = row in t12)) |])
     CsvFile<_>.Create(stringArrayToRow, rowToStringArray, FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false @"<RESOLUTION_FOLDER>" "" "CSV" "" uri)), ",", '"', true, false, 0, false)
 
+    static member New: rows:CsvProvider+Row seq -> CsvProvider
+    let rowToStringArray = new Func<_,_>(fun (row:_ * _ * _ * _ * _ * _ * _ * _) -> 
+                                            [| TextRuntime.ConvertIntegerBack("", Some (let t1,_,_,_,_,_,_,_,_,_,_,_ = row in t1))
+                                               TextRuntime.ConvertBooleanBack(Some (let _,t2,_,_,_,_,_,_,_,_,_,_ = row in t2), false)
+                                               TextRuntime.ConvertIntegerBack("", Some (let _,_,t3,_,_,_,_,_,_,_,_,_ = row in t3))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,t4,_,_,_,_,_,_,_,_ = row in t4))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,t5,_,_,_,_,_,_,_ = row in t5))
+                                               TextRuntime.ConvertFloatBack("", "", Some (let _,_,_,_,_,t6,_,_,_,_,_,_ = row in t6))
+                                               TextRuntime.ConvertIntegerBack("", Some (let _,_,_,_,_,_,t7,_,_,_,_,_ = row in t7))
+                                               TextRuntime.ConvertIntegerBack("", Some (let _,_,_,_,_,_,_,t8,_,_,_,_ = row in t8))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,t9,_,_,_ = row in t9))
+                                               TextRuntime.ConvertDecimalBack("", Some (let _,_,_,_,_,_,_,_,_,t10,_,_ = row in t10))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,_,_,t11,_ = row in t11))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,_,_,_,t12 = row in t12)) |])
+    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "PassengerId"
+                                                           "Survived"
+                                                           "Pclass"
+                                                           "Name"
+                                                           "Sex"
+                                                           "Age"
+                                                           "SibSp"
+                                                           "Parch"
+                                                           "Ticket"
+                                                           "Fare"
+                                                           "Cabin"
+                                                           "Embarked" |], 12, ",", '"')
+
     static member Parse: text:string -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -333,6 +360,20 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
 
 
 class CsvProvider+Row : int * bool * int * string * string * float * int * int * string * decimal * string * string
+    new : PassengerId:int -> Survived:bool -> Pclass:int -> Name:string -> Sex:string -> Age:float -> SibSp:int -> Parch:int -> Ticket:string -> Fare:decimal -> Cabin:string -> Embarked:string -> CsvProvider+Row
+    PassengerId,
+    Survived,
+    Pclass,
+    Name,
+    Sex,
+    Age,
+    SibSp,
+    Parch,
+    Ticket,
+    Fare,
+    Cabin,
+    Embarked
+
     member Age: float with get
     (let _,_,_,_,_,t6,_,_,_,_,_,_ = this in t6)
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Csv,Titanic.csv,,,True,False,False,,,.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Csv,Titanic.csv,,,True,False,False,,,.expected
@@ -1,4 +1,31 @@
 class CsvProvider : FDR.CsvFile<CsvProvider+Row>
+    new : rows:CsvProvider+Row seq -> CsvProvider
+    let rowToStringArray = new Func<_,_>(fun (row:_ * _ * _ * _ * _ * _ * _ * _) -> 
+                                            [| TextRuntime.ConvertIntegerBack("", Some (let t1,_,_,_,_,_,_,_,_,_,_,_ = row in t1))
+                                               TextRuntime.ConvertBooleanBack(Some (let _,t2,_,_,_,_,_,_,_,_,_,_ = row in t2), false)
+                                               TextRuntime.ConvertIntegerBack("", Some (let _,_,t3,_,_,_,_,_,_,_,_,_ = row in t3))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,t4,_,_,_,_,_,_,_,_ = row in t4))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,t5,_,_,_,_,_,_,_ = row in t5))
+                                               TextRuntime.ConvertFloatBack("", "", Some (let _,_,_,_,_,t6,_,_,_,_,_,_ = row in t6))
+                                               TextRuntime.ConvertIntegerBack("", Some (let _,_,_,_,_,_,t7,_,_,_,_,_ = row in t7))
+                                               TextRuntime.ConvertIntegerBack("", Some (let _,_,_,_,_,_,_,t8,_,_,_,_ = row in t8))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,t9,_,_,_ = row in t9))
+                                               TextRuntime.ConvertDecimalBack("", Some (let _,_,_,_,_,_,_,_,_,t10,_,_ = row in t10))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,_,_,t11,_ = row in t11))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,_,_,_,t12 = row in t12)) |])
+    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "PassengerId"
+                                                           "Survived"
+                                                           "Pclass"
+                                                           "Name"
+                                                           "Sex"
+                                                           "Age"
+                                                           "SibSp"
+                                                           "Parch"
+                                                           "Ticket"
+                                                           "Fare"
+                                                           "Cabin"
+                                                           "Embarked" |], 12, ",", '"')
+
     new : () -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -290,33 +317,6 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
                                                TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,_,_,_,t12 = row in t12)) |])
     CsvFile<_>.Create(stringArrayToRow, rowToStringArray, FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false @"<RESOLUTION_FOLDER>" "" "CSV" "" uri)), ",", '"', true, false, 0, false)
 
-    static member New: rows:CsvProvider+Row seq -> CsvProvider
-    let rowToStringArray = new Func<_,_>(fun (row:_ * _ * _ * _ * _ * _ * _ * _) -> 
-                                            [| TextRuntime.ConvertIntegerBack("", Some (let t1,_,_,_,_,_,_,_,_,_,_,_ = row in t1))
-                                               TextRuntime.ConvertBooleanBack(Some (let _,t2,_,_,_,_,_,_,_,_,_,_ = row in t2), false)
-                                               TextRuntime.ConvertIntegerBack("", Some (let _,_,t3,_,_,_,_,_,_,_,_,_ = row in t3))
-                                               TextRuntime.ConvertStringBack(Some (let _,_,_,t4,_,_,_,_,_,_,_,_ = row in t4))
-                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,t5,_,_,_,_,_,_,_ = row in t5))
-                                               TextRuntime.ConvertFloatBack("", "", Some (let _,_,_,_,_,t6,_,_,_,_,_,_ = row in t6))
-                                               TextRuntime.ConvertIntegerBack("", Some (let _,_,_,_,_,_,t7,_,_,_,_,_ = row in t7))
-                                               TextRuntime.ConvertIntegerBack("", Some (let _,_,_,_,_,_,_,t8,_,_,_,_ = row in t8))
-                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,t9,_,_,_ = row in t9))
-                                               TextRuntime.ConvertDecimalBack("", Some (let _,_,_,_,_,_,_,_,_,t10,_,_ = row in t10))
-                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,_,_,t11,_ = row in t11))
-                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,_,_,_,t12 = row in t12)) |])
-    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "PassengerId"
-                                                           "Survived"
-                                                           "Pclass"
-                                                           "Name"
-                                                           "Sex"
-                                                           "Age"
-                                                           "SibSp"
-                                                           "Parch"
-                                                           "Ticket"
-                                                           "Fare"
-                                                           "Cabin"
-                                                           "Embarked" |], 12, ",", '"')
-
     static member Parse: text:string -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -360,19 +360,19 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
 
 
 class CsvProvider+Row : int * bool * int * string * string * float * int * int * string * decimal * string * string
-    new : PassengerId:int -> Survived:bool -> Pclass:int -> Name:string -> Sex:string -> Age:float -> SibSp:int -> Parch:int -> Ticket:string -> Fare:decimal -> Cabin:string -> Embarked:string -> CsvProvider+Row
-    PassengerId,
-    Survived,
-    Pclass,
-    Name,
-    Sex,
-    Age,
-    SibSp,
-    Parch,
-    Ticket,
-    Fare,
-    Cabin,
-    Embarked
+    new : passengerId:int -> survived:bool -> pclass:int -> name:string -> sex:string -> age:float -> sibSp:int -> parch:int -> ticket:string -> fare:decimal -> cabin:string -> embarked:string -> CsvProvider+Row
+    passengerId,
+    survived,
+    pclass,
+    name,
+    sex,
+    age,
+    sibSp,
+    parch,
+    ticket,
+    fare,
+    cabin,
+    embarked
 
     member Age: float with get
     (let _,_,_,_,_,t6,_,_,_,_,_,_ = this in t6)

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Csv,Titanic.csv,,passengerid = int ; Pclass -&gt; Class; Parch -&gt; ParentsOrChildren = int&lt;meter&gt;;SibSp-&gt;SiblingsOrSpouse,True,True,True,,,.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Csv,Titanic.csv,,passengerid = int ; Pclass -&gt; Class; Parch -&gt; ParentsOrChildren = int&lt;meter&gt;;SibSp-&gt;SiblingsOrSpouse,True,True,True,,,.expected
@@ -1,4 +1,31 @@
 class CsvProvider : FDR.CsvFile<CsvProvider+Row>
+    new : rows:CsvProvider+Row seq -> CsvProvider
+    let rowToStringArray = new Func<_,_>(fun (row:_ * _ * _ * _ * _ * _ * _ * _) -> 
+                                            [| TextRuntime.ConvertIntegerBack("", Some (let t1,_,_,_,_,_,_,_,_,_,_,_ = row in t1))
+                                               TextRuntime.ConvertBooleanBack((let _,t2,_,_,_,_,_,_,_,_,_,_ = row in t2), false)
+                                               TextRuntime.ConvertIntegerBack("", (let _,_,t3,_,_,_,_,_,_,_,_,_ = row in t3))
+                                               TextRuntime.ConvertStringBack((let _,_,_,t4,_,_,_,_,_,_,_,_ = row in t4))
+                                               TextRuntime.ConvertStringBack((let _,_,_,_,t5,_,_,_,_,_,_,_ = row in t5))
+                                               TextRuntime.ConvertDecimalBack("", (let _,_,_,_,_,t6,_,_,_,_,_,_ = row in t6))
+                                               TextRuntime.ConvertIntegerBack("", (let _,_,_,_,_,_,t7,_,_,_,_,_ = row in t7))
+                                               TextRuntime.ConvertIntegerBack("", Some (let _,_,_,_,_,_,_,t8,_,_,_,_ = row in t8))
+                                               TextRuntime.ConvertStringBack((let _,_,_,_,_,_,_,_,t9,_,_,_ = row in t9))
+                                               TextRuntime.ConvertDecimalBack("", (let _,_,_,_,_,_,_,_,_,t10,_,_ = row in t10))
+                                               TextRuntime.ConvertStringBack((let _,_,_,_,_,_,_,_,_,_,t11,_ = row in t11))
+                                               TextRuntime.ConvertStringBack((let _,_,_,_,_,_,_,_,_,_,_,t12 = row in t12)) |])
+    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "PassengerId"
+                                                           "Survived"
+                                                           "Pclass"
+                                                           "Name"
+                                                           "Sex"
+                                                           "Age"
+                                                           "SibSp"
+                                                           "Parch"
+                                                           "Ticket"
+                                                           "Fare"
+                                                           "Cabin"
+                                                           "Embarked" |], 12, ",", '"')
+
     new : () -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -220,33 +247,6 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
                                                TextRuntime.ConvertStringBack((let _,_,_,_,_,_,_,_,_,_,_,t12 = row in t12)) |])
     CsvFile<_>.Create(stringArrayToRow, rowToStringArray, FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false @"<RESOLUTION_FOLDER>" "" "CSV" "" uri)), ",", '"', true, false, 0, false)
 
-    static member New: rows:CsvProvider+Row seq -> CsvProvider
-    let rowToStringArray = new Func<_,_>(fun (row:_ * _ * _ * _ * _ * _ * _ * _) -> 
-                                            [| TextRuntime.ConvertIntegerBack("", Some (let t1,_,_,_,_,_,_,_,_,_,_,_ = row in t1))
-                                               TextRuntime.ConvertBooleanBack((let _,t2,_,_,_,_,_,_,_,_,_,_ = row in t2), false)
-                                               TextRuntime.ConvertIntegerBack("", (let _,_,t3,_,_,_,_,_,_,_,_,_ = row in t3))
-                                               TextRuntime.ConvertStringBack((let _,_,_,t4,_,_,_,_,_,_,_,_ = row in t4))
-                                               TextRuntime.ConvertStringBack((let _,_,_,_,t5,_,_,_,_,_,_,_ = row in t5))
-                                               TextRuntime.ConvertDecimalBack("", (let _,_,_,_,_,t6,_,_,_,_,_,_ = row in t6))
-                                               TextRuntime.ConvertIntegerBack("", (let _,_,_,_,_,_,t7,_,_,_,_,_ = row in t7))
-                                               TextRuntime.ConvertIntegerBack("", Some (let _,_,_,_,_,_,_,t8,_,_,_,_ = row in t8))
-                                               TextRuntime.ConvertStringBack((let _,_,_,_,_,_,_,_,t9,_,_,_ = row in t9))
-                                               TextRuntime.ConvertDecimalBack("", (let _,_,_,_,_,_,_,_,_,t10,_,_ = row in t10))
-                                               TextRuntime.ConvertStringBack((let _,_,_,_,_,_,_,_,_,_,t11,_ = row in t11))
-                                               TextRuntime.ConvertStringBack((let _,_,_,_,_,_,_,_,_,_,_,t12 = row in t12)) |])
-    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "PassengerId"
-                                                           "Survived"
-                                                           "Pclass"
-                                                           "Name"
-                                                           "Sex"
-                                                           "Age"
-                                                           "SibSp"
-                                                           "Parch"
-                                                           "Ticket"
-                                                           "Fare"
-                                                           "Cabin"
-                                                           "Embarked" |], 12, ",", '"')
-
     static member Parse: text:string -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -280,19 +280,19 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
 
 
 class CsvProvider+Row : int * bool option * int option * string option * string option * decimal option * int option * int * string option * decimal option * string option * string option
-    new : PassengerId:int -> Survived:bool option -> Class:int option -> Name:string option -> Sex:string option -> Age:decimal option -> SiblingsOrSpouse:int option -> ParentsOrChildren:int<meter> -> Ticket:string option -> Fare:decimal option -> Cabin:string option -> Embarked:string option -> CsvProvider+Row
-    PassengerId,
-    Survived,
-    Class,
-    Name,
-    Sex,
-    Age,
-    SiblingsOrSpouse,
-    ParentsOrChildren,
-    Ticket,
-    Fare,
-    Cabin,
-    Embarked
+    new : passengerId:int -> survived:bool option -> class:int option -> name:string option -> sex:string option -> age:decimal option -> siblingsOrSpouse:int option -> parentsOrChildren:int<meter> -> ticket:string option -> fare:decimal option -> cabin:string option -> embarked:string option -> CsvProvider+Row
+    passengerId,
+    survived,
+    class,
+    name,
+    sex,
+    age,
+    siblingsOrSpouse,
+    parentsOrChildren,
+    ticket,
+    fare,
+    cabin,
+    embarked
 
     member Age: decimal option with get
     (let _,_,_,_,_,t6,_,_,_,_,_,_ = this in t6)

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Csv,Titanic.csv,,passengerid = int ; Pclass -&gt; Class; Parch -&gt; ParentsOrChildren = int&lt;meter&gt;;SibSp-&gt;SiblingsOrSpouse,True,True,True,,,.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Csv,Titanic.csv,,passengerid = int ; Pclass -&gt; Class; Parch -&gt; ParentsOrChildren = int&lt;meter&gt;;SibSp-&gt;SiblingsOrSpouse,True,True,True,,,.expected
@@ -220,6 +220,33 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
                                                TextRuntime.ConvertStringBack((let _,_,_,_,_,_,_,_,_,_,_,t12 = row in t12)) |])
     CsvFile<_>.Create(stringArrayToRow, rowToStringArray, FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false @"<RESOLUTION_FOLDER>" "" "CSV" "" uri)), ",", '"', true, false, 0, false)
 
+    static member New: rows:CsvProvider+Row seq -> CsvProvider
+    let rowToStringArray = new Func<_,_>(fun (row:_ * _ * _ * _ * _ * _ * _ * _) -> 
+                                            [| TextRuntime.ConvertIntegerBack("", Some (let t1,_,_,_,_,_,_,_,_,_,_,_ = row in t1))
+                                               TextRuntime.ConvertBooleanBack((let _,t2,_,_,_,_,_,_,_,_,_,_ = row in t2), false)
+                                               TextRuntime.ConvertIntegerBack("", (let _,_,t3,_,_,_,_,_,_,_,_,_ = row in t3))
+                                               TextRuntime.ConvertStringBack((let _,_,_,t4,_,_,_,_,_,_,_,_ = row in t4))
+                                               TextRuntime.ConvertStringBack((let _,_,_,_,t5,_,_,_,_,_,_,_ = row in t5))
+                                               TextRuntime.ConvertDecimalBack("", (let _,_,_,_,_,t6,_,_,_,_,_,_ = row in t6))
+                                               TextRuntime.ConvertIntegerBack("", (let _,_,_,_,_,_,t7,_,_,_,_,_ = row in t7))
+                                               TextRuntime.ConvertIntegerBack("", Some (let _,_,_,_,_,_,_,t8,_,_,_,_ = row in t8))
+                                               TextRuntime.ConvertStringBack((let _,_,_,_,_,_,_,_,t9,_,_,_ = row in t9))
+                                               TextRuntime.ConvertDecimalBack("", (let _,_,_,_,_,_,_,_,_,t10,_,_ = row in t10))
+                                               TextRuntime.ConvertStringBack((let _,_,_,_,_,_,_,_,_,_,t11,_ = row in t11))
+                                               TextRuntime.ConvertStringBack((let _,_,_,_,_,_,_,_,_,_,_,t12 = row in t12)) |])
+    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "PassengerId"
+                                                           "Survived"
+                                                           "Pclass"
+                                                           "Name"
+                                                           "Sex"
+                                                           "Age"
+                                                           "SibSp"
+                                                           "Parch"
+                                                           "Ticket"
+                                                           "Fare"
+                                                           "Cabin"
+                                                           "Embarked" |], 12, ",", '"')
+
     static member Parse: text:string -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -253,6 +280,20 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
 
 
 class CsvProvider+Row : int * bool option * int option * string option * string option * decimal option * int option * int * string option * decimal option * string option * string option
+    new : PassengerId:int -> Survived:bool option -> Class:int option -> Name:string option -> Sex:string option -> Age:decimal option -> SiblingsOrSpouse:int option -> ParentsOrChildren:int<meter> -> Ticket:string option -> Fare:decimal option -> Cabin:string option -> Embarked:string option -> CsvProvider+Row
+    PassengerId,
+    Survived,
+    Class,
+    Name,
+    Sex,
+    Age,
+    SiblingsOrSpouse,
+    ParentsOrChildren,
+    Ticket,
+    Fare,
+    Cabin,
+    Embarked
+
     member Age: decimal option with get
     (let _,_,_,_,_,t6,_,_,_,_,_,_ = this in t6)
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Csv,cp932.csv,,,True,False,False,NaN (非数値),ja-JP,932.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Csv,cp932.csv,,,True,False,False,NaN (非数値),ja-JP,932.expected
@@ -1,4 +1,11 @@
 class CsvProvider : FDR.CsvFile<CsvProvider+Row>
+    new : rows:CsvProvider+Row seq -> CsvProvider
+    let rowToStringArray = new Func<_,_>(fun (row:_ * _) -> 
+                                            [| TextRuntime.ConvertIntegerBack("ja-JP", Some (let t1,_ = row in t1))
+                                               TextRuntime.ConvertFloatBack("ja-JP", "NaN (非数値)", Some (let _,t2 = row in t2)) |])
+    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "id"
+                                                           "value" |], 2, ",", '"')
+
     new : () -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -80,13 +87,6 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
                                                TextRuntime.ConvertFloatBack("ja-JP", "NaN (非数値)", Some (let _,t2 = row in t2)) |])
     CsvFile<_>.Create(stringArrayToRow, rowToStringArray, FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false @"<RESOLUTION_FOLDER>" "" "CSV" "932" uri)), ",", '"', true, false, 0, false)
 
-    static member New: rows:CsvProvider+Row seq -> CsvProvider
-    let rowToStringArray = new Func<_,_>(fun (row:_ * _) -> 
-                                            [| TextRuntime.ConvertIntegerBack("ja-JP", Some (let t1,_ = row in t1))
-                                               TextRuntime.ConvertFloatBack("ja-JP", "NaN (非数値)", Some (let _,t2 = row in t2)) |])
-    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "id"
-                                                           "value" |], 2, ",", '"')
-
     static member Parse: text:string -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -100,9 +100,9 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
 
 
 class CsvProvider+Row : int * float
-    new : Id:int -> Value:float -> CsvProvider+Row
-    Id,
-    Value
+    new : id:int -> value:float -> CsvProvider+Row
+    id,
+    value
 
     member Id: int with get
     (let t1,_ = this in t1)

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Csv,cp932.csv,,,True,False,False,NaN (非数値),ja-JP,932.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Csv,cp932.csv,,,True,False,False,NaN (非数値),ja-JP,932.expected
@@ -80,6 +80,13 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
                                                TextRuntime.ConvertFloatBack("ja-JP", "NaN (非数値)", Some (let _,t2 = row in t2)) |])
     CsvFile<_>.Create(stringArrayToRow, rowToStringArray, FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false @"<RESOLUTION_FOLDER>" "" "CSV" "932" uri)), ",", '"', true, false, 0, false)
 
+    static member New: rows:CsvProvider+Row seq -> CsvProvider
+    let rowToStringArray = new Func<_,_>(fun (row:_ * _) -> 
+                                            [| TextRuntime.ConvertIntegerBack("ja-JP", Some (let t1,_ = row in t1))
+                                               TextRuntime.ConvertFloatBack("ja-JP", "NaN (非数値)", Some (let _,t2 = row in t2)) |])
+    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "id"
+                                                           "value" |], 2, ",", '"')
+
     static member Parse: text:string -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -93,6 +100,10 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
 
 
 class CsvProvider+Row : int * float
+    new : Id:int -> Value:float -> CsvProvider+Row
+    Id,
+    Value
+
     member Id: int with get
     (let t1,_ = this in t1)
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Csv,file with spaces.csv,,,True,False,False,,,.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Csv,file with spaces.csv,,,True,False,False,,,.expected
@@ -80,6 +80,13 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
                                                TextRuntime.ConvertDecimalBack("", Some (let _,t2 = row in t2)) |])
     CsvFile<_>.Create(stringArrayToRow, rowToStringArray, FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false @"<RESOLUTION_FOLDER>" "" "CSV" "" uri)), ",", '"', true, false, 0, false)
 
+    static member New: rows:CsvProvider+Row seq -> CsvProvider
+    let rowToStringArray = new Func<_,_>(fun (row:_ * _) -> 
+                                            [| TextRuntime.ConvertIntegerBack("", Some (let t1,_ = row in t1))
+                                               TextRuntime.ConvertDecimalBack("", Some (let _,t2 = row in t2)) |])
+    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "Distance (metre)"
+                                                           "Time (second)" |], 2, ",", '"')
+
     static member Parse: text:string -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -93,6 +100,10 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
 
 
 class CsvProvider+Row : int * decimal
+    new : Distance:int<metre> -> Time:decimal<second> -> CsvProvider+Row
+    Distance,
+    Time
+
     member Distance: int<metre> with get
     (let t1,_ = this in t1)
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Csv,file with spaces.csv,,,True,False,False,,,.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Csv,file with spaces.csv,,,True,False,False,,,.expected
@@ -1,4 +1,11 @@
 class CsvProvider : FDR.CsvFile<CsvProvider+Row>
+    new : rows:CsvProvider+Row seq -> CsvProvider
+    let rowToStringArray = new Func<_,_>(fun (row:_ * _) -> 
+                                            [| TextRuntime.ConvertIntegerBack("", Some (let t1,_ = row in t1))
+                                               TextRuntime.ConvertDecimalBack("", Some (let _,t2 = row in t2)) |])
+    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "Distance (metre)"
+                                                           "Time (second)" |], 2, ",", '"')
+
     new : () -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -80,13 +87,6 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
                                                TextRuntime.ConvertDecimalBack("", Some (let _,t2 = row in t2)) |])
     CsvFile<_>.Create(stringArrayToRow, rowToStringArray, FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false @"<RESOLUTION_FOLDER>" "" "CSV" "" uri)), ",", '"', true, false, 0, false)
 
-    static member New: rows:CsvProvider+Row seq -> CsvProvider
-    let rowToStringArray = new Func<_,_>(fun (row:_ * _) -> 
-                                            [| TextRuntime.ConvertIntegerBack("", Some (let t1,_ = row in t1))
-                                               TextRuntime.ConvertDecimalBack("", Some (let _,t2 = row in t2)) |])
-    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "Distance (metre)"
-                                                           "Time (second)" |], 2, ",", '"')
-
     static member Parse: text:string -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -100,9 +100,9 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
 
 
 class CsvProvider+Row : int * decimal
-    new : Distance:int<metre> -> Time:decimal<second> -> CsvProvider+Row
-    Distance,
-    Time
+    new : distance:int<metre> -> time:decimal<second> -> CsvProvider+Row
+    distance,
+    time
 
     member Distance: int<metre> with get
     (let t1,_ = this in t1)

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Csv,tendulkarHistoryWithGameNumber.csv,,,True,False,False,,,.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Csv,tendulkarHistoryWithGameNumber.csv,,,True,False,False,,,.expected
@@ -1,4 +1,31 @@
 class CsvProvider : FDR.CsvFile<CsvProvider+Row>
+    new : rows:CsvProvider+Row seq -> CsvProvider
+    let rowToStringArray = new Func<_,_>(fun (row:_ * _ * _ * _ * _ * _ * _ * _) -> 
+                                            [| TextRuntime.ConvertIntegerBack("", Some (let t1,_,_,_,_,_,_,_,_,_,_,_ = row in t1))
+                                               TextRuntime.ConvertStringBack(Some (let _,t2,_,_,_,_,_,_,_,_,_,_ = row in t2))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,t3,_,_,_,_,_,_,_,_,_ = row in t3))
+                                               TextRuntime.ConvertFloatBack("", "", Some (let _,_,_,t4,_,_,_,_,_,_,_,_ = row in t4))
+                                               TextRuntime.ConvertFloatBack("", "", Some (let _,_,_,_,t5,_,_,_,_,_,_,_ = row in t5))
+                                               TextRuntime.ConvertFloatBack("", "", Some (let _,_,_,_,_,t6,_,_,_,_,_,_ = row in t6))
+                                               TextRuntime.ConvertFloatBack("", "", Some (let _,_,_,_,_,_,t7,_,_,_,_,_ = row in t7))
+                                               TextRuntime.ConvertFloatBack("", "", Some (let _,_,_,_,_,_,_,t8,_,_,_,_ = row in t8))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,t9,_,_,_ = row in t9))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,_,t10,_,_ = row in t10))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,_,_,t11,_ = row in t11))
+                                               TextRuntime.ConvertDateTimeBack("", Some (let _,_,_,_,_,_,_,_,_,_,_,t12 = row in t12)) |])
+    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "Game"
+                                                           "Bat1"
+                                                           "Bat2"
+                                                           "Runs"
+                                                           "Wkts"
+                                                           "Conceded"
+                                                           "Caught"
+                                                           "Stumped"
+                                                           ""
+                                                           "Opposition"
+                                                           "Ground"
+                                                           "StartDate" |], 12, ",", '"')
+
     new : () -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -290,33 +317,6 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
                                                TextRuntime.ConvertDateTimeBack("", Some (let _,_,_,_,_,_,_,_,_,_,_,t12 = row in t12)) |])
     CsvFile<_>.Create(stringArrayToRow, rowToStringArray, FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false @"<RESOLUTION_FOLDER>" "" "CSV" "" uri)), ",", '"', true, false, 0, false)
 
-    static member New: rows:CsvProvider+Row seq -> CsvProvider
-    let rowToStringArray = new Func<_,_>(fun (row:_ * _ * _ * _ * _ * _ * _ * _) -> 
-                                            [| TextRuntime.ConvertIntegerBack("", Some (let t1,_,_,_,_,_,_,_,_,_,_,_ = row in t1))
-                                               TextRuntime.ConvertStringBack(Some (let _,t2,_,_,_,_,_,_,_,_,_,_ = row in t2))
-                                               TextRuntime.ConvertStringBack(Some (let _,_,t3,_,_,_,_,_,_,_,_,_ = row in t3))
-                                               TextRuntime.ConvertFloatBack("", "", Some (let _,_,_,t4,_,_,_,_,_,_,_,_ = row in t4))
-                                               TextRuntime.ConvertFloatBack("", "", Some (let _,_,_,_,t5,_,_,_,_,_,_,_ = row in t5))
-                                               TextRuntime.ConvertFloatBack("", "", Some (let _,_,_,_,_,t6,_,_,_,_,_,_ = row in t6))
-                                               TextRuntime.ConvertFloatBack("", "", Some (let _,_,_,_,_,_,t7,_,_,_,_,_ = row in t7))
-                                               TextRuntime.ConvertFloatBack("", "", Some (let _,_,_,_,_,_,_,t8,_,_,_,_ = row in t8))
-                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,t9,_,_,_ = row in t9))
-                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,_,t10,_,_ = row in t10))
-                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,_,_,t11,_ = row in t11))
-                                               TextRuntime.ConvertDateTimeBack("", Some (let _,_,_,_,_,_,_,_,_,_,_,t12 = row in t12)) |])
-    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "Game"
-                                                           "Bat1"
-                                                           "Bat2"
-                                                           "Runs"
-                                                           "Wkts"
-                                                           "Conceded"
-                                                           "Caught"
-                                                           "Stumped"
-                                                           ""
-                                                           "Opposition"
-                                                           "Ground"
-                                                           "StartDate" |], 12, ",", '"')
-
     static member Parse: text:string -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -360,19 +360,19 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
 
 
 class CsvProvider+Row : int * string * string * float * float * float * float * float * string * string * string * System.DateTime
-    new : Game:int -> Bat1:string -> Bat2:string -> Runs:float -> Wkts:float -> Conceded:float -> Caught:float -> Stumped:float -> Column9:string -> Opposition:string -> Ground:string -> StartDate:System.DateTime -> CsvProvider+Row
-    Game,
-    Bat1,
-    Bat2,
-    Runs,
-    Wkts,
-    Conceded,
-    Caught,
-    Stumped,
-    Column9,
-    Opposition,
-    Ground,
-    StartDate
+    new : game:int -> bat1:string -> bat2:string -> runs:float -> wkts:float -> conceded:float -> caught:float -> stumped:float -> column9:string -> opposition:string -> ground:string -> startDate:System.DateTime -> CsvProvider+Row
+    game,
+    bat1,
+    bat2,
+    runs,
+    wkts,
+    conceded,
+    caught,
+    stumped,
+    column9,
+    opposition,
+    ground,
+    startDate
 
     member Bat1: string with get
     (let _,t2,_,_,_,_,_,_,_,_,_,_ = this in t2)

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Csv,tendulkarHistoryWithGameNumber.csv,,,True,False,False,,,.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Csv,tendulkarHistoryWithGameNumber.csv,,,True,False,False,,,.expected
@@ -290,6 +290,33 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
                                                TextRuntime.ConvertDateTimeBack("", Some (let _,_,_,_,_,_,_,_,_,_,_,t12 = row in t12)) |])
     CsvFile<_>.Create(stringArrayToRow, rowToStringArray, FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false @"<RESOLUTION_FOLDER>" "" "CSV" "" uri)), ",", '"', true, false, 0, false)
 
+    static member New: rows:CsvProvider+Row seq -> CsvProvider
+    let rowToStringArray = new Func<_,_>(fun (row:_ * _ * _ * _ * _ * _ * _ * _) -> 
+                                            [| TextRuntime.ConvertIntegerBack("", Some (let t1,_,_,_,_,_,_,_,_,_,_,_ = row in t1))
+                                               TextRuntime.ConvertStringBack(Some (let _,t2,_,_,_,_,_,_,_,_,_,_ = row in t2))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,t3,_,_,_,_,_,_,_,_,_ = row in t3))
+                                               TextRuntime.ConvertFloatBack("", "", Some (let _,_,_,t4,_,_,_,_,_,_,_,_ = row in t4))
+                                               TextRuntime.ConvertFloatBack("", "", Some (let _,_,_,_,t5,_,_,_,_,_,_,_ = row in t5))
+                                               TextRuntime.ConvertFloatBack("", "", Some (let _,_,_,_,_,t6,_,_,_,_,_,_ = row in t6))
+                                               TextRuntime.ConvertFloatBack("", "", Some (let _,_,_,_,_,_,t7,_,_,_,_,_ = row in t7))
+                                               TextRuntime.ConvertFloatBack("", "", Some (let _,_,_,_,_,_,_,t8,_,_,_,_ = row in t8))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,t9,_,_,_ = row in t9))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,_,t10,_,_ = row in t10))
+                                               TextRuntime.ConvertStringBack(Some (let _,_,_,_,_,_,_,_,_,_,t11,_ = row in t11))
+                                               TextRuntime.ConvertDateTimeBack("", Some (let _,_,_,_,_,_,_,_,_,_,_,t12 = row in t12)) |])
+    CsvFile<_>.CreateEmpty(rowToStringArray, rows, Some [| "Game"
+                                                           "Bat1"
+                                                           "Bat2"
+                                                           "Runs"
+                                                           "Wkts"
+                                                           "Conceded"
+                                                           "Caught"
+                                                           "Stumped"
+                                                           ""
+                                                           "Opposition"
+                                                           "Ground"
+                                                           "StartDate" |], 12, ",", '"')
+
     static member Parse: text:string -> CsvProvider
     let stringArrayToRow = new Func<_,_,_>(fun (parent:obj) (row:string[]) -> 
                                               let value = TextConversions.AsString(row.[0])
@@ -333,6 +360,20 @@ class CsvProvider : FDR.CsvFile<CsvProvider+Row>
 
 
 class CsvProvider+Row : int * string * string * float * float * float * float * float * string * string * string * System.DateTime
+    new : Game:int -> Bat1:string -> Bat2:string -> Runs:float -> Wkts:float -> Conceded:float -> Caught:float -> Stumped:float -> Column9:string -> Opposition:string -> Ground:string -> StartDate:System.DateTime -> CsvProvider+Row
+    Game,
+    Bat1,
+    Bat2,
+    Runs,
+    Wkts,
+    Conceded,
+    Caught,
+    Stumped,
+    Column9,
+    Opposition,
+    Ground,
+    StartDate
+
     member Bat1: string with get
     (let _,t2,_,_,_,_,_,_,_,_,_,_ = this in t2)
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Html,SimpleHtmlTablesWithThead.htm,False,.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Html,SimpleHtmlTablesWithThead.htm,False,.expected
@@ -1,2 +1,0 @@
-class HtmlTableProvider
-

--- a/tests/FSharp.Data.Tests/CsvProvider.fs
+++ b/tests/FSharp.Data.Tests/CsvProvider.fs
@@ -395,4 +395,11 @@ let ``Can set created rows``() =
   csv.Headers.Value.[1]  |> should equal "ColumnB"
   let s = csv.SaveToString()
   s |> should notEqual ""
-   
+
+
+type CsvUom = CsvProvider<"Data/SmallTest.csv">
+[<Test>] 
+let ``Can create new csv row with units of measure``() =
+  let row = new CsvUom.Row("name", 3.5M<metre>, 27M<Data.UnitSystems.SI.UnitSymbols.s>)
+  row.Distance |> should equal 3.5M<metre>
+  

--- a/tests/FSharp.Data.Tests/CsvProvider.fs
+++ b/tests/FSharp.Data.Tests/CsvProvider.fs
@@ -387,8 +387,8 @@ let ``Create particular row``() =
 [<Test>]
 let ``Can set created rows``() = 
   let row1 = new SimpleWithStrCsv.Row(true, "foo", 1.3M)
-  let row2 = new SimpleWithStrCsv.Row(Column1 = false, ColumnB = "foo", Column3 = 42M)
-  let csv = SimpleWithStrCsv.New([row1; row2])
+  let row2 = new SimpleWithStrCsv.Row(column1 = false, columnB = "foo", column3 = 42M)
+  let csv = new SimpleWithStrCsv([row1; row2])
   csv.Rows |> Seq.nth 0 |> should equal row1
   csv.Rows |> Seq.nth 1 |> should equal row2
 

--- a/tests/FSharp.Data.Tests/CsvProvider.fs
+++ b/tests/FSharp.Data.Tests/CsvProvider.fs
@@ -354,3 +354,45 @@ let ``Can parse http://databank.worldbank.org/data/download/GDP.csv``() =
    firstRow.Column1 |> should equal "USA"
    firstRow.Economy |> should equal "United States"   
    firstRow.``US dollars)`` |> should equal 16800000.
+
+
+let [<Literal>] simpleWithStrCsv = """
+  Column1,ColumnB,Column3
+  TRUE,abc,3
+  "yes","Freddy", 1.92 """
+
+
+type SimpleWithStrCsv = CsvProvider<simpleWithStrCsv>
+
+[<Test>]
+let ``Can duplicate own rows``() = 
+  let csv = SimpleWithStrCsv.GetSample()
+  let csv' = csv.Append csv.Rows
+  let out = csv'.SaveToString()
+  let reParsed = SimpleWithStrCsv.Parse(out)
+  reParsed.Rows |> Seq.length |> should equal 4
+  let row = reParsed.Rows |> Seq.nth 3
+  row.Column1 |> should equal true
+  row.ColumnB |> should equal "Freddy"
+  row.Column3 |> should equal 1.92
+
+[<Test>]
+let ``Create particular row``() = 
+  let row = new SimpleWithStrCsv.Row(true, "Second col", 42.5M)
+
+  row.Column1 |> should equal true
+  row.ColumnB |> should equal "Second col"
+  row.Column3 |> should equal 42.5M
+
+[<Test>]
+let ``Can set created rows``() = 
+  let row1 = new SimpleWithStrCsv.Row(true, "foo", 1.3M)
+  let row2 = new SimpleWithStrCsv.Row(Column1 = false, ColumnB = "foo", Column3 = 42M)
+  let csv = SimpleWithStrCsv.New([row1; row2])
+  csv.Rows |> Seq.nth 0 |> should equal row1
+  csv.Rows |> Seq.nth 1 |> should equal row2
+
+  csv.Headers.Value.[1]  |> should equal "ColumnB"
+  let s = csv.SaveToString()
+  s |> should notEqual ""
+   


### PR DESCRIPTION
Added append and replace-rows (`With`) methods to CsvFile, and add constructor to generated csv row type.
Constructor has optional parameters for each column but string types unfortunately default to null rather than "".

As per #578. Not sure if this is the right API, guided by `Filter` etc methods. Other caveat, I wasn't able to get the proper defaults for optional parameters in the generated constructor so that's rather 'hacked in' to avoid a NRE on saving the CSV.
