### PR TITLE
Sorting out qualified/unqualified forms and namespaces

### DIFF
--- a/src/TypeProviderInstantiation.fs
+++ b/src/TypeProviderInstantiation.fs
@@ -29,6 +29,12 @@ type XmlProviderArgs =
       Culture : string
       ResolutionFolder : string }
 
+type XsdProviderArgs = 
+    { SchemaFile : string
+      ResolutionFolder : string
+      IncludeMetadata : bool
+      FailOnUnsupported : bool }
+
 type JsonProviderArgs = 
     { Sample : string
       SampleIsList : bool
@@ -54,6 +60,7 @@ type FreebaseProviderArgs =
 type TypeProviderInstantiation = 
     | Csv of CsvProviderArgs
     | Xml of XmlProviderArgs
+    | Xsd of XsdProviderArgs
     | Json of JsonProviderArgs
     | WorldBank of WorldBankProviderArgs
     | Freebase of FreebaseProviderArgs
@@ -83,6 +90,12 @@ type TypeProviderInstantiation =
                    box x.Global
                    box x.Culture
                    box x.ResolutionFolder |] 
+            | Xsd x ->
+                (fun cfg -> new XsdProvider(cfg) :> TypeProviderForNamespaces),
+                [| box x.SchemaFile
+                   box x.ResolutionFolder
+                   box x.IncludeMetadata
+                   box x.FailOnUnsupported |] 
             | Json x -> 
                 (fun cfg -> new JsonProvider(cfg) :> TypeProviderForNamespaces),
                 [| box x.Sample
@@ -124,6 +137,11 @@ type TypeProviderInstantiation =
              x.SampleIsList.ToString()
              x.Global.ToString()
              x.Culture]
+        | Xsd x -> 
+            ["Xsd"
+             x.SchemaFile
+             x.IncludeMetadata.ToString()
+             x.FailOnUnsupported.ToString()]
         | Json x -> 
             ["Json"
              x.Sample
@@ -180,6 +198,11 @@ type TypeProviderInstantiation =
                   Global = args.[3] |> bool.Parse
                   Culture = args.[4]
                   ResolutionFolder = "" }
+        | "Xsd" ->
+            Xsd { SchemaFile = args.[1]
+                  ResolutionFolder = ""
+                  IncludeMetadata = true
+                  FailOnUnsupported = false } 
         | "Json" ->
             Json { Sample = args.[1]
                    SampleIsList = args.[2] |> bool.Parse

--- a/src/Xsd/XsdProvider.fs
+++ b/src/Xsd/XsdProvider.fs
@@ -23,134 +23,107 @@ type public XsdProvider(cfg:TypeProviderConfig) as this =
   let xmlProvTy = ProvidedTypeDefinition(asm, ns, "XsdProvider", Some typeof<obj>)
 
   let buildTypes (typeName:string) (args:obj[]) =
-    try
-        let elements = ref []
-        let types = ref  StructuralTypes.InferedType.Top
-        // Generate the required type
-        let tpType = ProvidedTypeDefinition(asm, ns, typeName, Some typeof<obj>)
-        
-        let sample = args.[0] :?> string
-        let resolutionFolder = args.[1] :?> string
-        let includeMetadata = args.[2] :?> bool
-        let failOnUnsupported = args.[3] :?>  bool
-        
-        let parseSingle _ value = XDocument.Parse(value).Root
-        let parseList _ value = XDocument.Parse(value).Root.Elements()
-        
-        let getTypes sample =
-          match !types with
-          StructuralTypes.InferedType.Top ->
-            let read (reader:TextReader) = 
-                let schema = XmlSchema.Read(reader,(fun o (e:ValidationEventArgs) -> failwith e.Message))
-                reader.Dispose()
-                schema
-            let ts =
-              let path,reader = 
-                 if File.Exists(sample) then
-                    sample,new StreamReader(File.OpenRead(sample)) :> TextReader
-                 else
-                     try
-                           XDocument.Parse(sample) |> ignore
-                           Path.Combine(resolutionFolder, "temp.xsd"),new StringReader(sample) :> TextReader
-                     with e ->
-                           let exists,path = 
-                               try
-                                  let p = Path.Combine(resolutionFolder,sample)
-                                  File.Exists(p),p
-                               with e ->
-                                  false, ""
-                           if  exists then
-                              path, new StreamReader(File.OpenRead(path)) :> TextReader
-                           else
-                              failwith "Could not find a file and could not interprete as valid XML either"
-              let schema = read reader
-              schema.SourceUri <- path
-              elements := [for e in schema.Elements do yield e:?>XmlSchemaElement]
-              schema |> XsdBuilder.generateType <| includeMetadata <| failOnUnsupported |> List.fold (StructuralInference.subtypeInfered (*allowNulls*)true) StructuralTypes.Top 
-            types := ts
-            ts
-          | _ -> !types
-        
-        let getTypesFromSchema (schema:string) = 
-          let samples = schema |> getTypes
-              
-          let inferedType =
-            match samples with
-            StructuralTypes.InferedType.Record(_) as t -> t
-            | StructuralTypes.InferedType.Heterogeneous cases ->
-                 let t = StructuralTypes.InferedType.Collection(cases |> Map.toList |> List.map fst, cases |> Map.map (fun _ v -> (StructuralTypes.InferedMultiplicity.Single, v)))
-                 //If there's no top level type then wrap the types in a parent, this type won't be used
-                 //We'll create a parse method for each individual type that can be used
-                 StructuralTypes.InferedType.Record(Some "Schema",[{Name = "";
-                                                                    Type = t}],false)
-            | _ as t -> t
-        
-          let ctx = XmlGenerationContext.Create(System.Globalization.CultureInfo.CurrentCulture.Name, tpType, true, replacer)  
-          XmlTypeBuilder.generateXmlType ctx inferedType
-        
-        let result = getTypesFromSchema sample
-        
-        let getSpec _ = 
-          { GeneratedType = tpType
-            RepresentationType = result.ConvertedType
-            CreateFromTextReader = fun reader -> 
-              result.Converter <@@ XmlElement.Create(%reader) @@>
-            CreateFromTextReaderForSampleList = fun reader -> 
-              result.Converter <@@ XmlElement.CreateList(%reader) @@> }
-        
-        let providedType =
-            generateType "XSD" sample false
-                                 parseSingle parseList getSpec
-                                 version this cfg replacer resolutionFolder typeName
-        
-        let inferedType = getTypes sample
-        
+      let elements = ref []
+      // Generate the required type
+      let tpType = ProvidedTypeDefinition(asm, ns, typeName, Some typeof<obj>)
+      
+      let sample = args.[0] :?> string
+      let resolutionFolder = args.[1] :?> string
+      let includeMetadata = args.[2] :?> bool
+      let failOnUnsupported = args.[3] :?>  bool
+      
+      let read (reader:TextReader) = 
+          let schema = XmlSchema.Read(reader,(fun o (e:ValidationEventArgs) -> failwith e.Message))
+          reader.Dispose()
+          schema
+
+      let parseSingle _ (value: string) = 
+          use sr = new StringReader(value)
+          read sr
+      let parseList _ _ = failwith "Never pass sampleIsList=true"
+      
+      let addTopLevelItems inferedType result = 
         match inferedType with
-          StructuralTypes.InferedType.Heterogeneous types ->
-            for (_,t) in types |> Map.toList do
-              match t with
-              StructuralTypes.InferedType.Record(Some _, [{Name = ""; Type = StructuralTypes.InferedType.Primitive(_)}],_) ->
-                  ()
-              | StructuralTypes.InferedType.Record(Some n, _,_)  ->
-                //For each top level type create a method to parse that type
-                let n = NameUtils.nicePascalName n
-                let res = providedType.GetMember(n) 
-                match res with
-                  [||] -> 
-                      failwithf "Could not find a provided type for %s" n
-                  | [|res|] when (res :? ProvidedTypeDefinition) ->
-                      let resultType = res :?> ProvidedTypeDefinition
-                      let args = [ ProvidedParameter("text", typeof<string>) ]
-                      let m = ProvidedMethod("Parse" + n, args, resultType, IsStaticMethod = true)
-                      let nlower = n.ToLower()
-                      m.InvokeCode <- fun (Singleton text) -> 
-                        
-                        <@ 
-                            let t = %%text
-                            let doc = XDocument.Parse(t)
-                            let t = 
-                              if doc.Root.Name.LocalName.ToLower() = nlower then
-                                 //wrap the XML in a new root to make the XMLRuntime pick the right child elements
-                                 let newRoot = new XElement(doc.Root.Name.Namespace.GetName("root__"))
-                                 newRoot.Add(doc.Root)
-                                 let newDoc = new XDocument(doc.Declaration)
-                                 newDoc.Add(newRoot)
-                                 doc.ToString()
-                              else
-                                 //Assume that the XML is already wrapped
-                                 t
-                            new StringReader(t) :> TextReader
-                        @>
-                        |> fun reader -> result.Converter <@@ XmlElement.Create(%reader) @@>
-                      m.AddXmlDoc <| sprintf "Parses the specified XML string as a %s" n
-                      tpType.AddMember m
-                  | [|res|] -> failwithf "%s is not a provided type but a " res.Name (res.GetType().Name)
-                  | _ as res -> failwithf "Found several nested types (%A) with the name %s" res n
-              | _ -> ()
-          | _ as t -> failwithf "Did not expect %A" t
-        providedType
-    with e ->
-       failwith (e.ToString())
+        StructuralTypes.InferedType.Heterogeneous types ->
+          for (_,t) in types |> Map.toList do
+            match t with
+            StructuralTypes.InferedType.Record(Some _, [{Name = ""; Type = StructuralTypes.InferedType.Primitive(_)}],_) ->
+                ()
+            | StructuralTypes.InferedType.Record(Some n, _,_)  ->
+              //For each top level type create a method to parse that type
+              let n = NameUtils.nicePascalName n
+              let res = tpType.GetMember(n) 
+              match res with
+                [||] -> 
+                    failwithf "Could not find a provided type for %s" n
+                | [|res|] when (res :? ProvidedTypeDefinition) ->
+                    let resultType = res :?> ProvidedTypeDefinition
+                    let args = [ ProvidedParameter("text", typeof<string>) ]
+                    let m = ProvidedMethod("Parse" + n, args, resultType, IsStaticMethod = true)
+                    let nlower = n.ToLower()
+                    m.InvokeCode <- fun (Singleton text) -> 
+                      
+                      <@ 
+                          let t = %%text
+                          let doc = XDocument.Parse(t)
+                          let t = 
+                            if doc.Root.Name.LocalName.ToLower() = nlower then
+                               //wrap the XML in a new root to make the XMLRuntime pick the right child elements
+                               let newRoot = new XElement(doc.Root.Name.Namespace.GetName("root__"))
+                               newRoot.Add(doc.Root)
+                               let newDoc = new XDocument(doc.Declaration)
+                               newDoc.Add(newRoot)
+                               doc.ToString()
+                            else
+                               //Assume that the XML is already wrapped
+                               t
+                          new StringReader(t) :> TextReader
+                      @>
+                      |> fun reader -> result.Converter <@@ XmlElement.Create(%reader) @@>
+                    m.AddXmlDoc <| sprintf "Parses the specified XML string as a %s" n
+                    tpType.AddMember m
+                | [|res|] -> failwithf "%s is not a provided type but a " res.Name (res.GetType().Name)
+                | _ as res -> failwithf "Found several nested types (%A) with the name %s" res n
+            | _ -> ()
+        | _ as t -> failwithf "Did not expect %A" t
+
+      let getTypes (schema : XmlSchema) =
+        schema.SourceUri <- Path.Combine(resolutionFolder, "temp.xsd")
+        elements := [for e in schema.Elements do yield e:?>XmlSchemaElement]
+        schema |> XsdBuilder.generateType <| includeMetadata <| failOnUnsupported |> List.fold (StructuralInference.subtypeInfered (*allowNulls*)true) StructuralTypes.Top 
+      
+      let getTypesFromSchema (schema:XmlSchema) = 
+        let inferredType = schema |> getTypes
+            
+        let wrappedType =
+          match inferredType with
+          StructuralTypes.InferedType.Record(_) as t -> t
+          | StructuralTypes.InferedType.Heterogeneous cases ->
+               let t = StructuralTypes.InferedType.Collection(cases |> Map.toList |> List.map fst, cases |> Map.map (fun _ v -> (StructuralTypes.InferedMultiplicity.Single, v)))
+               //If there's no top level type then wrap the types in a parent, this type won't be used
+               //We'll create a parse method for each individual type that can be used
+               StructuralTypes.InferedType.Record(Some "Schema",[{Name = "";
+                                                                  Type = t}],false)
+          | _ as t -> t
+      
+        let ctx = XmlGenerationContext.Create(System.Globalization.CultureInfo.CurrentCulture.Name, tpType, true, replacer)  
+        XmlTypeBuilder.generateXmlType ctx wrappedType, inferredType
+      
+      let getSpec (schema : XmlSchema seq) = 
+        let result, inferredType = schema |> Seq.exactlyOne |> getTypesFromSchema 
+
+        addTopLevelItems inferredType result
+
+        { GeneratedType = tpType
+          RepresentationType = result.ConvertedType
+          CreateFromTextReader = fun reader -> 
+            result.Converter <@@ XmlElement.Create(%reader) @@>
+          CreateFromTextReaderForSampleList = fun reader -> 
+            result.Converter <@@ XmlElement.CreateList(%reader) @@> }
+      
+      generateType "XSD" sample false
+                               parseSingle parseList getSpec
+                               version this cfg replacer resolutionFolder typeName
     
 
   // Add static parameter that specifies the API we want to get (compile-time) 

--- a/tests/FSharp.Data.DesignTime.Tests/SignatureTestCases.config
+++ b/tests/FSharp.Data.DesignTime.Tests/SignatureTestCases.config
@@ -26,6 +26,9 @@ Xml,heterogeneous.xml,false,false,
 Xml,missingInnerValue.xml,true,false,
 Xml,missingInnerValue.xml,true,true,
 Xml,JsonInXml.xml,true,false,
+Xsd,gpx.xsd
+Xsd,xaml2006.xsd
+Xsd,purchaseOrder.xsd
 Json,WorldBank.json,false,WorldBank,
 Json,TwitterStream.json,true,,
 Json,TwitterSample.json,true,,

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Freebase,5,True,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Freebase,5,True,True.expected
@@ -139,6 +139,9 @@ class FreebaseDataProvider+ServiceTypes+DomainObjects+Commons : FDR.Freebase.Fre
     member Chemistry: FreebaseDataProvider+ServiceTypes+DomainObjects+ChemistryDomain with get
     this.GetDomainById("/chemistry")
 
+    member Comedy: FreebaseDataProvider+ServiceTypes+DomainObjects+ComedyDomain with get
+    this.GetDomainById("/comedy")
+
     member Comics: FreebaseDataProvider+ServiceTypes+DomainObjects+ComicsDomain with get
     this.GetDomainById("/comic_books")
 
@@ -207,6 +210,9 @@ class FreebaseDataProvider+ServiceTypes+DomainObjects+Commons : FDR.Freebase.Fre
 
     member Library: FreebaseDataProvider+ServiceTypes+DomainObjects+LibraryDomain with get
     this.GetDomainById("/library")
+
+    member Lightweight: <NULL> with get
+    this.GetDomainById("/base/lightweight")
 
     member Location: FreebaseDataProvider+ServiceTypes+DomainObjects+LocationDomain with get
     this.GetDomainById("/location")
@@ -605,6 +611,9 @@ class FreebaseDataProvider+ServiceTypes+DomainObjects+ArchitectureDomain : FDR.F
     member Building Occupants: FreebaseDataProvider+ServiceTypes+Architecture+Architecture+Building_occupantDataCollection with get
     this.GetObjectsOfTypeId("/architecture/building_occupant")
 
+    member Building complex functions: FreebaseDataProvider+ServiceTypes+Architecture+Architecture+Building_complex_functionDataCollection with get
+    this.GetObjectsOfTypeId("/architecture/building_complex_function")
+
     member Building complexs: FreebaseDataProvider+ServiceTypes+Architecture+Architecture+Building_complexDataCollection with get
     this.GetObjectsOfTypeId("/architecture/building_complex")
 
@@ -994,6 +1003,9 @@ class FreebaseDataProvider+ServiceTypes+DomainObjects+AwardsDomain : FDR.Freebas
     member Award achievement levels: FreebaseDataProvider+ServiceTypes+Award+Award+Award_achievement_levelDataCollection with get
     this.GetObjectsOfTypeId("/award/award_achievement_level")
 
+    member Award announcements: FreebaseDataProvider+ServiceTypes+Award+Award+Award_announcementDataCollection with get
+    this.GetObjectsOfTypeId("/award/award_announcement")
+
     member Award categories: FreebaseDataProvider+ServiceTypes+Award+Award+Award_categoryDataCollection with get
     this.GetObjectsOfTypeId("/award/award_category")
 
@@ -1002,6 +1014,9 @@ class FreebaseDataProvider+ServiceTypes+DomainObjects+AwardsDomain : FDR.Freebas
 
     member Award disciplines: FreebaseDataProvider+ServiceTypes+Award+Award+Award_disciplineDataCollection with get
     this.GetObjectsOfTypeId("/award/award_discipline")
+
+    member Award nomination announcements: FreebaseDataProvider+ServiceTypes+Award+Award+Award_nomination_announcementDataCollection with get
+    this.GetObjectsOfTypeId("/award/award_nomination_announcement")
 
     member Award-Nominated Works: FreebaseDataProvider+ServiceTypes+Award+Award+Award_nominated_workDataCollection with get
     this.GetObjectsOfTypeId("/award/award_nominated_work")
@@ -1256,6 +1271,9 @@ class FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Accident_typeDataIndiv
     member Aircraft hijacking: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Accident_typeDataIndividuals+Aircraft hijacking Item with get
     this.GetIndividualById("/aviation/accident_type", "/m/0wj1")
 
+    member Aviation accident or incident: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Accident_typeDataIndividuals+Aviation accident or incident Item with get
+    this.GetIndividualById("/aviation/accident_type", "/m/015xf8")
+
     member Bomb: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Accident_typeDataIndividuals+Bomb Item with get
     this.GetIndividualById("/aviation/accident_type", "/m/0ct4f")
 
@@ -1265,16 +1283,19 @@ class FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Accident_typeDataIndiv
     member Sabotage: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Accident_typeDataIndividuals+Sabotage Item with get
     this.GetIndividualById("/aviation/accident_type", "/m/0795q")
 
-    member Wind shear: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Accident_typeDataIndividuals+Wind shear Item with get
-    this.GetIndividualById("/aviation/accident_type", "/m/01gmh2")
-
 
 class FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Accident_typeDataIndividuals10 : FDR.Freebase.FreebaseIndividuals
     member Aircraft hijacking: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Accident_typeDataIndividuals10+Aircraft hijacking Item with get
     this.GetIndividualById("/aviation/accident_type", "/m/0wj1")
 
+    member Aircraft upset: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Accident_typeDataIndividuals10+Aircraft upset Item with get
+    this.GetIndividualById("/aviation/accident_type", "/m/0cb79t")
+
     member Atmospheric icing: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Accident_typeDataIndividuals10+Atmospheric icing Item with get
     this.GetIndividualById("/aviation/accident_type", "/m/083d7q")
+
+    member Aviation accident or incident: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Accident_typeDataIndividuals10+Aviation accident or incident Item with get
+    this.GetIndividualById("/aviation/accident_type", "/m/015xf8")
 
     member Bird strike: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Accident_typeDataIndividuals10+Bird strike Item with get
     this.GetIndividualById("/aviation/accident_type", "/m/04gk6_")
@@ -1344,8 +1365,14 @@ class FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Accident_typeDataIndiv
     member Aircraft hijacking: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Accident_typeDataIndividuals100+Aircraft hijacking Item with get
     this.GetIndividualById("/aviation/accident_type", "/m/0wj1")
 
+    member Aircraft upset: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Accident_typeDataIndividuals100+Aircraft upset Item with get
+    this.GetIndividualById("/aviation/accident_type", "/m/0cb79t")
+
     member Atmospheric icing: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Accident_typeDataIndividuals100+Atmospheric icing Item with get
     this.GetIndividualById("/aviation/accident_type", "/m/083d7q")
+
+    member Aviation accident or incident: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Accident_typeDataIndividuals100+Aviation accident or incident Item with get
+    this.GetIndividualById("/aviation/accident_type", "/m/015xf8")
 
     member Bird strike: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Accident_typeDataIndividuals100+Bird strike Item with get
     this.GetIndividualById("/aviation/accident_type", "/m/04gk6_")
@@ -1667,6 +1694,12 @@ class FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividual
     member 2006 Mexico DC-9 drug bust: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividuals100+2006 Mexico DC-9 drug bust Item with get
     this.GetIndividualById("/aviation/aircraft", "/m/0cp7gx")
 
+    member AHRLAC Holdings Ahrlac: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividuals100+AHRLAC Holdings Ahrlac Item with get
+    this.GetIndividualById("/aviation/aircraft", "/m/0h7lzhg")
+
+    member Aero-X: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividuals100+Aero-X Item with get
+    this.GetIndividualById("/aviation/aircraft", "/m/0ll4xyc")
+
     member Akutan Zero: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividuals100+Akutan Zero Item with get
     this.GetIndividualById("/aviation/aircraft", "/m/051z2vs")
 
@@ -1706,6 +1739,9 @@ class FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividual
     member Bravo November: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividuals100+Bravo November Item with get
     this.GetIndividualById("/aviation/aircraft", "/m/07s4xq_")
 
+    member Brazilian Air Force One: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividuals100+Brazilian Air Force One Item with get
+    this.GetIndividualById("/aviation/aircraft", "/m/026k9s4")
+
     member Breitling Orbiter 3: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividuals100+Breitling Orbiter 3 Item with get
     this.GetIndividualById("/aviation/aircraft", "/m/09kr0z")
 
@@ -1738,6 +1774,9 @@ class FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividual
 
     member Double Eagle V: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividuals100+Double Eagle V Item with get
     this.GetIndividualById("/aviation/aircraft", "/m/02695pv")
+
+    member Douglas R4D-3 N763A: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividuals100+Douglas R4D-3 N763A Item with get
+    this.GetIndividualById("/aviation/aircraft", "/m/027ty2y")
 
     member Enola Gay: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividuals100+Enola Gay Item with get
     this.GetIndividualById("/aviation/aircraft", "/m/02m5s")
@@ -1798,6 +1837,9 @@ class FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividual
 
     member Kee Bird: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividuals100+Kee Bird Item with get
     this.GetIndividualById("/aviation/aircraft", "/m/026cfk4")
+
+    member Kiowa Warrior: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividuals100+Kiowa Warrior Item with get
+    this.GetIndividualById("/aviation/aircraft", "/m/011__hyf")
 
     member L'Oiseau Blanc: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividuals100+L'Oiseau Blanc Item with get
     this.GetIndividualById("/aviation/aircraft", "/m/043qr5k")
@@ -1865,6 +1907,9 @@ class FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividual
     member Old 666: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividuals100+Old 666 Item with get
     this.GetIndividualById("/aviation/aircraft", "/m/02pthhk")
 
+    member Orlan-10: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividuals100+Orlan-10 Item with get
+    this.GetIndividualById("/aviation/aircraft", "/m/010s9t4j")
+
     member Osoaviakhim-1: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividuals100+Osoaviakhim-1 Item with get
     this.GetIndividualById("/aviation/aircraft", "/m/05s_gxk")
 
@@ -1891,9 +1936,6 @@ class FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividual
 
     member R101: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividuals100+R101 Item with get
     this.GetIndividualById("/aviation/aircraft", "/m/01rnwx")
-
-    member R4D-3 05078: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividuals100+R4D-3 05078 Item with get
-    this.GetIndividualById("/aviation/aircraft", "/m/027ty2y")
 
     member Rare Bear: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+AircraftDataIndividuals100+Rare Bear Item with get
     this.GetIndividualById("/aviation/aircraft", "/m/0gp28q")
@@ -2102,6 +2144,9 @@ class FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Aircraft_designerDataI
 
 
 class FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Aircraft_designerDataIndividuals10 : FDR.Freebase.FreebaseIndividuals
+    member ATR: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Aircraft_designerDataIndividuals10+ATR Item with get
+    this.GetIndividualById("/aviation/aircraft_designer", "/m/01l2_v")
+
     member Airbus: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Aircraft_designerDataIndividuals10+Airbus Item with get
     this.GetIndividualById("/aviation/aircraft_designer", "/m/015zfz")
 
@@ -2206,9 +2251,6 @@ class FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Aircraft_designerDataI
 
     member Northrop Grumman: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Aircraft_designerDataIndividuals10+Northrop Grumman Item with get
     this.GetIndividualById("/aviation/aircraft_designer", "/m/01frpd")
-
-    member Oskar Ursinus: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Aircraft_designerDataIndividuals10+Oskar Ursinus Item with get
-    this.GetIndividualById("/aviation/aircraft_designer", "/m/0246fc")
 
     member PZL: FreebaseDataProvider+ServiceTypes+Aviation+Aviation+Aircraft_designerDataIndividuals10+PZL Item with get
     this.GetIndividualById("/aviation/aircraft_designer", "/m/01hftq")

--- a/tests/FSharp.Data.DesignTime.Tests/expected/WorldBank,World Development Indicators;Global Financial Development,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/WorldBank,World Development Indicators;Global Financial Development,True.expected
@@ -32,6 +32,9 @@ class WorldBankDataProvider+ServiceTypes+Countries : FDR.WorldBank.CountryCollec
     member American Samoa: WorldBankDataProvider+ServiceTypes+Country with get
     (this :> ICountryCollection).GetCountry("ASM", "American Samoa")
 
+    member Andean Region: WorldBankDataProvider+ServiceTypes+Country with get
+    (this :> ICountryCollection).GetCountry("ANR", "Andean Region")
+
     member Andorra: WorldBankDataProvider+ServiceTypes+Country with get
     (this :> ICountryCollection).GetCountry("AND", "Andorra")
 
@@ -136,6 +139,9 @@ class WorldBankDataProvider+ServiceTypes+Countries : FDR.WorldBank.CountryCollec
 
     member Central African Republic: WorldBankDataProvider+ServiceTypes+Country with get
     (this :> ICountryCollection).GetCountry("CAF", "Central African Republic")
+
+    member Central Europe and the Baltics: WorldBankDataProvider+ServiceTypes+Country with get
+    (this :> ICountryCollection).GetCountry("CEB", "Central Europe and the Baltics")
 
     member Chad: WorldBankDataProvider+ServiceTypes+Country with get
     (this :> ICountryCollection).GetCountry("TCD", "Chad")
@@ -247,6 +253,9 @@ class WorldBankDataProvider+ServiceTypes+Countries : FDR.WorldBank.CountryCollec
 
     member Finland: WorldBankDataProvider+ServiceTypes+Country with get
     (this :> ICountryCollection).GetCountry("FIN", "Finland")
+
+    member Fragile and conflict affected situations: WorldBankDataProvider+ServiceTypes+Country with get
+    (this :> ICountryCollection).GetCountry("FCS", "Fragile and conflict affected situations")
 
     member France: WorldBankDataProvider+ServiceTypes+Country with get
     (this :> ICountryCollection).GetCountry("FRA", "France")
@@ -386,6 +395,9 @@ class WorldBankDataProvider+ServiceTypes+Countries : FDR.WorldBank.CountryCollec
     member Latin America & Caribbean (developing only): WorldBankDataProvider+ServiceTypes+Country with get
     (this :> ICountryCollection).GetCountry("LAC", "Latin America & Caribbean (developing only)")
 
+    member Latin America and the Caribbean: WorldBankDataProvider+ServiceTypes+Country with get
+    (this :> ICountryCollection).GetCountry("LCR", "Latin America and the Caribbean")
+
     member Latin America and the Caribbean (IFC classification): WorldBankDataProvider+ServiceTypes+Country with get
     (this :> ICountryCollection).GetCountry("CLA", "Latin America and the Caribbean (IFC classification)")
 
@@ -460,6 +472,9 @@ class WorldBankDataProvider+ServiceTypes+Countries : FDR.WorldBank.CountryCollec
 
     member Mexico: WorldBankDataProvider+ServiceTypes+Country with get
     (this :> ICountryCollection).GetCountry("MEX", "Mexico")
+
+    member Mexico and Central America: WorldBankDataProvider+ServiceTypes+Country with get
+    (this :> ICountryCollection).GetCountry("MCA", "Mexico and Central America")
 
     member Micronesia, Fed. Sts.: WorldBankDataProvider+ServiceTypes+Country with get
     (this :> ICountryCollection).GetCountry("FSM", "Micronesia, Fed. Sts.")
@@ -647,6 +662,9 @@ class WorldBankDataProvider+ServiceTypes+Countries : FDR.WorldBank.CountryCollec
     member South Sudan: WorldBankDataProvider+ServiceTypes+Country with get
     (this :> ICountryCollection).GetCountry("SSD", "South Sudan")
 
+    member Southern Cone Extended: WorldBankDataProvider+ServiceTypes+Country with get
+    (this :> ICountryCollection).GetCountry("SCE", "Southern Cone Extended")
+
     member Spain: WorldBankDataProvider+ServiceTypes+Country with get
     (this :> ICountryCollection).GetCountry("ESP", "Spain")
 
@@ -790,11 +808,17 @@ class WorldBankDataProvider+ServiceTypes+Regions : FDR.WorldBank.RegionCollectio
     member Africa: WorldBankDataProvider+ServiceTypes+Region with get
     (this :> IRegionCollection).GetRegion("AFR")
 
+    member Andean Region: WorldBankDataProvider+ServiceTypes+Region with get
+    (this :> IRegionCollection).GetRegion("ANR")
+
     member Arab World: WorldBankDataProvider+ServiceTypes+Region with get
     (this :> IRegionCollection).GetRegion("ARB")
 
     member Caribbean small states: WorldBankDataProvider+ServiceTypes+Region with get
     (this :> IRegionCollection).GetRegion("CSS")
+
+    member Central Europe and the Baltics: WorldBankDataProvider+ServiceTypes+Region with get
+    (this :> IRegionCollection).GetRegion("CEB")
 
     member East Asia & Pacific (all income levels): WorldBankDataProvider+ServiceTypes+Region with get
     (this :> IRegionCollection).GetRegion("EAS")
@@ -820,17 +844,26 @@ class WorldBankDataProvider+ServiceTypes+Regions : FDR.WorldBank.RegionCollectio
     member European Union: WorldBankDataProvider+ServiceTypes+Region with get
     (this :> IRegionCollection).GetRegion("EUU")
 
+    member Fragile and conflict affected situations: WorldBankDataProvider+ServiceTypes+Region with get
+    (this :> IRegionCollection).GetRegion("FCS")
+
     member Latin America & Caribbean (all income levels): WorldBankDataProvider+ServiceTypes+Region with get
     (this :> IRegionCollection).GetRegion("LCN")
 
     member Latin America & Caribbean (developing only): WorldBankDataProvider+ServiceTypes+Region with get
     (this :> IRegionCollection).GetRegion("LAC")
 
+    member Latin America and the Caribbean: WorldBankDataProvider+ServiceTypes+Region with get
+    (this :> IRegionCollection).GetRegion("LCR")
+
     member Latin America and the Caribbean (IFC classification): WorldBankDataProvider+ServiceTypes+Region with get
     (this :> IRegionCollection).GetRegion("CLA")
 
     member Least developed countries: UN classification: WorldBankDataProvider+ServiceTypes+Region with get
     (this :> IRegionCollection).GetRegion("LDC")
+
+    member Mexico and Central America: WorldBankDataProvider+ServiceTypes+Region with get
+    (this :> IRegionCollection).GetRegion("MCA")
 
     member Middle East & North Africa (all income levels): WorldBankDataProvider+ServiceTypes+Region with get
     (this :> IRegionCollection).GetRegion("MEA")
@@ -864,6 +897,9 @@ class WorldBankDataProvider+ServiceTypes+Regions : FDR.WorldBank.RegionCollectio
 
     member South Asia (IFC classification): WorldBankDataProvider+ServiceTypes+Region with get
     (this :> IRegionCollection).GetRegion("CSA")
+
+    member Southern Cone Extended: WorldBankDataProvider+ServiceTypes+Region with get
+    (this :> IRegionCollection).GetRegion("SCE")
 
     member Sub-Saharan Africa (IFC classification): WorldBankDataProvider+ServiceTypes+Region with get
     (this :> IRegionCollection).GetRegion("CAA")
@@ -1004,6 +1040,12 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member (%) Program participation - Unemp benefits and ALMP: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("lm_ub.cov_pop")
 
+    member 2005 PPP conversion factor, GDP (LCU per international $): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("PA.NUS.PPP.05")
+
+    member 2005 PPP conversion factor, private consumption (LCU per international $): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("PA.NUS.PRVT.PP.05")
+
     member 5-bank asset concentration: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("GFDD.OI.06")
 
@@ -1015,6 +1057,21 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
 
     member Access to electricity (% of population): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("EG.ELC.ACCS.ZS")
+
+    member Access to electricity, rural (% of population): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("EG.ELC.ACCS.RU.ZS")
+
+    member Access to electricity, urban (% of population): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("EG.ELC.ACCS.UR.ZS")
+
+    member Access to non-solid fuel (% of households): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("EG.NSF.ACCS.ZS")
+
+    member Access to non-solid fuel, rural (% of households): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("EG.NSF.ACCS.RU.ZS")
+
+    member Access to non-solid fuel, urban (% of households): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("EG.NSF.ACCS.UR.ZS")
 
     member Account at a formal financial institution (% age 15+): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("GFDD.AI.05")
@@ -1030,6 +1087,18 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
 
     member Account used to receive wages (% age 15+): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("GFDD.AI.11")
+
+    member Adequacy of social insurance programs (% of total welfare of beneficiary households): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("per_si_allsi.adq_pop_tot")
+
+    member Adequacy of social protection and labor programs (% of total welfare of beneficiary households): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("per_allsp.adq_pop_tot")
+
+    member Adequacy of social safety net programs (% of total welfare of beneficiary households): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("per_sa_allsa.adq_pop_tot")
+
+    member Adequacy of unemployment benefits and ALMP (% of total welfare of beneficiary households): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("per_lm_alllm.adq_pop_tot")
 
     member Adjusted net enrollment rate, primary (% of primary school age children): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SE.PRM.TENR")
@@ -1048,6 +1117,9 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
 
     member Adjusted net national income (current US$): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("NY.ADJ.NNTY.CD")
+
+    member Adjusted net national income per capita (current US$): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("NY.ADJ.NNTY.PC.CD")
 
     member Adjusted net savings, excluding particulate emission damage (% of GNI): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("NY.ADJ.SVNX.GN.ZS")
@@ -1208,7 +1280,13 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member Annual freshwater withdrawals, total (billion cubic meters): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("ER.H2O.FWTL.K3")
 
-    member Antiretroviral therapy coverage (% of people with advanced HIV infection): FDR.WorldBank.Indicator async with get
+    member Annualized growth in survey mean consumption or income per capita, bottom 40% (%, based on 2005 PPP): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SI.SPR.PC40.ZG")
+
+    member Annualized growth in survey mean consumption or income per capita, total population (%, based on 2005 PPP): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SI.SPR.PCAP.ZG")
+
+    member Antiretroviral therapy coverage (% of people living with HIV): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SH.HIV.ARTC.ZS")
 
     member Arable land (% of land area): FDR.WorldBank.Indicator async with get
@@ -1349,6 +1427,18 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member Battle-related deaths (number of people): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("VC.BTL.DETH")
 
+    member Benefits incidence in poorest quintile (%) - All Labor Market: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("per_lm_alllm.ben_q1_tot")
+
+    member Benefits incidence in poorest quintile (%) - All Social Assistance: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("per_sa_allsa.ben_q1_tot")
+
+    member Benefits incidence in poorest quintile (%) - All Social Insurance: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("per_si_allsi.ben_q1_tot")
+
+    member Benefits incidence in poorest quintile (%) -All Social Protection and Labor: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("per_allsp.ben_q1_tot")
+
     member Binding coverage, all products (%): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.TAX.MRCH.BC.ZS")
 
@@ -1400,11 +1490,11 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member Business extent of disclosure index (0=less disclosure to 10=more disclosure): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("IC.BUS.DISC.XQ")
 
-    member CO2 emissions (kg per 2005 PPP $ of GDP): FDR.WorldBank.Indicator async with get
-    (this :> IIndicators).AsyncGetIndicator("EN.ATM.CO2E.PP.GD.KD")
-
     member CO2 emissions (kg per 2005 US$ of GDP): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("EN.ATM.CO2E.KD.GD")
+
+    member CO2 emissions (kg per 2011 PPP $ of GDP): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("EN.ATM.CO2E.PP.GD.KD")
 
     member CO2 emissions (kg per PPP $ of GDP): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("EN.ATM.CO2E.PP.GD")
@@ -1754,11 +1844,11 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member Consolidated foreign claims of BIS reporting banks to GDP (%): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("GFDD.OI.14")
 
-    member Consumer price index (2005 = 100): FDR.WorldBank.Indicator async with get
-    (this :> IIndicators).AsyncGetIndicator("FP.CPI.TOTL")
-
     member Consumer price index (2005=100, December): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("GFDD.OE.01")
+
+    member Consumer price index (2010 = 100): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("FP.CPI.TOTL")
 
     member Consumption of iodized salt (% of households): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SN.ITK.SALT.ZS")
@@ -1787,11 +1877,20 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member Cost to import (US$ per container): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("IC.IMP.COST.CD")
 
+    member Coverage (%) - All Labor Market: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("per_lm_alllm.cov_pop_tot")
+
+    member Coverage (%) - All Social Assistance: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("per_sa_allsa.cov_pop_tot")
+
+    member Coverage (%) - All Social Insurance: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("per_si_allsi.cov_pop_tot")
+
+    member Coverage (%) -All Social Protection and Labor: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("per_allsp.cov_pop_tot")
+
     member Credit card (% age 15+): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("GFDD.AI.20")
-
-    member Credit depth of information index (0=low to 6=high): FDR.WorldBank.Indicator async with get
-    (this :> IIndicators).AsyncGetIndicator("IC.CRD.INFO.XQ")
 
     member Credit to government and state owned enterprises to GDP (%): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("GFDD.EI.08")
@@ -1898,6 +1997,9 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member Depositors with commercial banks (per 1,000 adults): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("FB.CBK.DPTR.P3")
 
+    member Depth of credit information index (0=low to 8=high): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("IC.CRD.INFO.XQ")
+
     member Depth of the food deficit (kilocalories per person per day): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SN.ITK.DFCT")
 
@@ -1930,6 +2032,9 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
 
     member Discrepancy in expenditure estimate of GDP (current LCU): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("NY.GDP.DISC.CN")
+
+    member Distance to frontier score (0=lowest performance to 100=frontier): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("IC.BUS.DFRN.XQ")
 
     member Documents to export (number): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("IC.EXP.DOCS")
@@ -2105,7 +2210,7 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member Energy use (kg of oil equivalent per capita): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("EG.USE.PCAP.KG.OE")
 
-    member Energy use (kg of oil equivalent) per $1,000 GDP (constant 2005 PPP): FDR.WorldBank.Indicator async with get
+    member Energy use (kg of oil equivalent) per $1,000 GDP (constant 2011 PPP): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("EG.USE.COMM.GD.PP.KD")
 
     member Energy use (kt of oil equivalent): FDR.WorldBank.Indicator async with get
@@ -2402,7 +2507,7 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member GDP per capita growth (annual %): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("NY.GDP.PCAP.KD.ZG")
 
-    member GDP per capita, PPP (constant 2005 international $): FDR.WorldBank.Indicator async with get
+    member GDP per capita, PPP (constant 2011 international $): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("NY.GDP.PCAP.PP.KD")
 
     member GDP per capita, PPP (current international $): FDR.WorldBank.Indicator async with get
@@ -2414,10 +2519,10 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member GDP per unit of energy use (PPP $ per kg of oil equivalent): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("EG.GDP.PUSE.KO.PP")
 
-    member GDP per unit of energy use (constant 2005 PPP $ per kg of oil equivalent): FDR.WorldBank.Indicator async with get
+    member GDP per unit of energy use (constant 2011 PPP $ per kg of oil equivalent): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("EG.GDP.PUSE.KO.PP.KD")
 
-    member GDP, PPP (constant 2005 international $): FDR.WorldBank.Indicator async with get
+    member GDP, PPP (constant 2011 international $): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("NY.GDP.MKTP.PP.KD")
 
     member GDP, PPP (current international $): FDR.WorldBank.Indicator async with get
@@ -2429,7 +2534,7 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member GHG net emissions/removals by LUCF (Mt of CO2 equivalent): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("EN.CLC.GHGR.MT.CE")
 
-    member GINI index: FDR.WorldBank.Indicator async with get
+    member GINI index (World Bank estimate): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SI.POV.GINI")
 
     member GNI (constant 2005 US$): FDR.WorldBank.Indicator async with get
@@ -2462,7 +2567,7 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member GNI per capita, Atlas method (current US$): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("NY.GNP.PCAP.CD")
 
-    member GNI per capita, PPP (constant 2005 international $): FDR.WorldBank.Indicator async with get
+    member GNI per capita, PPP (constant 2011 international $): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("NY.GNP.PCAP.PP.KD")
 
     member GNI per capita, PPP (current international $): FDR.WorldBank.Indicator async with get
@@ -2471,7 +2576,7 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member GNI, Atlas method (current US$): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("NY.GNP.ATLS.CD")
 
-    member GNI, PPP (constant 2005 international $): FDR.WorldBank.Indicator async with get
+    member GNI, PPP (constant 2011 international $): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("NY.GNP.MKTP.PP.KD")
 
     member GNI, PPP (current international $): FDR.WorldBank.Indicator async with get
@@ -2606,9 +2711,6 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member Gross national expenditure deflator (base year varies by country): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("NE.DAB.DEFL.ZS")
 
-    member Gross national income (constant LCU): FDR.WorldBank.Indicator async with get
-    (this :> IIndicators).AsyncGetIndicator("NY.GNY.TOTL.KN")
-
     member Gross portfolio debt liabilities to GDP (%): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("GFDD.DM.10")
 
@@ -2699,7 +2801,7 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member Household final consumption expenditure per capita growth (annual %): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("NE.CON.PRVT.PC.KD.ZG")
 
-    member Household final consumption expenditure, PPP (constant 2005 international $): FDR.WorldBank.Indicator async with get
+    member Household final consumption expenditure, PPP (constant 2011 international $): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("NE.CON.PRVT.PP.KD")
 
     member Household final consumption expenditure, PPP (current international $): FDR.WorldBank.Indicator async with get
@@ -3392,6 +3494,9 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member Methane emissions in energy sector (thousand metric tons of CO2 equivalent): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("EN.ATM.METH.EG.KT.CE")
 
+    member Methodology assessment of statistical capacity (scale 0 - 100): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("IQ.SCI.MTHD")
+
     member Military expenditure (% of GDP): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("MS.MIL.XPND.GD.ZS")
 
@@ -3442,12 +3547,6 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
 
     member Mortality rate, infant, female (per 1,000 live births): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.DYN.IMRT.FE.IN")
-
-    member Mortality rate, infant, female (per 1,000 live births): FDR.WorldBank.Indicator async with get
-    (this :> IIndicators).AsyncGetIndicator("SP.DYN.IMRT.FE.IN")
-
-    member Mortality rate, infant, male (per 1,000 live births): FDR.WorldBank.Indicator async with get
-    (this :> IIndicators).AsyncGetIndicator("SP.DYN.IMRT.MA.IN")
 
     member Mortality rate, infant, male (per 1,000 live births): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.DYN.IMRT.MA.IN")
@@ -3833,12 +3932,6 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member Ores and metals imports (% of merchandise imports): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("TM.VAL.MMTL.ZS.UN")
 
-    member Organic water pollutant (BOD) emissions (kg per day per worker): FDR.WorldBank.Indicator async with get
-    (this :> IIndicators).AsyncGetIndicator("EE.BOD.WRKR.KG")
-
-    member Organic water pollutant (BOD) emissions (kg per day): FDR.WorldBank.Indicator async with get
-    (this :> IIndicators).AsyncGetIndicator("EE.BOD.TOTL.KG")
-
     member Other expense (% of expense): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("GC.XPN.OTHR.ZS")
 
@@ -3878,11 +3971,17 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member Outstanding international public debt securities to GDP (%): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("GFDD.DM.06")
 
+    member Overall level of statistical capacity (scale 0 - 100): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("IQ.SCI.OVRL")
+
     member PFC gas emissions (thousand metric tons of CO2 equivalent): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("EN.ATM.PFCG.KT.CE")
 
-    member PM10, country level (micrograms per cubic meter): FDR.WorldBank.Indicator async with get
-    (this :> IIndicators).AsyncGetIndicator("EN.ATM.PM10.MC.M3")
+    member PM2.5 pollution, mean annual exposure (micrograms per cubic meter): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("EN.ATM.PM25.MC.M3")
+
+    member PM2.5 pollution, population exposed to levels exceeding WHO guideline value (% of total): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("EN.ATM.PM25.MC.ZS")
 
     member PNG, bonds (AMT, current US$): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("DT.AMT.PNGB.CD")
@@ -4142,9 +4241,6 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member PPG, private creditors (TDS, current US$): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("DT.TDS.PRVT.CD")
 
-    member PPP conversion factor (GDP) to market exchange rate ratio: FDR.WorldBank.Indicator async with get
-    (this :> IIndicators).AsyncGetIndicator("PA.NUS.PPPC.RF")
-
     member PPP conversion factor, GDP (LCU per international $): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("PA.NUS.PPP")
 
@@ -4174,6 +4270,9 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
 
     member Pension fund assets to GDP (%): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("GFDD.DI.13")
+
+    member Periodicity and timeliness assessment of statistical capacity (scale 0 - 100): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("IQ.SCI.PRDC")
 
     member Permanent cropland (% of land area): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("AG.LND.CROP.ZS")
@@ -4217,9 +4316,6 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member Point-of-sale terminals (per 100,000 adults): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("FB.POS.TOTL.P5")
 
-    member Population (Total): FDR.WorldBank.Indicator async with get
-    (this :> IIndicators).AsyncGetIndicator("SP.POP.TOTL")
-
     member Population ages 0-14 (% of total): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.POP.0014.TO.ZS")
 
@@ -4253,6 +4349,9 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member Population, female (% of total): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.POP.TOTL.FE.ZS")
 
+    member Population, total: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SP.POP.TOTL")
+
     member Portfolio Investment, net (BoP, current US$): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("BN.KLT.PTXL.CD")
 
@@ -4268,14 +4367,8 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member Poverty gap at $2 a day (PPP) (%): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SI.POV.GAP2")
 
-    member Poverty gap at national poverty line (%): FDR.WorldBank.Indicator async with get
+    member Poverty gap at national poverty lines (%): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SI.POV.NAGP")
-
-    member Poverty gap at rural poverty line (%): FDR.WorldBank.Indicator async with get
-    (this :> IIndicators).AsyncGetIndicator("SI.POV.RUGP")
-
-    member Poverty gap at urban poverty line (%): FDR.WorldBank.Indicator async with get
-    (this :> IIndicators).AsyncGetIndicator("SI.POV.URGP")
 
     member Poverty headcount ratio at $1.25 a day (PPP) (% of population): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SI.POV.DDAY")
@@ -4283,14 +4376,8 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member Poverty headcount ratio at $2 a day (PPP) (% of population): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SI.POV.2DAY")
 
-    member Poverty headcount ratio at national poverty line (% of population): FDR.WorldBank.Indicator async with get
+    member Poverty headcount ratio at national poverty lines (% of population): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SI.POV.NAHC")
-
-    member Poverty headcount ratio at rural poverty line (% of rural population): FDR.WorldBank.Indicator async with get
-    (this :> IIndicators).AsyncGetIndicator("SI.POV.RUHC")
-
-    member Poverty headcount ratio at urban poverty line (% of urban population): FDR.WorldBank.Indicator async with get
-    (this :> IIndicators).AsyncGetIndicator("SI.POV.URHC")
 
     member Power outages in firms in a typical month (number): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("IC.ELC.OUTG")
@@ -4321,6 +4408,9 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
 
     member Prevalence of anemia among children (% of children under 5): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SH.ANM.CHLD.ZS")
+
+    member Prevalence of anemia among non-pregnant women (% of women ages 15-49): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SH.ANM.NPRG.ZS")
 
     member Prevalence of anemia among pregnant women (%): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SH.PRG.ANEM")
@@ -4355,6 +4445,9 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member Prevalence of wasting, male (% of children under 5): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SH.STA.WAST.MA.ZS")
 
+    member Price level ratio of PPP conversion factor (GDP) to market exchange rate: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("PA.NUS.PPPC.RF")
+
     member Primary completion rate, female (% of relevant age group): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SE.PRM.CMPT.FE.ZS")
 
@@ -4379,7 +4472,7 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member Primary education, teachers (% female): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SE.PRM.TCHR.FE.ZS")
 
-    member Primary income on FDI (current US$): FDR.WorldBank.Indicator async with get
+    member Primary income on FDI, payments (current US$): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("BX.KLT.DREM.CD.DT")
 
     member Primary income payments (BoP, current US$): FDR.WorldBank.Indicator async with get
@@ -4526,7 +4619,7 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member Ratio of young literate females to males (% ages 15-24): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SE.ADT.1524.LT.FM.ZS")
 
-    member Real effective exchange rate index (2005 = 100): FDR.WorldBank.Indicator async with get
+    member Real effective exchange rate index (2010 = 100): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("PX.REX.REER")
 
     member Real interest rate (%): FDR.WorldBank.Indicator async with get
@@ -4630,6 +4723,12 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
 
     member Rural population growth (annual %): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.RUR.TOTL.ZG")
+
+    member Rural poverty gap at national poverty lines (%): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SI.POV.RUGP")
+
+    member Rural poverty headcount ratio at national poverty lines (% of rural population): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SI.POV.RUHC")
 
     member S&P Global Equity Indices (annual % change): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("CM.MKT.INDX.ZG")
@@ -4808,6 +4907,15 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member Share of women employed in the nonagricultural sector (% of total nonagricultural employment): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SL.EMP.INSV.FE.ZS")
 
+    member Share of youth not in education, employment or training, female (% of female youth population): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SL.UEM.NEET.FE.ZS")
+
+    member Share of youth not in education, employment or training, male (% of male youth population): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SL.UEM.NEET.MA.ZS")
+
+    member Share of youth not in education, employment or training, total (% of youth population): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SL.UEM.NEET.ZS")
+
     member Short-term debt (% of exports of goods, services and primary income): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("DT.DOD.DSTC.XP.ZS")
 
@@ -4831,6 +4939,9 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
 
     member Social contributions (current LCU): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("GC.REV.SOCL.CN")
+
+    member Source data assessment of statistical capacity (scale 0 - 100): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("IQ.SCI.SRCE")
 
     member Start-up procedures to register a business (number): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("IC.REG.PROC")
@@ -4859,7 +4970,7 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member Stocks traded, turnover ratio (%): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("CM.MKT.TRNR")
 
-    member Strength of legal rights index (0=weak to 10=strong): FDR.WorldBank.Indicator async with get
+    member Strength of legal rights index (0=weak to 12=strong): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("IC.LGL.CRED.XQ")
 
     member Subsidies and other transfers (% of expense): FDR.WorldBank.Indicator async with get
@@ -4870,6 +4981,12 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
 
     member Surface area (sq. km): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("AG.SRF.TOTL.K2")
+
+    member Survey mean consumption or income per capita, bottom 40% (2005 PPP $ per day): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SI.SPR.PC40")
+
+    member Survey mean consumption or income per capita, total population (2005 PPP $ per day): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SI.SPR.PCAP")
 
     member Survival to age 65, female (% of cohort): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.DYN.TO65.FE.ZS")
@@ -5105,7 +5222,7 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member Tuberculosis case detection rate (%, all forms): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SH.TBS.DTEC.ZS")
 
-    member Tuberculosis treatment success rate (% of registered cases): FDR.WorldBank.Indicator async with get
+    member Tuberculosis treatment success rate (% of new cases): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SH.TBS.CURE.ZS")
 
     member Undisbursed external debt, official creditors (UND, current US$): FDR.WorldBank.Indicator async with get
@@ -5192,6 +5309,12 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member Urban population growth (annual %): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.URB.GROW")
 
+    member Urban poverty gap at national poverty lines (%): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SI.POV.URGP")
+
+    member Urban poverty headcount ratio at national poverty lines (% of urban population): FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SI.POV.URHC")
+
     member Use of IMF credit (DOD, current US$): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("DT.DOD.DIMF.CD")
 
@@ -5234,34 +5357,10 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member Wanted fertility rate (births per woman): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.DYN.WFRT")
 
-    member Water pollution, chemical industry (% of total BOD emissions): FDR.WorldBank.Indicator async with get
-    (this :> IIndicators).AsyncGetIndicator("EE.BOD.CHEM.ZS")
-
-    member Water pollution, clay and glass industry (% of total BOD emissions): FDR.WorldBank.Indicator async with get
-    (this :> IIndicators).AsyncGetIndicator("EE.BOD.CGLS.ZS")
-
-    member Water pollution, food industry (% of total BOD emissions): FDR.WorldBank.Indicator async with get
-    (this :> IIndicators).AsyncGetIndicator("EE.BOD.FOOD.ZS")
-
-    member Water pollution, metal industry (% of total BOD emissions): FDR.WorldBank.Indicator async with get
-    (this :> IIndicators).AsyncGetIndicator("EE.BOD.MTAL.ZS")
-
-    member Water pollution, other industry (% of total BOD emissions): FDR.WorldBank.Indicator async with get
-    (this :> IIndicators).AsyncGetIndicator("EE.BOD.OTHR.ZS")
-
-    member Water pollution, paper and pulp industry (% of total BOD emissions): FDR.WorldBank.Indicator async with get
-    (this :> IIndicators).AsyncGetIndicator("EE.BOD.PAPR.ZS")
-
-    member Water pollution, textile industry (% of total BOD emissions): FDR.WorldBank.Indicator async with get
-    (this :> IIndicators).AsyncGetIndicator("EE.BOD.TXTL.ZS")
-
-    member Water pollution, wood industry (% of total BOD emissions): FDR.WorldBank.Indicator async with get
-    (this :> IIndicators).AsyncGetIndicator("EE.BOD.WOOD.ZS")
-
     member Water productivity, total (constant 2005 US$ GDP per cubic meter of total freshwater withdrawal): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("ER.GDP.FWTL.M3.KD")
 
-    member Wholesale price index (2005 = 100): FDR.WorldBank.Indicator async with get
+    member Wholesale price index (2010 = 100): FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("FP.WPI.TOTL")
 
     member Women who believe a husband is justified in beating his wife (any of five reasons) (%): FDR.WorldBank.Indicator async with get
@@ -5326,6 +5425,12 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member (%) Program participation - Unemp benefits and ALMP: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("lm_ub.cov_pop")
 
+    member 2005 PPP conversion factor, GDP (LCU per international $): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("PA.NUS.PPP.05")
+
+    member 2005 PPP conversion factor, private consumption (LCU per international $): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("PA.NUS.PRVT.PP.05")
+
     member 5-bank asset concentration: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("GFDD.OI.06")
 
@@ -5337,6 +5442,21 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
 
     member Access to electricity (% of population): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("EG.ELC.ACCS.ZS")
+
+    member Access to electricity, rural (% of population): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("EG.ELC.ACCS.RU.ZS")
+
+    member Access to electricity, urban (% of population): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("EG.ELC.ACCS.UR.ZS")
+
+    member Access to non-solid fuel (% of households): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("EG.NSF.ACCS.ZS")
+
+    member Access to non-solid fuel, rural (% of households): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("EG.NSF.ACCS.RU.ZS")
+
+    member Access to non-solid fuel, urban (% of households): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("EG.NSF.ACCS.UR.ZS")
 
     member Account at a formal financial institution (% age 15+): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("GFDD.AI.05")
@@ -5352,6 +5472,18 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
 
     member Account used to receive wages (% age 15+): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("GFDD.AI.11")
+
+    member Adequacy of social insurance programs (% of total welfare of beneficiary households): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("per_si_allsi.adq_pop_tot")
+
+    member Adequacy of social protection and labor programs (% of total welfare of beneficiary households): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("per_allsp.adq_pop_tot")
+
+    member Adequacy of social safety net programs (% of total welfare of beneficiary households): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("per_sa_allsa.adq_pop_tot")
+
+    member Adequacy of unemployment benefits and ALMP (% of total welfare of beneficiary households): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("per_lm_alllm.adq_pop_tot")
 
     member Adjusted net enrollment rate, primary (% of primary school age children): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SE.PRM.TENR")
@@ -5370,6 +5502,9 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
 
     member Adjusted net national income (current US$): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("NY.ADJ.NNTY.CD")
+
+    member Adjusted net national income per capita (current US$): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("NY.ADJ.NNTY.PC.CD")
 
     member Adjusted net savings, excluding particulate emission damage (% of GNI): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("NY.ADJ.SVNX.GN.ZS")
@@ -5530,7 +5665,13 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member Annual freshwater withdrawals, total (billion cubic meters): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("ER.H2O.FWTL.K3")
 
-    member Antiretroviral therapy coverage (% of people with advanced HIV infection): FDR.WorldBank.IndicatorDescription with get
+    member Annualized growth in survey mean consumption or income per capita, bottom 40% (%, based on 2005 PPP): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SI.SPR.PC40.ZG")
+
+    member Annualized growth in survey mean consumption or income per capita, total population (%, based on 2005 PPP): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SI.SPR.PCAP.ZG")
+
+    member Antiretroviral therapy coverage (% of people living with HIV): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SH.HIV.ARTC.ZS")
 
     member Arable land (% of land area): FDR.WorldBank.IndicatorDescription with get
@@ -5671,6 +5812,18 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member Battle-related deaths (number of people): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("VC.BTL.DETH")
 
+    member Benefits incidence in poorest quintile (%) - All Labor Market: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("per_lm_alllm.ben_q1_tot")
+
+    member Benefits incidence in poorest quintile (%) - All Social Assistance: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("per_sa_allsa.ben_q1_tot")
+
+    member Benefits incidence in poorest quintile (%) - All Social Insurance: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("per_si_allsi.ben_q1_tot")
+
+    member Benefits incidence in poorest quintile (%) -All Social Protection and Labor: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("per_allsp.ben_q1_tot")
+
     member Binding coverage, all products (%): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.TAX.MRCH.BC.ZS")
 
@@ -5722,11 +5875,11 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member Business extent of disclosure index (0=less disclosure to 10=more disclosure): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("IC.BUS.DISC.XQ")
 
-    member CO2 emissions (kg per 2005 PPP $ of GDP): FDR.WorldBank.IndicatorDescription with get
-    (this :> IIndicatorsDescriptions).GetIndicator("EN.ATM.CO2E.PP.GD.KD")
-
     member CO2 emissions (kg per 2005 US$ of GDP): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("EN.ATM.CO2E.KD.GD")
+
+    member CO2 emissions (kg per 2011 PPP $ of GDP): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("EN.ATM.CO2E.PP.GD.KD")
 
     member CO2 emissions (kg per PPP $ of GDP): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("EN.ATM.CO2E.PP.GD")
@@ -6076,11 +6229,11 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member Consolidated foreign claims of BIS reporting banks to GDP (%): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("GFDD.OI.14")
 
-    member Consumer price index (2005 = 100): FDR.WorldBank.IndicatorDescription with get
-    (this :> IIndicatorsDescriptions).GetIndicator("FP.CPI.TOTL")
-
     member Consumer price index (2005=100, December): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("GFDD.OE.01")
+
+    member Consumer price index (2010 = 100): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("FP.CPI.TOTL")
 
     member Consumption of iodized salt (% of households): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SN.ITK.SALT.ZS")
@@ -6109,11 +6262,20 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member Cost to import (US$ per container): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("IC.IMP.COST.CD")
 
+    member Coverage (%) - All Labor Market: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("per_lm_alllm.cov_pop_tot")
+
+    member Coverage (%) - All Social Assistance: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("per_sa_allsa.cov_pop_tot")
+
+    member Coverage (%) - All Social Insurance: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("per_si_allsi.cov_pop_tot")
+
+    member Coverage (%) -All Social Protection and Labor: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("per_allsp.cov_pop_tot")
+
     member Credit card (% age 15+): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("GFDD.AI.20")
-
-    member Credit depth of information index (0=low to 6=high): FDR.WorldBank.IndicatorDescription with get
-    (this :> IIndicatorsDescriptions).GetIndicator("IC.CRD.INFO.XQ")
 
     member Credit to government and state owned enterprises to GDP (%): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("GFDD.EI.08")
@@ -6220,6 +6382,9 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member Depositors with commercial banks (per 1,000 adults): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("FB.CBK.DPTR.P3")
 
+    member Depth of credit information index (0=low to 8=high): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("IC.CRD.INFO.XQ")
+
     member Depth of the food deficit (kilocalories per person per day): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SN.ITK.DFCT")
 
@@ -6252,6 +6417,9 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
 
     member Discrepancy in expenditure estimate of GDP (current LCU): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("NY.GDP.DISC.CN")
+
+    member Distance to frontier score (0=lowest performance to 100=frontier): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("IC.BUS.DFRN.XQ")
 
     member Documents to export (number): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("IC.EXP.DOCS")
@@ -6427,7 +6595,7 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member Energy use (kg of oil equivalent per capita): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("EG.USE.PCAP.KG.OE")
 
-    member Energy use (kg of oil equivalent) per $1,000 GDP (constant 2005 PPP): FDR.WorldBank.IndicatorDescription with get
+    member Energy use (kg of oil equivalent) per $1,000 GDP (constant 2011 PPP): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("EG.USE.COMM.GD.PP.KD")
 
     member Energy use (kt of oil equivalent): FDR.WorldBank.IndicatorDescription with get
@@ -6724,7 +6892,7 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member GDP per capita growth (annual %): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("NY.GDP.PCAP.KD.ZG")
 
-    member GDP per capita, PPP (constant 2005 international $): FDR.WorldBank.IndicatorDescription with get
+    member GDP per capita, PPP (constant 2011 international $): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("NY.GDP.PCAP.PP.KD")
 
     member GDP per capita, PPP (current international $): FDR.WorldBank.IndicatorDescription with get
@@ -6736,10 +6904,10 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member GDP per unit of energy use (PPP $ per kg of oil equivalent): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("EG.GDP.PUSE.KO.PP")
 
-    member GDP per unit of energy use (constant 2005 PPP $ per kg of oil equivalent): FDR.WorldBank.IndicatorDescription with get
+    member GDP per unit of energy use (constant 2011 PPP $ per kg of oil equivalent): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("EG.GDP.PUSE.KO.PP.KD")
 
-    member GDP, PPP (constant 2005 international $): FDR.WorldBank.IndicatorDescription with get
+    member GDP, PPP (constant 2011 international $): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("NY.GDP.MKTP.PP.KD")
 
     member GDP, PPP (current international $): FDR.WorldBank.IndicatorDescription with get
@@ -6751,7 +6919,7 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member GHG net emissions/removals by LUCF (Mt of CO2 equivalent): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("EN.CLC.GHGR.MT.CE")
 
-    member GINI index: FDR.WorldBank.IndicatorDescription with get
+    member GINI index (World Bank estimate): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SI.POV.GINI")
 
     member GNI (constant 2005 US$): FDR.WorldBank.IndicatorDescription with get
@@ -6784,7 +6952,7 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member GNI per capita, Atlas method (current US$): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("NY.GNP.PCAP.CD")
 
-    member GNI per capita, PPP (constant 2005 international $): FDR.WorldBank.IndicatorDescription with get
+    member GNI per capita, PPP (constant 2011 international $): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("NY.GNP.PCAP.PP.KD")
 
     member GNI per capita, PPP (current international $): FDR.WorldBank.IndicatorDescription with get
@@ -6793,7 +6961,7 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member GNI, Atlas method (current US$): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("NY.GNP.ATLS.CD")
 
-    member GNI, PPP (constant 2005 international $): FDR.WorldBank.IndicatorDescription with get
+    member GNI, PPP (constant 2011 international $): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("NY.GNP.MKTP.PP.KD")
 
     member GNI, PPP (current international $): FDR.WorldBank.IndicatorDescription with get
@@ -6928,9 +7096,6 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member Gross national expenditure deflator (base year varies by country): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("NE.DAB.DEFL.ZS")
 
-    member Gross national income (constant LCU): FDR.WorldBank.IndicatorDescription with get
-    (this :> IIndicatorsDescriptions).GetIndicator("NY.GNY.TOTL.KN")
-
     member Gross portfolio debt liabilities to GDP (%): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("GFDD.DM.10")
 
@@ -7021,7 +7186,7 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member Household final consumption expenditure per capita growth (annual %): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("NE.CON.PRVT.PC.KD.ZG")
 
-    member Household final consumption expenditure, PPP (constant 2005 international $): FDR.WorldBank.IndicatorDescription with get
+    member Household final consumption expenditure, PPP (constant 2011 international $): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("NE.CON.PRVT.PP.KD")
 
     member Household final consumption expenditure, PPP (current international $): FDR.WorldBank.IndicatorDescription with get
@@ -7714,6 +7879,9 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member Methane emissions in energy sector (thousand metric tons of CO2 equivalent): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("EN.ATM.METH.EG.KT.CE")
 
+    member Methodology assessment of statistical capacity (scale 0 - 100): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("IQ.SCI.MTHD")
+
     member Military expenditure (% of GDP): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("MS.MIL.XPND.GD.ZS")
 
@@ -7764,12 +7932,6 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
 
     member Mortality rate, infant, female (per 1,000 live births): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.DYN.IMRT.FE.IN")
-
-    member Mortality rate, infant, female (per 1,000 live births): FDR.WorldBank.IndicatorDescription with get
-    (this :> IIndicatorsDescriptions).GetIndicator("SP.DYN.IMRT.FE.IN")
-
-    member Mortality rate, infant, male (per 1,000 live births): FDR.WorldBank.IndicatorDescription with get
-    (this :> IIndicatorsDescriptions).GetIndicator("SP.DYN.IMRT.MA.IN")
 
     member Mortality rate, infant, male (per 1,000 live births): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.DYN.IMRT.MA.IN")
@@ -8155,12 +8317,6 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member Ores and metals imports (% of merchandise imports): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("TM.VAL.MMTL.ZS.UN")
 
-    member Organic water pollutant (BOD) emissions (kg per day per worker): FDR.WorldBank.IndicatorDescription with get
-    (this :> IIndicatorsDescriptions).GetIndicator("EE.BOD.WRKR.KG")
-
-    member Organic water pollutant (BOD) emissions (kg per day): FDR.WorldBank.IndicatorDescription with get
-    (this :> IIndicatorsDescriptions).GetIndicator("EE.BOD.TOTL.KG")
-
     member Other expense (% of expense): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("GC.XPN.OTHR.ZS")
 
@@ -8200,11 +8356,17 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member Outstanding international public debt securities to GDP (%): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("GFDD.DM.06")
 
+    member Overall level of statistical capacity (scale 0 - 100): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("IQ.SCI.OVRL")
+
     member PFC gas emissions (thousand metric tons of CO2 equivalent): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("EN.ATM.PFCG.KT.CE")
 
-    member PM10, country level (micrograms per cubic meter): FDR.WorldBank.IndicatorDescription with get
-    (this :> IIndicatorsDescriptions).GetIndicator("EN.ATM.PM10.MC.M3")
+    member PM2.5 pollution, mean annual exposure (micrograms per cubic meter): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("EN.ATM.PM25.MC.M3")
+
+    member PM2.5 pollution, population exposed to levels exceeding WHO guideline value (% of total): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("EN.ATM.PM25.MC.ZS")
 
     member PNG, bonds (AMT, current US$): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("DT.AMT.PNGB.CD")
@@ -8464,9 +8626,6 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member PPG, private creditors (TDS, current US$): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("DT.TDS.PRVT.CD")
 
-    member PPP conversion factor (GDP) to market exchange rate ratio: FDR.WorldBank.IndicatorDescription with get
-    (this :> IIndicatorsDescriptions).GetIndicator("PA.NUS.PPPC.RF")
-
     member PPP conversion factor, GDP (LCU per international $): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("PA.NUS.PPP")
 
@@ -8496,6 +8655,9 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
 
     member Pension fund assets to GDP (%): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("GFDD.DI.13")
+
+    member Periodicity and timeliness assessment of statistical capacity (scale 0 - 100): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("IQ.SCI.PRDC")
 
     member Permanent cropland (% of land area): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("AG.LND.CROP.ZS")
@@ -8539,9 +8701,6 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member Point-of-sale terminals (per 100,000 adults): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("FB.POS.TOTL.P5")
 
-    member Population (Total): FDR.WorldBank.IndicatorDescription with get
-    (this :> IIndicatorsDescriptions).GetIndicator("SP.POP.TOTL")
-
     member Population ages 0-14 (% of total): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.POP.0014.TO.ZS")
 
@@ -8575,6 +8734,9 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member Population, female (% of total): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.POP.TOTL.FE.ZS")
 
+    member Population, total: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SP.POP.TOTL")
+
     member Portfolio Investment, net (BoP, current US$): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("BN.KLT.PTXL.CD")
 
@@ -8590,14 +8752,8 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member Poverty gap at $2 a day (PPP) (%): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SI.POV.GAP2")
 
-    member Poverty gap at national poverty line (%): FDR.WorldBank.IndicatorDescription with get
+    member Poverty gap at national poverty lines (%): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SI.POV.NAGP")
-
-    member Poverty gap at rural poverty line (%): FDR.WorldBank.IndicatorDescription with get
-    (this :> IIndicatorsDescriptions).GetIndicator("SI.POV.RUGP")
-
-    member Poverty gap at urban poverty line (%): FDR.WorldBank.IndicatorDescription with get
-    (this :> IIndicatorsDescriptions).GetIndicator("SI.POV.URGP")
 
     member Poverty headcount ratio at $1.25 a day (PPP) (% of population): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SI.POV.DDAY")
@@ -8605,14 +8761,8 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member Poverty headcount ratio at $2 a day (PPP) (% of population): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SI.POV.2DAY")
 
-    member Poverty headcount ratio at national poverty line (% of population): FDR.WorldBank.IndicatorDescription with get
+    member Poverty headcount ratio at national poverty lines (% of population): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SI.POV.NAHC")
-
-    member Poverty headcount ratio at rural poverty line (% of rural population): FDR.WorldBank.IndicatorDescription with get
-    (this :> IIndicatorsDescriptions).GetIndicator("SI.POV.RUHC")
-
-    member Poverty headcount ratio at urban poverty line (% of urban population): FDR.WorldBank.IndicatorDescription with get
-    (this :> IIndicatorsDescriptions).GetIndicator("SI.POV.URHC")
 
     member Power outages in firms in a typical month (number): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("IC.ELC.OUTG")
@@ -8643,6 +8793,9 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
 
     member Prevalence of anemia among children (% of children under 5): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SH.ANM.CHLD.ZS")
+
+    member Prevalence of anemia among non-pregnant women (% of women ages 15-49): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SH.ANM.NPRG.ZS")
 
     member Prevalence of anemia among pregnant women (%): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SH.PRG.ANEM")
@@ -8677,6 +8830,9 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member Prevalence of wasting, male (% of children under 5): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SH.STA.WAST.MA.ZS")
 
+    member Price level ratio of PPP conversion factor (GDP) to market exchange rate: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("PA.NUS.PPPC.RF")
+
     member Primary completion rate, female (% of relevant age group): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SE.PRM.CMPT.FE.ZS")
 
@@ -8701,7 +8857,7 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member Primary education, teachers (% female): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SE.PRM.TCHR.FE.ZS")
 
-    member Primary income on FDI (current US$): FDR.WorldBank.IndicatorDescription with get
+    member Primary income on FDI, payments (current US$): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("BX.KLT.DREM.CD.DT")
 
     member Primary income payments (BoP, current US$): FDR.WorldBank.IndicatorDescription with get
@@ -8848,7 +9004,7 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member Ratio of young literate females to males (% ages 15-24): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SE.ADT.1524.LT.FM.ZS")
 
-    member Real effective exchange rate index (2005 = 100): FDR.WorldBank.IndicatorDescription with get
+    member Real effective exchange rate index (2010 = 100): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("PX.REX.REER")
 
     member Real interest rate (%): FDR.WorldBank.IndicatorDescription with get
@@ -8952,6 +9108,12 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
 
     member Rural population growth (annual %): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.RUR.TOTL.ZG")
+
+    member Rural poverty gap at national poverty lines (%): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SI.POV.RUGP")
+
+    member Rural poverty headcount ratio at national poverty lines (% of rural population): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SI.POV.RUHC")
 
     member S&P Global Equity Indices (annual % change): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("CM.MKT.INDX.ZG")
@@ -9130,6 +9292,15 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member Share of women employed in the nonagricultural sector (% of total nonagricultural employment): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SL.EMP.INSV.FE.ZS")
 
+    member Share of youth not in education, employment or training, female (% of female youth population): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SL.UEM.NEET.FE.ZS")
+
+    member Share of youth not in education, employment or training, male (% of male youth population): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SL.UEM.NEET.MA.ZS")
+
+    member Share of youth not in education, employment or training, total (% of youth population): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SL.UEM.NEET.ZS")
+
     member Short-term debt (% of exports of goods, services and primary income): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("DT.DOD.DSTC.XP.ZS")
 
@@ -9153,6 +9324,9 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
 
     member Social contributions (current LCU): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("GC.REV.SOCL.CN")
+
+    member Source data assessment of statistical capacity (scale 0 - 100): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("IQ.SCI.SRCE")
 
     member Start-up procedures to register a business (number): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("IC.REG.PROC")
@@ -9181,7 +9355,7 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member Stocks traded, turnover ratio (%): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("CM.MKT.TRNR")
 
-    member Strength of legal rights index (0=weak to 10=strong): FDR.WorldBank.IndicatorDescription with get
+    member Strength of legal rights index (0=weak to 12=strong): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("IC.LGL.CRED.XQ")
 
     member Subsidies and other transfers (% of expense): FDR.WorldBank.IndicatorDescription with get
@@ -9192,6 +9366,12 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
 
     member Surface area (sq. km): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("AG.SRF.TOTL.K2")
+
+    member Survey mean consumption or income per capita, bottom 40% (2005 PPP $ per day): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SI.SPR.PC40")
+
+    member Survey mean consumption or income per capita, total population (2005 PPP $ per day): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SI.SPR.PCAP")
 
     member Survival to age 65, female (% of cohort): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.DYN.TO65.FE.ZS")
@@ -9427,7 +9607,7 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member Tuberculosis case detection rate (%, all forms): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SH.TBS.DTEC.ZS")
 
-    member Tuberculosis treatment success rate (% of registered cases): FDR.WorldBank.IndicatorDescription with get
+    member Tuberculosis treatment success rate (% of new cases): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SH.TBS.CURE.ZS")
 
     member Undisbursed external debt, official creditors (UND, current US$): FDR.WorldBank.IndicatorDescription with get
@@ -9514,6 +9694,12 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member Urban population growth (annual %): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.URB.GROW")
 
+    member Urban poverty gap at national poverty lines (%): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SI.POV.URGP")
+
+    member Urban poverty headcount ratio at national poverty lines (% of urban population): FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SI.POV.URHC")
+
     member Use of IMF credit (DOD, current US$): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("DT.DOD.DIMF.CD")
 
@@ -9556,34 +9742,10 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member Wanted fertility rate (births per woman): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.DYN.WFRT")
 
-    member Water pollution, chemical industry (% of total BOD emissions): FDR.WorldBank.IndicatorDescription with get
-    (this :> IIndicatorsDescriptions).GetIndicator("EE.BOD.CHEM.ZS")
-
-    member Water pollution, clay and glass industry (% of total BOD emissions): FDR.WorldBank.IndicatorDescription with get
-    (this :> IIndicatorsDescriptions).GetIndicator("EE.BOD.CGLS.ZS")
-
-    member Water pollution, food industry (% of total BOD emissions): FDR.WorldBank.IndicatorDescription with get
-    (this :> IIndicatorsDescriptions).GetIndicator("EE.BOD.FOOD.ZS")
-
-    member Water pollution, metal industry (% of total BOD emissions): FDR.WorldBank.IndicatorDescription with get
-    (this :> IIndicatorsDescriptions).GetIndicator("EE.BOD.MTAL.ZS")
-
-    member Water pollution, other industry (% of total BOD emissions): FDR.WorldBank.IndicatorDescription with get
-    (this :> IIndicatorsDescriptions).GetIndicator("EE.BOD.OTHR.ZS")
-
-    member Water pollution, paper and pulp industry (% of total BOD emissions): FDR.WorldBank.IndicatorDescription with get
-    (this :> IIndicatorsDescriptions).GetIndicator("EE.BOD.PAPR.ZS")
-
-    member Water pollution, textile industry (% of total BOD emissions): FDR.WorldBank.IndicatorDescription with get
-    (this :> IIndicatorsDescriptions).GetIndicator("EE.BOD.TXTL.ZS")
-
-    member Water pollution, wood industry (% of total BOD emissions): FDR.WorldBank.IndicatorDescription with get
-    (this :> IIndicatorsDescriptions).GetIndicator("EE.BOD.WOOD.ZS")
-
     member Water productivity, total (constant 2005 US$ GDP per cubic meter of total freshwater withdrawal): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("ER.GDP.FWTL.M3.KD")
 
-    member Wholesale price index (2005 = 100): FDR.WorldBank.IndicatorDescription with get
+    member Wholesale price index (2010 = 100): FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("FP.WPI.TOTL")
 
     member Women who believe a husband is justified in beating his wife (any of five reasons) (%): FDR.WorldBank.IndicatorDescription with get

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Xsd,gpx.xsd,True,False.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Xsd,gpx.xsd,True,False.expected
@@ -1,0 +1,1368 @@
+class XsdProvider
+    static member AsyncGetSample: () -> XsdProvider+Schema async
+    let f = new Func<_,_>(fun (t:TextReader) -> XmlElement.Create(t))
+    TextRuntime.AsyncMap((IO.asyncReadTextAtRuntimeWithDesignTimeRules @"<RESOLUTION_FOLDER>" "" "XSD" "gpx.xsd"), f)
+
+    static member AsyncLoad: uri:string -> XsdProvider+Schema async
+    let f = new Func<_,_>(fun (t:TextReader) -> XmlElement.Create(t))
+    TextRuntime.AsyncMap((IO.asyncReadTextAtRuntime false @"<RESOLUTION_FOLDER>" "" "XSD" uri), f)
+
+    static member GetSample: () -> XsdProvider+Schema
+    XmlElement.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntimeWithDesignTimeRules @"<RESOLUTION_FOLDER>" "" "XSD" "gpx.xsd")))
+
+    static member Load: stream:System.IO.Stream -> XsdProvider+Schema
+    XmlElement.Create(((new StreamReader(stream)) :> TextReader))
+
+    static member Load: reader:System.IO.TextReader -> XsdProvider+Schema
+    XmlElement.Create(reader)
+
+    static member Load: uri:string -> XsdProvider+Schema
+    XmlElement.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false @"<RESOLUTION_FOLDER>" "" "XSD" uri)))
+
+    static member Parse: text:string -> XsdProvider+Schema
+    XmlElement.Create(((new StringReader(text)) :> TextReader))
+
+    static member ParseBoundsType: text:string -> XsdProvider+BoundsType
+    XmlElement.Create(let t = text
+                      let doc = XDocument.Parse(t)
+                      let t = IfThenElse (Call (None, op_Equality,
+                  [Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                             get_Root, [])),
+                                                 get_Name, [])), get_LocalName,
+                                     [])), ToLower, []), Value ("boundstype")]),
+            Let (newRoot,
+                 NewObject (XElement,
+                            Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                                      get_Root,
+                                                                      [])),
+                                                          get_Name, [])),
+                                              get_Namespace, [])), GetName,
+                                  [Value ("root__")])),
+                 Sequential (Call (Some (newRoot), Add,
+                                   [Coerce (Call (Some (doc), get_Root, []),
+                                            Object)]),
+                             Let (newDoc,
+                                  NewObject (XDocument,
+                                             Call (Some (doc), get_Declaration,
+                                                   []), NewArray (Object)),
+                                  Sequential (Call (Some (newDoc), Add,
+                                                    [Coerce (newRoot, Object)]),
+                                              Call (Some (doc), ToString, []))))),
+            t)
+                      ((new StringReader(t)) :> TextReader))
+
+    static member ParseCopyrightType: text:string -> XsdProvider+CopyrightType
+    XmlElement.Create(let t = text
+                      let doc = XDocument.Parse(t)
+                      let t = IfThenElse (Call (None, op_Equality,
+                  [Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                             get_Root, [])),
+                                                 get_Name, [])), get_LocalName,
+                                     [])), ToLower, []), Value ("copyrighttype")]),
+            Let (newRoot,
+                 NewObject (XElement,
+                            Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                                      get_Root,
+                                                                      [])),
+                                                          get_Name, [])),
+                                              get_Namespace, [])), GetName,
+                                  [Value ("root__")])),
+                 Sequential (Call (Some (newRoot), Add,
+                                   [Coerce (Call (Some (doc), get_Root, []),
+                                            Object)]),
+                             Let (newDoc,
+                                  NewObject (XDocument,
+                                             Call (Some (doc), get_Declaration,
+                                                   []), NewArray (Object)),
+                                  Sequential (Call (Some (newDoc), Add,
+                                                    [Coerce (newRoot, Object)]),
+                                              Call (Some (doc), ToString, []))))),
+            t)
+                      ((new StringReader(t)) :> TextReader))
+
+    static member ParseEmailType: text:string -> XsdProvider+EmailType
+    XmlElement.Create(let t = text
+                      let doc = XDocument.Parse(t)
+                      let t = IfThenElse (Call (None, op_Equality,
+                  [Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                             get_Root, [])),
+                                                 get_Name, [])), get_LocalName,
+                                     [])), ToLower, []), Value ("emailtype")]),
+            Let (newRoot,
+                 NewObject (XElement,
+                            Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                                      get_Root,
+                                                                      [])),
+                                                          get_Name, [])),
+                                              get_Namespace, [])), GetName,
+                                  [Value ("root__")])),
+                 Sequential (Call (Some (newRoot), Add,
+                                   [Coerce (Call (Some (doc), get_Root, []),
+                                            Object)]),
+                             Let (newDoc,
+                                  NewObject (XDocument,
+                                             Call (Some (doc), get_Declaration,
+                                                   []), NewArray (Object)),
+                                  Sequential (Call (Some (newDoc), Add,
+                                                    [Coerce (newRoot, Object)]),
+                                              Call (Some (doc), ToString, []))))),
+            t)
+                      ((new StringReader(t)) :> TextReader))
+
+    static member ParseExtensionsType: text:string -> XsdProvider+ExtensionsType
+    XmlElement.Create(let t = text
+                      let doc = XDocument.Parse(t)
+                      let t = IfThenElse (Call (None, op_Equality,
+                  [Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                             get_Root, [])),
+                                                 get_Name, [])), get_LocalName,
+                                     [])), ToLower, []),
+                   Value ("extensionstype")]),
+            Let (newRoot,
+                 NewObject (XElement,
+                            Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                                      get_Root,
+                                                                      [])),
+                                                          get_Name, [])),
+                                              get_Namespace, [])), GetName,
+                                  [Value ("root__")])),
+                 Sequential (Call (Some (newRoot), Add,
+                                   [Coerce (Call (Some (doc), get_Root, []),
+                                            Object)]),
+                             Let (newDoc,
+                                  NewObject (XDocument,
+                                             Call (Some (doc), get_Declaration,
+                                                   []), NewArray (Object)),
+                                  Sequential (Call (Some (newDoc), Add,
+                                                    [Coerce (newRoot, Object)]),
+                                              Call (Some (doc), ToString, []))))),
+            t)
+                      ((new StringReader(t)) :> TextReader))
+
+    static member ParseGpx: text:string -> XsdProvider+Gpx
+    XmlElement.Create(let t = text
+                      let doc = XDocument.Parse(t)
+                      let t = IfThenElse (Call (None, op_Equality,
+                  [Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                             get_Root, [])),
+                                                 get_Name, [])), get_LocalName,
+                                     [])), ToLower, []), Value ("gpx")]),
+            Let (newRoot,
+                 NewObject (XElement,
+                            Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                                      get_Root,
+                                                                      [])),
+                                                          get_Name, [])),
+                                              get_Namespace, [])), GetName,
+                                  [Value ("root__")])),
+                 Sequential (Call (Some (newRoot), Add,
+                                   [Coerce (Call (Some (doc), get_Root, []),
+                                            Object)]),
+                             Let (newDoc,
+                                  NewObject (XDocument,
+                                             Call (Some (doc), get_Declaration,
+                                                   []), NewArray (Object)),
+                                  Sequential (Call (Some (newDoc), Add,
+                                                    [Coerce (newRoot, Object)]),
+                                              Call (Some (doc), ToString, []))))),
+            t)
+                      ((new StringReader(t)) :> TextReader))
+
+    static member ParseGpxType: text:string -> XsdProvider+GpxType
+    XmlElement.Create(let t = text
+                      let doc = XDocument.Parse(t)
+                      let t = IfThenElse (Call (None, op_Equality,
+                  [Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                             get_Root, [])),
+                                                 get_Name, [])), get_LocalName,
+                                     [])), ToLower, []), Value ("gpxtype")]),
+            Let (newRoot,
+                 NewObject (XElement,
+                            Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                                      get_Root,
+                                                                      [])),
+                                                          get_Name, [])),
+                                              get_Namespace, [])), GetName,
+                                  [Value ("root__")])),
+                 Sequential (Call (Some (newRoot), Add,
+                                   [Coerce (Call (Some (doc), get_Root, []),
+                                            Object)]),
+                             Let (newDoc,
+                                  NewObject (XDocument,
+                                             Call (Some (doc), get_Declaration,
+                                                   []), NewArray (Object)),
+                                  Sequential (Call (Some (newDoc), Add,
+                                                    [Coerce (newRoot, Object)]),
+                                              Call (Some (doc), ToString, []))))),
+            t)
+                      ((new StringReader(t)) :> TextReader))
+
+    static member ParseLinkType: text:string -> XsdProvider+LinkType
+    XmlElement.Create(let t = text
+                      let doc = XDocument.Parse(t)
+                      let t = IfThenElse (Call (None, op_Equality,
+                  [Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                             get_Root, [])),
+                                                 get_Name, [])), get_LocalName,
+                                     [])), ToLower, []), Value ("linktype")]),
+            Let (newRoot,
+                 NewObject (XElement,
+                            Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                                      get_Root,
+                                                                      [])),
+                                                          get_Name, [])),
+                                              get_Namespace, [])), GetName,
+                                  [Value ("root__")])),
+                 Sequential (Call (Some (newRoot), Add,
+                                   [Coerce (Call (Some (doc), get_Root, []),
+                                            Object)]),
+                             Let (newDoc,
+                                  NewObject (XDocument,
+                                             Call (Some (doc), get_Declaration,
+                                                   []), NewArray (Object)),
+                                  Sequential (Call (Some (newDoc), Add,
+                                                    [Coerce (newRoot, Object)]),
+                                              Call (Some (doc), ToString, []))))),
+            t)
+                      ((new StringReader(t)) :> TextReader))
+
+    static member ParseMetadataType: text:string -> XsdProvider+MetadataType
+    XmlElement.Create(let t = text
+                      let doc = XDocument.Parse(t)
+                      let t = IfThenElse (Call (None, op_Equality,
+                  [Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                             get_Root, [])),
+                                                 get_Name, [])), get_LocalName,
+                                     [])), ToLower, []), Value ("metadatatype")]),
+            Let (newRoot,
+                 NewObject (XElement,
+                            Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                                      get_Root,
+                                                                      [])),
+                                                          get_Name, [])),
+                                              get_Namespace, [])), GetName,
+                                  [Value ("root__")])),
+                 Sequential (Call (Some (newRoot), Add,
+                                   [Coerce (Call (Some (doc), get_Root, []),
+                                            Object)]),
+                             Let (newDoc,
+                                  NewObject (XDocument,
+                                             Call (Some (doc), get_Declaration,
+                                                   []), NewArray (Object)),
+                                  Sequential (Call (Some (newDoc), Add,
+                                                    [Coerce (newRoot, Object)]),
+                                              Call (Some (doc), ToString, []))))),
+            t)
+                      ((new StringReader(t)) :> TextReader))
+
+    static member ParsePersonType: text:string -> XsdProvider+PersonType
+    XmlElement.Create(let t = text
+                      let doc = XDocument.Parse(t)
+                      let t = IfThenElse (Call (None, op_Equality,
+                  [Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                             get_Root, [])),
+                                                 get_Name, [])), get_LocalName,
+                                     [])), ToLower, []), Value ("persontype")]),
+            Let (newRoot,
+                 NewObject (XElement,
+                            Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                                      get_Root,
+                                                                      [])),
+                                                          get_Name, [])),
+                                              get_Namespace, [])), GetName,
+                                  [Value ("root__")])),
+                 Sequential (Call (Some (newRoot), Add,
+                                   [Coerce (Call (Some (doc), get_Root, []),
+                                            Object)]),
+                             Let (newDoc,
+                                  NewObject (XDocument,
+                                             Call (Some (doc), get_Declaration,
+                                                   []), NewArray (Object)),
+                                  Sequential (Call (Some (newDoc), Add,
+                                                    [Coerce (newRoot, Object)]),
+                                              Call (Some (doc), ToString, []))))),
+            t)
+                      ((new StringReader(t)) :> TextReader))
+
+    static member ParsePtType: text:string -> XsdProvider+PtType
+    XmlElement.Create(let t = text
+                      let doc = XDocument.Parse(t)
+                      let t = IfThenElse (Call (None, op_Equality,
+                  [Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                             get_Root, [])),
+                                                 get_Name, [])), get_LocalName,
+                                     [])), ToLower, []), Value ("pttype")]),
+            Let (newRoot,
+                 NewObject (XElement,
+                            Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                                      get_Root,
+                                                                      [])),
+                                                          get_Name, [])),
+                                              get_Namespace, [])), GetName,
+                                  [Value ("root__")])),
+                 Sequential (Call (Some (newRoot), Add,
+                                   [Coerce (Call (Some (doc), get_Root, []),
+                                            Object)]),
+                             Let (newDoc,
+                                  NewObject (XDocument,
+                                             Call (Some (doc), get_Declaration,
+                                                   []), NewArray (Object)),
+                                  Sequential (Call (Some (newDoc), Add,
+                                                    [Coerce (newRoot, Object)]),
+                                              Call (Some (doc), ToString, []))))),
+            t)
+                      ((new StringReader(t)) :> TextReader))
+
+    static member ParsePtsegType: text:string -> XsdProvider+PtsegType
+    XmlElement.Create(let t = text
+                      let doc = XDocument.Parse(t)
+                      let t = IfThenElse (Call (None, op_Equality,
+                  [Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                             get_Root, [])),
+                                                 get_Name, [])), get_LocalName,
+                                     [])), ToLower, []), Value ("ptsegtype")]),
+            Let (newRoot,
+                 NewObject (XElement,
+                            Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                                      get_Root,
+                                                                      [])),
+                                                          get_Name, [])),
+                                              get_Namespace, [])), GetName,
+                                  [Value ("root__")])),
+                 Sequential (Call (Some (newRoot), Add,
+                                   [Coerce (Call (Some (doc), get_Root, []),
+                                            Object)]),
+                             Let (newDoc,
+                                  NewObject (XDocument,
+                                             Call (Some (doc), get_Declaration,
+                                                   []), NewArray (Object)),
+                                  Sequential (Call (Some (newDoc), Add,
+                                                    [Coerce (newRoot, Object)]),
+                                              Call (Some (doc), ToString, []))))),
+            t)
+                      ((new StringReader(t)) :> TextReader))
+
+    static member ParseRteType: text:string -> XsdProvider+RteType
+    XmlElement.Create(let t = text
+                      let doc = XDocument.Parse(t)
+                      let t = IfThenElse (Call (None, op_Equality,
+                  [Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                             get_Root, [])),
+                                                 get_Name, [])), get_LocalName,
+                                     [])), ToLower, []), Value ("rtetype")]),
+            Let (newRoot,
+                 NewObject (XElement,
+                            Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                                      get_Root,
+                                                                      [])),
+                                                          get_Name, [])),
+                                              get_Namespace, [])), GetName,
+                                  [Value ("root__")])),
+                 Sequential (Call (Some (newRoot), Add,
+                                   [Coerce (Call (Some (doc), get_Root, []),
+                                            Object)]),
+                             Let (newDoc,
+                                  NewObject (XDocument,
+                                             Call (Some (doc), get_Declaration,
+                                                   []), NewArray (Object)),
+                                  Sequential (Call (Some (newDoc), Add,
+                                                    [Coerce (newRoot, Object)]),
+                                              Call (Some (doc), ToString, []))))),
+            t)
+                      ((new StringReader(t)) :> TextReader))
+
+    static member ParseTrkType: text:string -> XsdProvider+TrkType
+    XmlElement.Create(let t = text
+                      let doc = XDocument.Parse(t)
+                      let t = IfThenElse (Call (None, op_Equality,
+                  [Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                             get_Root, [])),
+                                                 get_Name, [])), get_LocalName,
+                                     [])), ToLower, []), Value ("trktype")]),
+            Let (newRoot,
+                 NewObject (XElement,
+                            Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                                      get_Root,
+                                                                      [])),
+                                                          get_Name, [])),
+                                              get_Namespace, [])), GetName,
+                                  [Value ("root__")])),
+                 Sequential (Call (Some (newRoot), Add,
+                                   [Coerce (Call (Some (doc), get_Root, []),
+                                            Object)]),
+                             Let (newDoc,
+                                  NewObject (XDocument,
+                                             Call (Some (doc), get_Declaration,
+                                                   []), NewArray (Object)),
+                                  Sequential (Call (Some (newDoc), Add,
+                                                    [Coerce (newRoot, Object)]),
+                                              Call (Some (doc), ToString, []))))),
+            t)
+                      ((new StringReader(t)) :> TextReader))
+
+    static member ParseTrksegType: text:string -> XsdProvider+TrksegType
+    XmlElement.Create(let t = text
+                      let doc = XDocument.Parse(t)
+                      let t = IfThenElse (Call (None, op_Equality,
+                  [Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                             get_Root, [])),
+                                                 get_Name, [])), get_LocalName,
+                                     [])), ToLower, []), Value ("trksegtype")]),
+            Let (newRoot,
+                 NewObject (XElement,
+                            Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                                      get_Root,
+                                                                      [])),
+                                                          get_Name, [])),
+                                              get_Namespace, [])), GetName,
+                                  [Value ("root__")])),
+                 Sequential (Call (Some (newRoot), Add,
+                                   [Coerce (Call (Some (doc), get_Root, []),
+                                            Object)]),
+                             Let (newDoc,
+                                  NewObject (XDocument,
+                                             Call (Some (doc), get_Declaration,
+                                                   []), NewArray (Object)),
+                                  Sequential (Call (Some (newDoc), Add,
+                                                    [Coerce (newRoot, Object)]),
+                                              Call (Some (doc), ToString, []))))),
+            t)
+                      ((new StringReader(t)) :> TextReader))
+
+    static member ParseWptType: text:string -> XsdProvider+WptType
+    XmlElement.Create(let t = text
+                      let doc = XDocument.Parse(t)
+                      let t = IfThenElse (Call (None, op_Equality,
+                  [Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                             get_Root, [])),
+                                                 get_Name, [])), get_LocalName,
+                                     [])), ToLower, []), Value ("wpttype")]),
+            Let (newRoot,
+                 NewObject (XElement,
+                            Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                                      get_Root,
+                                                                      [])),
+                                                          get_Name, [])),
+                                              get_Namespace, [])), GetName,
+                                  [Value ("root__")])),
+                 Sequential (Call (Some (newRoot), Add,
+                                   [Coerce (Call (Some (doc), get_Root, []),
+                                            Object)]),
+                             Let (newDoc,
+                                  NewObject (XDocument,
+                                             Call (Some (doc), get_Declaration,
+                                                   []), NewArray (Object)),
+                                  Sequential (Call (Some (newDoc), Add,
+                                                    [Coerce (newRoot, Object)]),
+                                              Call (Some (doc), ToString, []))))),
+            t)
+                      ((new StringReader(t)) :> TextReader))
+
+
+class XsdProvider+BoundsType : FDR.XmlElement
+    new : minlat:decimal -> minlon:decimal -> maxlat:decimal -> maxlon:decimal -> targetNamespace:string -> typeName:string -> XsdProvider+BoundsType
+    XmlRuntime.CreateRecord("boundsType", 
+                            [| ("minlat",
+                                (minlat :> obj))
+                               ("minlon",
+                                (minlon :> obj))
+                               ("maxlat",
+                                (maxlat :> obj))
+                               ("maxlon",
+                                (maxlon :> obj)) |], 
+                            [| ("TargetNamespace",
+                                (targetNamespace :> obj))
+                               ("TypeName",
+                                (typeName :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+BoundsType
+    XmlElement.Create(xElement)
+
+    member Maxlat: decimal with get
+    let value = XmlRuntime.TryGetAttribute(this, "maxlat")
+    TextRuntime.GetNonOptionalValue("Attribute maxlat", TextRuntime.ConvertDecimal("en-GB", value), value)
+
+    member Maxlon: decimal with get
+    let value = XmlRuntime.TryGetAttribute(this, "maxlon")
+    TextRuntime.GetNonOptionalValue("Attribute maxlon", TextRuntime.ConvertDecimal("en-GB", value), value)
+
+    member Minlat: decimal with get
+    let value = XmlRuntime.TryGetAttribute(this, "minlat")
+    TextRuntime.GetNonOptionalValue("Attribute minlat", TextRuntime.ConvertDecimal("en-GB", value), value)
+
+    member Minlon: decimal with get
+    let value = XmlRuntime.TryGetAttribute(this, "minlon")
+    TextRuntime.GetNonOptionalValue("Attribute minlon", TextRuntime.ConvertDecimal("en-GB", value), value)
+
+    member TargetNamespace: string with get
+    ("http://www.topografix.com/GPX/1/1" :> obj)
+
+    member TypeName: string with get
+    ("boundsType" :> obj)
+
+
+class XsdProvider+CopyrightType : FDR.XmlElement
+    new : author:string -> targetNamespace:string -> typeName:string -> year:string option -> license:string option -> XsdProvider+CopyrightType
+    XmlRuntime.CreateRecord("copyrightType", 
+                            [| ("author",
+                                (author :> obj)) |], 
+                            [| ("TargetNamespace",
+                                (targetNamespace :> obj))
+                               ("TypeName",
+                                (typeName :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}year",
+                                (year :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}license",
+                                (license :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+CopyrightType
+    XmlElement.Create(xElement)
+
+    member Author: string with get
+    let value = XmlRuntime.TryGetAttribute(this, "author")
+    TextRuntime.GetNonOptionalValue("Attribute author", TextRuntime.ConvertString(value), value)
+
+    member License: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}license", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                    let value = XmlRuntime.TryGetValue(t)
+                                                                                                    TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member TargetNamespace: string with get
+    ("http://www.topografix.com/GPX/1/1" :> obj)
+
+    member TypeName: string with get
+    ("copyrightType" :> obj)
+
+    member Year: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}year", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                 let value = XmlRuntime.TryGetValue(t)
+                                                                                                 TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+
+class XsdProvider+EmailType : FDR.XmlElement
+    new : id:string -> domain:string -> targetNamespace:string -> typeName:string -> XsdProvider+EmailType
+    XmlRuntime.CreateRecord("emailType", 
+                            [| ("id",
+                                (id :> obj))
+                               ("domain",
+                                (domain :> obj)) |], 
+                            [| ("TargetNamespace",
+                                (targetNamespace :> obj))
+                               ("TypeName",
+                                (typeName :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+EmailType
+    XmlElement.Create(xElement)
+
+    member Domain: string with get
+    let value = XmlRuntime.TryGetAttribute(this, "domain")
+    TextRuntime.GetNonOptionalValue("Attribute domain", TextRuntime.ConvertString(value), value)
+
+    member Id: string with get
+    let value = XmlRuntime.TryGetAttribute(this, "id")
+    TextRuntime.GetNonOptionalValue("Attribute id", TextRuntime.ConvertString(value), value)
+
+    member TargetNamespace: string with get
+    ("http://www.topografix.com/GPX/1/1" :> obj)
+
+    member TypeName: string with get
+    ("emailType" :> obj)
+
+
+class XsdProvider+ExtensionsType : FDR.XmlElement
+    new : targetNamespace:string -> typeName:string -> XsdProvider+ExtensionsType
+    XmlRuntime.CreateRecord("extensionsType", 
+                            [| |], 
+                            [| ("TargetNamespace",
+                                (targetNamespace :> obj))
+                               ("TypeName",
+                                (typeName :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+ExtensionsType
+    XmlElement.Create(xElement)
+
+    member TargetNamespace: string with get
+    ("http://www.topografix.com/GPX/1/1" :> obj)
+
+    member TypeName: string with get
+    ("extensionsType" :> obj)
+
+
+class XsdProvider+Gpx : FDR.XmlElement
+    new : version:string -> creator:string -> targetNamespace:string -> typeName:string -> metadata:XsdProvider+MetadataType option -> wpts:XsdProvider+WptType[] -> rtes:XsdProvider+RteType[] -> trks:XsdProvider+TrkType[] -> extensions:XsdProvider+ExtensionsType option -> XsdProvider+Gpx
+    XmlRuntime.CreateRecord("gpx", 
+                            [| ("version",
+                                (version :> obj))
+                               ("creator",
+                                (creator :> obj)) |], 
+                            [| ("TargetNamespace",
+                                (targetNamespace :> obj))
+                               ("TypeName",
+                                (typeName :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}metadata",
+                                (metadata :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}wpt",
+                                (wpts :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}rte",
+                                (rtes :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}trk",
+                                (trks :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}extensions",
+                                (extensions :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+Gpx
+    XmlElement.Create(xElement)
+
+    member Creator: string with get
+    let value = XmlRuntime.TryGetAttribute(this, "creator")
+    TextRuntime.GetNonOptionalValue("Attribute creator", TextRuntime.ConvertString(value), value)
+
+    member Extensions: XsdProvider+ExtensionsType option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}extensions", new Func<_,_>(id)))
+
+    member Metadata: XsdProvider+MetadataType option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}metadata", new Func<_,_>(id)))
+
+    member Rtes: XsdProvider+RteType[] with get
+    XmlRuntime.ConvertArray(this, "{http://www.topografix.com/GPX/1/1}rte", new Func<_,_>(id)))
+
+    member TargetNamespace: string with get
+    ("http://www.topografix.com/GPX/1/1" :> obj)
+
+    member Trks: XsdProvider+TrkType[] with get
+    XmlRuntime.ConvertArray(this, "{http://www.topografix.com/GPX/1/1}trk", new Func<_,_>(id)))
+
+    member TypeName: string with get
+    ("gpxType" :> obj)
+
+    member Version: string with get
+    let value = XmlRuntime.TryGetAttribute(this, "version")
+    TextRuntime.GetNonOptionalValue("Attribute version", TextRuntime.ConvertString(value), value)
+
+    member Wpts: XsdProvider+WptType[] with get
+    XmlRuntime.ConvertArray(this, "{http://www.topografix.com/GPX/1/1}wpt", new Func<_,_>(id)))
+
+
+class XsdProvider+GpxType : FDR.XmlElement
+    new : version:string -> creator:string -> targetNamespace:string -> typeName:string -> metadata:XsdProvider+MetadataType option -> wpts:XsdProvider+WptType[] -> rtes:XsdProvider+RteType[] -> trks:XsdProvider+TrkType[] -> extensions:XsdProvider+ExtensionsType option -> XsdProvider+GpxType
+    XmlRuntime.CreateRecord("gpxType", 
+                            [| ("version",
+                                (version :> obj))
+                               ("creator",
+                                (creator :> obj)) |], 
+                            [| ("TargetNamespace",
+                                (targetNamespace :> obj))
+                               ("TypeName",
+                                (typeName :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}metadata",
+                                (metadata :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}wpt",
+                                (wpts :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}rte",
+                                (rtes :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}trk",
+                                (trks :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}extensions",
+                                (extensions :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+GpxType
+    XmlElement.Create(xElement)
+
+    member Creator: string with get
+    let value = XmlRuntime.TryGetAttribute(this, "creator")
+    TextRuntime.GetNonOptionalValue("Attribute creator", TextRuntime.ConvertString(value), value)
+
+    member Extensions: XsdProvider+ExtensionsType option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}extensions", new Func<_,_>(id)))
+
+    member Metadata: XsdProvider+MetadataType option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}metadata", new Func<_,_>(id)))
+
+    member Rtes: XsdProvider+RteType[] with get
+    XmlRuntime.ConvertArray(this, "{http://www.topografix.com/GPX/1/1}rte", new Func<_,_>(id)))
+
+    member TargetNamespace: string with get
+    ("http://www.topografix.com/GPX/1/1" :> obj)
+
+    member Trks: XsdProvider+TrkType[] with get
+    XmlRuntime.ConvertArray(this, "{http://www.topografix.com/GPX/1/1}trk", new Func<_,_>(id)))
+
+    member TypeName: string with get
+    ("gpxType" :> obj)
+
+    member Version: string with get
+    let value = XmlRuntime.TryGetAttribute(this, "version")
+    TextRuntime.GetNonOptionalValue("Attribute version", TextRuntime.ConvertString(value), value)
+
+    member Wpts: XsdProvider+WptType[] with get
+    XmlRuntime.ConvertArray(this, "{http://www.topografix.com/GPX/1/1}wpt", new Func<_,_>(id)))
+
+
+class XsdProvider+LinkType : FDR.XmlElement
+    new : href:string -> targetNamespace:string -> typeName:string -> text:string option -> type:string option -> XsdProvider+LinkType
+    XmlRuntime.CreateRecord("linkType", 
+                            [| ("href",
+                                (href :> obj)) |], 
+                            [| ("TargetNamespace",
+                                (targetNamespace :> obj))
+                               ("TypeName",
+                                (typeName :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}text",
+                                (text :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}type",
+                                (type :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+LinkType
+    XmlElement.Create(xElement)
+
+    member Href: string with get
+    let value = XmlRuntime.TryGetAttribute(this, "href")
+    TextRuntime.GetNonOptionalValue("Attribute href", TextRuntime.ConvertString(value), value)
+
+    member TargetNamespace: string with get
+    ("http://www.topografix.com/GPX/1/1" :> obj)
+
+    member Text: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}text", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                 let value = XmlRuntime.TryGetValue(t)
+                                                                                                 TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member Type: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}type", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                 let value = XmlRuntime.TryGetValue(t)
+                                                                                                 TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member TypeName: string with get
+    ("linkType" :> obj)
+
+
+class XsdProvider+MetadataType : FDR.XmlElement
+    new : targetNamespace:string -> typeName:string -> name:string option -> desc:string option -> author:XsdProvider+PersonType option -> copyright:XsdProvider+CopyrightType option -> links:XsdProvider+LinkType[] -> time:System.DateTime option -> keywords:string option -> bounds:XsdProvider+BoundsType option -> extensions:XsdProvider+ExtensionsType option -> XsdProvider+MetadataType
+    XmlRuntime.CreateRecord("metadataType", 
+                            [| |], 
+                            [| ("TargetNamespace",
+                                (targetNamespace :> obj))
+                               ("TypeName",
+                                (typeName :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}name",
+                                (name :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}desc",
+                                (desc :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}author",
+                                (author :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}copyright",
+                                (copyright :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}link",
+                                (links :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}time",
+                                (time :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}keywords",
+                                (keywords :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}bounds",
+                                (bounds :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}extensions",
+                                (extensions :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+MetadataType
+    XmlElement.Create(xElement)
+
+    member Author: XsdProvider+PersonType option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}author", new Func<_,_>(id)))
+
+    member Bounds: XsdProvider+BoundsType option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}bounds", new Func<_,_>(id)))
+
+    member Copyright: XsdProvider+CopyrightType option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}copyright", new Func<_,_>(id)))
+
+    member Desc: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}desc", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                 let value = XmlRuntime.TryGetValue(t)
+                                                                                                 TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member Extensions: XsdProvider+ExtensionsType option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}extensions", new Func<_,_>(id)))
+
+    member Keywords: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}keywords", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                     let value = XmlRuntime.TryGetValue(t)
+                                                                                                     TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member Links: XsdProvider+LinkType[] with get
+    XmlRuntime.ConvertArray(this, "{http://www.topografix.com/GPX/1/1}link", new Func<_,_>(id)))
+
+    member Name: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}name", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                 let value = XmlRuntime.TryGetValue(t)
+                                                                                                 TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member TargetNamespace: string with get
+    ("http://www.topografix.com/GPX/1/1" :> obj)
+
+    member Time: System.DateTime option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}time", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                 let value = XmlRuntime.TryGetValue(t)
+                                                                                                 TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertDateTime("en-GB", value), value)))
+
+    member TypeName: string with get
+    ("metadataType" :> obj)
+
+
+class XsdProvider+PersonType : FDR.XmlElement
+    new : targetNamespace:string -> typeName:string -> name:string option -> email:XsdProvider+EmailType option -> link:XsdProvider+LinkType option -> XsdProvider+PersonType
+    XmlRuntime.CreateRecord("personType", 
+                            [| |], 
+                            [| ("TargetNamespace",
+                                (targetNamespace :> obj))
+                               ("TypeName",
+                                (typeName :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}name",
+                                (name :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}email",
+                                (email :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}link",
+                                (link :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+PersonType
+    XmlElement.Create(xElement)
+
+    member Email: XsdProvider+EmailType option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}email", new Func<_,_>(id)))
+
+    member Link: XsdProvider+LinkType option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}link", new Func<_,_>(id)))
+
+    member Name: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}name", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                 let value = XmlRuntime.TryGetValue(t)
+                                                                                                 TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member TargetNamespace: string with get
+    ("http://www.topografix.com/GPX/1/1" :> obj)
+
+    member TypeName: string with get
+    ("personType" :> obj)
+
+
+class XsdProvider+PtType : FDR.XmlElement
+    new : lat:decimal -> lon:decimal -> targetNamespace:string -> typeName:string -> ele:decimal option -> time:System.DateTime option -> XsdProvider+PtType
+    XmlRuntime.CreateRecord("ptType", 
+                            [| ("lat",
+                                (lat :> obj))
+                               ("lon",
+                                (lon :> obj)) |], 
+                            [| ("TargetNamespace",
+                                (targetNamespace :> obj))
+                               ("TypeName",
+                                (typeName :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}ele",
+                                (ele :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}time",
+                                (time :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+PtType
+    XmlElement.Create(xElement)
+
+    member Ele: decimal option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}ele", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                let value = XmlRuntime.TryGetValue(t)
+                                                                                                TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertDecimal("en-GB", value), value)))
+
+    member Lat: decimal with get
+    let value = XmlRuntime.TryGetAttribute(this, "lat")
+    TextRuntime.GetNonOptionalValue("Attribute lat", TextRuntime.ConvertDecimal("en-GB", value), value)
+
+    member Lon: decimal with get
+    let value = XmlRuntime.TryGetAttribute(this, "lon")
+    TextRuntime.GetNonOptionalValue("Attribute lon", TextRuntime.ConvertDecimal("en-GB", value), value)
+
+    member TargetNamespace: string with get
+    ("http://www.topografix.com/GPX/1/1" :> obj)
+
+    member Time: System.DateTime option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}time", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                 let value = XmlRuntime.TryGetValue(t)
+                                                                                                 TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertDateTime("en-GB", value), value)))
+
+    member TypeName: string with get
+    ("ptType" :> obj)
+
+
+class XsdProvider+PtsegType : FDR.XmlElement
+    new : targetNamespace:string -> typeName:string -> pts:XsdProvider+PtType[] -> XsdProvider+PtsegType
+    XmlRuntime.CreateRecord("ptsegType", 
+                            [| |], 
+                            [| ("TargetNamespace",
+                                (targetNamespace :> obj))
+                               ("TypeName",
+                                (typeName :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}pt",
+                                (pts :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+PtsegType
+    XmlElement.Create(xElement)
+
+    member Pts: XsdProvider+PtType[] with get
+    XmlRuntime.ConvertArray(this, "{http://www.topografix.com/GPX/1/1}pt", new Func<_,_>(id)))
+
+    member TargetNamespace: string with get
+    ("http://www.topografix.com/GPX/1/1" :> obj)
+
+    member TypeName: string with get
+    ("ptsegType" :> obj)
+
+
+class XsdProvider+RteType : FDR.XmlElement
+    new : targetNamespace:string -> typeName:string -> name:string option -> cmt:string option -> desc:string option -> src:string option -> links:XsdProvider+LinkType[] -> number:string option -> type:string option -> extensions:XsdProvider+ExtensionsType option -> rtepts:XsdProvider+WptType[] -> XsdProvider+RteType
+    XmlRuntime.CreateRecord("rteType", 
+                            [| |], 
+                            [| ("TargetNamespace",
+                                (targetNamespace :> obj))
+                               ("TypeName",
+                                (typeName :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}name",
+                                (name :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}cmt",
+                                (cmt :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}desc",
+                                (desc :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}src",
+                                (src :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}link",
+                                (links :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}number",
+                                (number :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}type",
+                                (type :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}extensions",
+                                (extensions :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}rtept",
+                                (rtepts :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+RteType
+    XmlElement.Create(xElement)
+
+    member Cmt: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}cmt", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                let value = XmlRuntime.TryGetValue(t)
+                                                                                                TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member Desc: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}desc", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                 let value = XmlRuntime.TryGetValue(t)
+                                                                                                 TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member Extensions: XsdProvider+ExtensionsType option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}extensions", new Func<_,_>(id)))
+
+    member Links: XsdProvider+LinkType[] with get
+    XmlRuntime.ConvertArray(this, "{http://www.topografix.com/GPX/1/1}link", new Func<_,_>(id)))
+
+    member Name: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}name", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                 let value = XmlRuntime.TryGetValue(t)
+                                                                                                 TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member Number: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}number", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                   let value = XmlRuntime.TryGetValue(t)
+                                                                                                   TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member Rtepts: XsdProvider+WptType[] with get
+    XmlRuntime.ConvertArray(this, "{http://www.topografix.com/GPX/1/1}rtept", new Func<_,_>(id)))
+
+    member Src: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}src", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                let value = XmlRuntime.TryGetValue(t)
+                                                                                                TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member TargetNamespace: string with get
+    ("http://www.topografix.com/GPX/1/1" :> obj)
+
+    member Type: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}type", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                 let value = XmlRuntime.TryGetValue(t)
+                                                                                                 TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member TypeName: string with get
+    ("rteType" :> obj)
+
+
+class XsdProvider+Schema : FDR.XmlElement
+    new : boundsType:XsdProvider+BoundsType -> copyrightType:XsdProvider+CopyrightType -> degreesType:decimal -> dgpsStationType:int -> emailType:XsdProvider+EmailType -> extensionsType:XsdProvider+ExtensionsType -> fixType:string -> gpx:XsdProvider+Gpx -> gpxType:XsdProvider+GpxType -> latitudeType:decimal -> linkType:XsdProvider+LinkType -> longitudeType:decimal -> metadataType:XsdProvider+MetadataType -> personType:XsdProvider+PersonType -> ptType:XsdProvider+PtType -> ptsegType:XsdProvider+PtsegType -> rteType:XsdProvider+RteType -> trkType:XsdProvider+TrkType -> trksegType:XsdProvider+TrksegType -> wptType:XsdProvider+WptType -> XsdProvider+Schema
+    XmlRuntime.CreateRecord("Schema", 
+                            [| |], 
+                            [| ("boundsType",
+                                (boundsType :> obj))
+                               ("copyrightType",
+                                (copyrightType :> obj))
+                               ("degreesType",
+                                (degreesType :> obj))
+                               ("dgpsStationType",
+                                (dgpsStationType :> obj))
+                               ("emailType",
+                                (emailType :> obj))
+                               ("extensionsType",
+                                (extensionsType :> obj))
+                               ("fixType",
+                                (fixType :> obj))
+                               ("gpx",
+                                (gpx :> obj))
+                               ("gpxType",
+                                (gpxType :> obj))
+                               ("latitudeType",
+                                (latitudeType :> obj))
+                               ("linkType",
+                                (linkType :> obj))
+                               ("longitudeType",
+                                (longitudeType :> obj))
+                               ("metadataType",
+                                (metadataType :> obj))
+                               ("personType",
+                                (personType :> obj))
+                               ("ptType",
+                                (ptType :> obj))
+                               ("ptsegType",
+                                (ptsegType :> obj))
+                               ("rteType",
+                                (rteType :> obj))
+                               ("trkType",
+                                (trkType :> obj))
+                               ("trksegType",
+                                (trksegType :> obj))
+                               ("wptType",
+                                (wptType :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+Schema
+    XmlElement.Create(xElement)
+
+    member BoundsType: XsdProvider+BoundsType with get
+    XmlRuntime.GetChild(this, "boundsType")
+
+    member CopyrightType: XsdProvider+CopyrightType with get
+    XmlRuntime.GetChild(this, "copyrightType")
+
+    member DegreesType: decimal with get
+    let value = XmlRuntime.TryGetValue(XmlRuntime.GetChild(this, "degreesType"))
+    TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertDecimal("en-GB", value), value)
+
+    member DgpsStationType: int with get
+    let value = XmlRuntime.TryGetValue(XmlRuntime.GetChild(this, "dgpsStationType"))
+    TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertInteger("en-GB", value), value)
+
+    member EmailType: XsdProvider+EmailType with get
+    XmlRuntime.GetChild(this, "emailType")
+
+    member ExtensionsType: XsdProvider+ExtensionsType with get
+    XmlRuntime.GetChild(this, "extensionsType")
+
+    member FixType: string with get
+    let value = XmlRuntime.TryGetValue(XmlRuntime.GetChild(this, "fixType"))
+    TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)
+
+    member Gpx: XsdProvider+Gpx with get
+    XmlRuntime.GetChild(this, "gpx")
+
+    member GpxType: XsdProvider+GpxType with get
+    XmlRuntime.GetChild(this, "gpxType")
+
+    member LatitudeType: decimal with get
+    let value = XmlRuntime.TryGetValue(XmlRuntime.GetChild(this, "latitudeType"))
+    TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertDecimal("en-GB", value), value)
+
+    member LinkType: XsdProvider+LinkType with get
+    XmlRuntime.GetChild(this, "linkType")
+
+    member LongitudeType: decimal with get
+    let value = XmlRuntime.TryGetValue(XmlRuntime.GetChild(this, "longitudeType"))
+    TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertDecimal("en-GB", value), value)
+
+    member MetadataType: XsdProvider+MetadataType with get
+    XmlRuntime.GetChild(this, "metadataType")
+
+    member PersonType: XsdProvider+PersonType with get
+    XmlRuntime.GetChild(this, "personType")
+
+    member PtType: XsdProvider+PtType with get
+    XmlRuntime.GetChild(this, "ptType")
+
+    member PtsegType: XsdProvider+PtsegType with get
+    XmlRuntime.GetChild(this, "ptsegType")
+
+    member RteType: XsdProvider+RteType with get
+    XmlRuntime.GetChild(this, "rteType")
+
+    member TrkType: XsdProvider+TrkType with get
+    XmlRuntime.GetChild(this, "trkType")
+
+    member TrksegType: XsdProvider+TrksegType with get
+    XmlRuntime.GetChild(this, "trksegType")
+
+    member WptType: XsdProvider+WptType with get
+    XmlRuntime.GetChild(this, "wptType")
+
+
+class XsdProvider+TrkType : FDR.XmlElement
+    new : targetNamespace:string -> typeName:string -> name:string option -> cmt:string option -> desc:string option -> src:string option -> links:XsdProvider+LinkType[] -> number:string option -> type:string option -> extensions:XsdProvider+ExtensionsType option -> trksegs:XsdProvider+TrksegType[] -> XsdProvider+TrkType
+    XmlRuntime.CreateRecord("trkType", 
+                            [| |], 
+                            [| ("TargetNamespace",
+                                (targetNamespace :> obj))
+                               ("TypeName",
+                                (typeName :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}name",
+                                (name :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}cmt",
+                                (cmt :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}desc",
+                                (desc :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}src",
+                                (src :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}link",
+                                (links :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}number",
+                                (number :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}type",
+                                (type :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}extensions",
+                                (extensions :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}trkseg",
+                                (trksegs :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+TrkType
+    XmlElement.Create(xElement)
+
+    member Cmt: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}cmt", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                let value = XmlRuntime.TryGetValue(t)
+                                                                                                TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member Desc: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}desc", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                 let value = XmlRuntime.TryGetValue(t)
+                                                                                                 TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member Extensions: XsdProvider+ExtensionsType option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}extensions", new Func<_,_>(id)))
+
+    member Links: XsdProvider+LinkType[] with get
+    XmlRuntime.ConvertArray(this, "{http://www.topografix.com/GPX/1/1}link", new Func<_,_>(id)))
+
+    member Name: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}name", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                 let value = XmlRuntime.TryGetValue(t)
+                                                                                                 TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member Number: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}number", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                   let value = XmlRuntime.TryGetValue(t)
+                                                                                                   TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member Src: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}src", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                let value = XmlRuntime.TryGetValue(t)
+                                                                                                TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member TargetNamespace: string with get
+    ("http://www.topografix.com/GPX/1/1" :> obj)
+
+    member Trksegs: XsdProvider+TrksegType[] with get
+    XmlRuntime.ConvertArray(this, "{http://www.topografix.com/GPX/1/1}trkseg", new Func<_,_>(id)))
+
+    member Type: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}type", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                 let value = XmlRuntime.TryGetValue(t)
+                                                                                                 TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member TypeName: string with get
+    ("trkType" :> obj)
+
+
+class XsdProvider+TrksegType : FDR.XmlElement
+    new : targetNamespace:string -> typeName:string -> trkpts:XsdProvider+WptType[] -> extensions:XsdProvider+ExtensionsType option -> XsdProvider+TrksegType
+    XmlRuntime.CreateRecord("trksegType", 
+                            [| |], 
+                            [| ("TargetNamespace",
+                                (targetNamespace :> obj))
+                               ("TypeName",
+                                (typeName :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}trkpt",
+                                (trkpts :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}extensions",
+                                (extensions :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+TrksegType
+    XmlElement.Create(xElement)
+
+    member Extensions: XsdProvider+ExtensionsType option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}extensions", new Func<_,_>(id)))
+
+    member TargetNamespace: string with get
+    ("http://www.topografix.com/GPX/1/1" :> obj)
+
+    member Trkpts: XsdProvider+WptType[] with get
+    XmlRuntime.ConvertArray(this, "{http://www.topografix.com/GPX/1/1}trkpt", new Func<_,_>(id)))
+
+    member TypeName: string with get
+    ("trksegType" :> obj)
+
+
+class XsdProvider+WptType : FDR.XmlElement
+    new : lat:decimal -> lon:decimal -> targetNamespace:string -> typeName:string -> ele:decimal option -> time:System.DateTime option -> magvar:decimal option -> geoidheight:decimal option -> name:string option -> cmt:string option -> desc:string option -> src:string option -> links:XsdProvider+LinkType[] -> sym:string option -> type:string option -> fix:string option -> sat:string option -> hdop:decimal option -> vdop:decimal option -> pdop:decimal option -> ageofdgpsdata:decimal option -> dgpsid:int option -> extensions:XsdProvider+ExtensionsType option -> XsdProvider+WptType
+    XmlRuntime.CreateRecord("wptType", 
+                            [| ("lat",
+                                (lat :> obj))
+                               ("lon",
+                                (lon :> obj)) |], 
+                            [| ("TargetNamespace",
+                                (targetNamespace :> obj))
+                               ("TypeName",
+                                (typeName :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}ele",
+                                (ele :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}time",
+                                (time :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}magvar",
+                                (magvar :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}geoidheight",
+                                (geoidheight :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}name",
+                                (name :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}cmt",
+                                (cmt :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}desc",
+                                (desc :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}src",
+                                (src :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}link",
+                                (links :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}sym",
+                                (sym :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}type",
+                                (type :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}fix",
+                                (fix :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}sat",
+                                (sat :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}hdop",
+                                (hdop :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}vdop",
+                                (vdop :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}pdop",
+                                (pdop :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}ageofdgpsdata",
+                                (ageofdgpsdata :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}dgpsid",
+                                (dgpsid :> obj))
+                               ("{http://www.topografix.com/GPX/1/1}extensions",
+                                (extensions :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+WptType
+    XmlElement.Create(xElement)
+
+    member Ageofdgpsdata: decimal option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}ageofdgpsdata", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                          let value = XmlRuntime.TryGetValue(t)
+                                                                                                          TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertDecimal("en-GB", value), value)))
+
+    member Cmt: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}cmt", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                let value = XmlRuntime.TryGetValue(t)
+                                                                                                TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member Desc: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}desc", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                 let value = XmlRuntime.TryGetValue(t)
+                                                                                                 TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member Dgpsid: int option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}dgpsid", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                   let value = XmlRuntime.TryGetValue(t)
+                                                                                                   TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertInteger("en-GB", value), value)))
+
+    member Ele: decimal option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}ele", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                let value = XmlRuntime.TryGetValue(t)
+                                                                                                TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertDecimal("en-GB", value), value)))
+
+    member Extensions: XsdProvider+ExtensionsType option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}extensions", new Func<_,_>(id)))
+
+    member Fix: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}fix", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                let value = XmlRuntime.TryGetValue(t)
+                                                                                                TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member Geoidheight: decimal option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}geoidheight", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                        let value = XmlRuntime.TryGetValue(t)
+                                                                                                        TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertDecimal("en-GB", value), value)))
+
+    member Hdop: decimal option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}hdop", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                 let value = XmlRuntime.TryGetValue(t)
+                                                                                                 TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertDecimal("en-GB", value), value)))
+
+    member Lat: decimal with get
+    let value = XmlRuntime.TryGetAttribute(this, "lat")
+    TextRuntime.GetNonOptionalValue("Attribute lat", TextRuntime.ConvertDecimal("en-GB", value), value)
+
+    member Links: XsdProvider+LinkType[] with get
+    XmlRuntime.ConvertArray(this, "{http://www.topografix.com/GPX/1/1}link", new Func<_,_>(id)))
+
+    member Lon: decimal with get
+    let value = XmlRuntime.TryGetAttribute(this, "lon")
+    TextRuntime.GetNonOptionalValue("Attribute lon", TextRuntime.ConvertDecimal("en-GB", value), value)
+
+    member Magvar: decimal option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}magvar", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                   let value = XmlRuntime.TryGetValue(t)
+                                                                                                   TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertDecimal("en-GB", value), value)))
+
+    member Name: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}name", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                 let value = XmlRuntime.TryGetValue(t)
+                                                                                                 TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member Pdop: decimal option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}pdop", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                 let value = XmlRuntime.TryGetValue(t)
+                                                                                                 TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertDecimal("en-GB", value), value)))
+
+    member Sat: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}sat", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                let value = XmlRuntime.TryGetValue(t)
+                                                                                                TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member Src: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}src", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                let value = XmlRuntime.TryGetValue(t)
+                                                                                                TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member Sym: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}sym", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                let value = XmlRuntime.TryGetValue(t)
+                                                                                                TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member TargetNamespace: string with get
+    ("http://www.topografix.com/GPX/1/1" :> obj)
+
+    member Time: System.DateTime option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}time", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                 let value = XmlRuntime.TryGetValue(t)
+                                                                                                 TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertDateTime("en-GB", value), value)))
+
+    member Type: string option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}type", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                 let value = XmlRuntime.TryGetValue(t)
+                                                                                                 TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)))
+
+    member TypeName: string with get
+    ("wptType" :> obj)
+
+    member Vdop: decimal option with get
+    XmlRuntime.ConvertOptional(this, "{http://www.topografix.com/GPX/1/1}vdop", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                                 let value = XmlRuntime.TryGetValue(t)
+                                                                                                 TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertDecimal("en-GB", value), value)))
+
+

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Xsd,purchaseOrder.xsd,True,False.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Xsd,purchaseOrder.xsd,True,False.expected
@@ -1,0 +1,388 @@
+class XsdProvider
+    static member AsyncGetSample: () -> XsdProvider+Schema async
+    let f = new Func<_,_>(fun (t:TextReader) -> XmlElement.Create(t))
+    TextRuntime.AsyncMap((IO.asyncReadTextAtRuntimeWithDesignTimeRules @"<RESOLUTION_FOLDER>" "" "XSD" "purchaseOrder.xsd"), f)
+
+    static member AsyncLoad: uri:string -> XsdProvider+Schema async
+    let f = new Func<_,_>(fun (t:TextReader) -> XmlElement.Create(t))
+    TextRuntime.AsyncMap((IO.asyncReadTextAtRuntime false @"<RESOLUTION_FOLDER>" "" "XSD" uri), f)
+
+    static member GetSample: () -> XsdProvider+Schema
+    XmlElement.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntimeWithDesignTimeRules @"<RESOLUTION_FOLDER>" "" "XSD" "purchaseOrder.xsd")))
+
+    static member Load: stream:System.IO.Stream -> XsdProvider+Schema
+    XmlElement.Create(((new StreamReader(stream)) :> TextReader))
+
+    static member Load: reader:System.IO.TextReader -> XsdProvider+Schema
+    XmlElement.Create(reader)
+
+    static member Load: uri:string -> XsdProvider+Schema
+    XmlElement.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false @"<RESOLUTION_FOLDER>" "" "XSD" uri)))
+
+    static member Parse: text:string -> XsdProvider+Schema
+    XmlElement.Create(((new StringReader(text)) :> TextReader))
+
+    static member ParseItems: text:string -> XsdProvider+Items
+    XmlElement.Create(let t = text
+                      let doc = XDocument.Parse(t)
+                      let t = IfThenElse (Call (None, op_Equality,
+                  [Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                             get_Root, [])),
+                                                 get_Name, [])), get_LocalName,
+                                     [])), ToLower, []), Value ("items")]),
+            Let (newRoot,
+                 NewObject (XElement,
+                            Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                                      get_Root,
+                                                                      [])),
+                                                          get_Name, [])),
+                                              get_Namespace, [])), GetName,
+                                  [Value ("root__")])),
+                 Sequential (Call (Some (newRoot), Add,
+                                   [Coerce (Call (Some (doc), get_Root, []),
+                                            Object)]),
+                             Let (newDoc,
+                                  NewObject (XDocument,
+                                             Call (Some (doc), get_Declaration,
+                                                   []), NewArray (Object)),
+                                  Sequential (Call (Some (newDoc), Add,
+                                                    [Coerce (newRoot, Object)]),
+                                              Call (Some (doc), ToString, []))))),
+            t)
+                      ((new StringReader(t)) :> TextReader))
+
+    static member ParsePurchaseOrder: text:string -> XsdProvider+PurchaseOrder
+    XmlElement.Create(let t = text
+                      let doc = XDocument.Parse(t)
+                      let t = IfThenElse (Call (None, op_Equality,
+                  [Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                             get_Root, [])),
+                                                 get_Name, [])), get_LocalName,
+                                     [])), ToLower, []), Value ("purchaseorder")]),
+            Let (newRoot,
+                 NewObject (XElement,
+                            Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                                      get_Root,
+                                                                      [])),
+                                                          get_Name, [])),
+                                              get_Namespace, [])), GetName,
+                                  [Value ("root__")])),
+                 Sequential (Call (Some (newRoot), Add,
+                                   [Coerce (Call (Some (doc), get_Root, []),
+                                            Object)]),
+                             Let (newDoc,
+                                  NewObject (XDocument,
+                                             Call (Some (doc), get_Declaration,
+                                                   []), NewArray (Object)),
+                                  Sequential (Call (Some (newDoc), Add,
+                                                    [Coerce (newRoot, Object)]),
+                                              Call (Some (doc), ToString, []))))),
+            t)
+                      ((new StringReader(t)) :> TextReader))
+
+    static member ParsePurchaseOrderType: text:string -> XsdProvider+PurchaseOrderType
+    XmlElement.Create(let t = text
+                      let doc = XDocument.Parse(t)
+                      let t = IfThenElse (Call (None, op_Equality,
+                  [Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                             get_Root, [])),
+                                                 get_Name, [])), get_LocalName,
+                                     [])), ToLower, []),
+                   Value ("purchaseordertype")]),
+            Let (newRoot,
+                 NewObject (XElement,
+                            Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                                      get_Root,
+                                                                      [])),
+                                                          get_Name, [])),
+                                              get_Namespace, [])), GetName,
+                                  [Value ("root__")])),
+                 Sequential (Call (Some (newRoot), Add,
+                                   [Coerce (Call (Some (doc), get_Root, []),
+                                            Object)]),
+                             Let (newDoc,
+                                  NewObject (XDocument,
+                                             Call (Some (doc), get_Declaration,
+                                                   []), NewArray (Object)),
+                                  Sequential (Call (Some (newDoc), Add,
+                                                    [Coerce (newRoot, Object)]),
+                                              Call (Some (doc), ToString, []))))),
+            t)
+                      ((new StringReader(t)) :> TextReader))
+
+    static member ParseUsAddress: text:string -> XsdProvider+UsAddress
+    XmlElement.Create(let t = text
+                      let doc = XDocument.Parse(t)
+                      let t = IfThenElse (Call (None, op_Equality,
+                  [Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                             get_Root, [])),
+                                                 get_Name, [])), get_LocalName,
+                                     [])), ToLower, []), Value ("usaddress")]),
+            Let (newRoot,
+                 NewObject (XElement,
+                            Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                                      get_Root,
+                                                                      [])),
+                                                          get_Name, [])),
+                                              get_Namespace, [])), GetName,
+                                  [Value ("root__")])),
+                 Sequential (Call (Some (newRoot), Add,
+                                   [Coerce (Call (Some (doc), get_Root, []),
+                                            Object)]),
+                             Let (newDoc,
+                                  NewObject (XDocument,
+                                             Call (Some (doc), get_Declaration,
+                                                   []), NewArray (Object)),
+                                  Sequential (Call (Some (newDoc), Add,
+                                                    [Coerce (newRoot, Object)]),
+                                              Call (Some (doc), ToString, []))))),
+            t)
+                      ((new StringReader(t)) :> TextReader))
+
+
+class XsdProvider+Items : FDR.XmlElement
+    new : targetNamespace:string -> typeName:string -> items:XsdProvider+Item[] -> XsdProvider+Items
+    XmlRuntime.CreateRecord("Items", 
+                            [| |], 
+                            [| ("TargetNamespace",
+                                (targetNamespace :> obj))
+                               ("TypeName",
+                                (typeName :> obj))
+                               ("{http://tempuri.org/po.xsd}item",
+                                (items :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+Items
+    XmlElement.Create(xElement)
+
+    member Items: XsdProvider+Item[] with get
+    XmlRuntime.ConvertArray(this, "{http://tempuri.org/po.xsd}item", new Func<_,_>(id)))
+
+    member TargetNamespace: string with get
+    ("http://tempuri.org/po.xsd" :> obj)
+
+    member TypeName: string with get
+    ("Items" :> obj)
+
+
+class XsdProvider+PurchaseOrder : FDR.XmlElement
+    new : orderDate:System.DateTime -> targetNamespace:string -> typeName:string -> shipTo:XsdProvider+UsAddress -> billTo:XsdProvider+UsAddress -> items:XsdProvider+Items -> XsdProvider+PurchaseOrder
+    XmlRuntime.CreateRecord("purchaseOrder", 
+                            [| ("orderDate",
+                                (orderDate :> obj)) |], 
+                            [| ("TargetNamespace",
+                                (targetNamespace :> obj))
+                               ("TypeName",
+                                (typeName :> obj))
+                               ("{http://tempuri.org/po.xsd}shipTo",
+                                (shipTo :> obj))
+                               ("{http://tempuri.org/po.xsd}billTo",
+                                (billTo :> obj))
+                               ("{http://tempuri.org/po.xsd}items",
+                                (items :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+PurchaseOrder
+    XmlElement.Create(xElement)
+
+    member BillTo: XsdProvider+UsAddress with get
+    XmlRuntime.GetChild(this, "{http://tempuri.org/po.xsd}billTo")
+
+    member Items: XsdProvider+Items with get
+    XmlRuntime.GetChild(this, "{http://tempuri.org/po.xsd}items")
+
+    member OrderDate: System.DateTime with get
+    let value = XmlRuntime.TryGetAttribute(this, "orderDate")
+    TextRuntime.GetNonOptionalValue("Attribute orderDate", TextRuntime.ConvertDateTime("en-GB", value), value)
+
+    member ShipTo: XsdProvider+UsAddress with get
+    XmlRuntime.GetChild(this, "{http://tempuri.org/po.xsd}shipTo")
+
+    member TargetNamespace: string with get
+    ("http://tempuri.org/po.xsd" :> obj)
+
+    member TypeName: string with get
+    ("PurchaseOrderType" :> obj)
+
+
+class XsdProvider+PurchaseOrderType : FDR.XmlElement
+    new : orderDate:System.DateTime -> targetNamespace:string -> typeName:string -> shipTo:XsdProvider+UsAddress -> billTo:XsdProvider+UsAddress -> items:XsdProvider+Items -> XsdProvider+PurchaseOrderType
+    XmlRuntime.CreateRecord("PurchaseOrderType", 
+                            [| ("orderDate",
+                                (orderDate :> obj)) |], 
+                            [| ("TargetNamespace",
+                                (targetNamespace :> obj))
+                               ("TypeName",
+                                (typeName :> obj))
+                               ("{http://tempuri.org/po.xsd}shipTo",
+                                (shipTo :> obj))
+                               ("{http://tempuri.org/po.xsd}billTo",
+                                (billTo :> obj))
+                               ("{http://tempuri.org/po.xsd}items",
+                                (items :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+PurchaseOrderType
+    XmlElement.Create(xElement)
+
+    member BillTo: XsdProvider+UsAddress with get
+    XmlRuntime.GetChild(this, "{http://tempuri.org/po.xsd}billTo")
+
+    member Items: XsdProvider+Items with get
+    XmlRuntime.GetChild(this, "{http://tempuri.org/po.xsd}items")
+
+    member OrderDate: System.DateTime with get
+    let value = XmlRuntime.TryGetAttribute(this, "orderDate")
+    TextRuntime.GetNonOptionalValue("Attribute orderDate", TextRuntime.ConvertDateTime("en-GB", value), value)
+
+    member ShipTo: XsdProvider+UsAddress with get
+    XmlRuntime.GetChild(this, "{http://tempuri.org/po.xsd}shipTo")
+
+    member TargetNamespace: string with get
+    ("http://tempuri.org/po.xsd" :> obj)
+
+    member TypeName: string with get
+    ("PurchaseOrderType" :> obj)
+
+
+class XsdProvider+Schema : FDR.XmlElement
+    new : items:XsdProvider+Items -> purchaseOrderType:XsdProvider+PurchaseOrderType -> sku:string -> usAddress:XsdProvider+UsAddress -> comment:string -> purchaseOrder:XsdProvider+PurchaseOrder -> XsdProvider+Schema
+    XmlRuntime.CreateRecord("Schema", 
+                            [| |], 
+                            [| ("Items",
+                                (items :> obj))
+                               ("PurchaseOrderType",
+                                (purchaseOrderType :> obj))
+                               ("SKU",
+                                (sku :> obj))
+                               ("USAddress",
+                                (usAddress :> obj))
+                               ("comment",
+                                (comment :> obj))
+                               ("purchaseOrder",
+                                (purchaseOrder :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+Schema
+    XmlElement.Create(xElement)
+
+    member Comment: string with get
+    let value = XmlRuntime.TryGetValue(XmlRuntime.GetChild(this, "comment"))
+    TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)
+
+    member Items: XsdProvider+Items with get
+    XmlRuntime.GetChild(this, "Items")
+
+    member PurchaseOrder: XsdProvider+PurchaseOrder with get
+    XmlRuntime.GetChild(this, "purchaseOrder")
+
+    member PurchaseOrderType: XsdProvider+PurchaseOrderType with get
+    XmlRuntime.GetChild(this, "PurchaseOrderType")
+
+    member Sku: string with get
+    let value = XmlRuntime.TryGetValue(XmlRuntime.GetChild(this, "SKU"))
+    TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)
+
+    member UsAddress: XsdProvider+UsAddress with get
+    XmlRuntime.GetChild(this, "USAddress")
+
+
+class XsdProvider+UsAddress : FDR.XmlElement
+    new : country:string -> targetNamespace:string -> typeName:string -> name:string -> street:string -> city:string -> state:string -> zip:decimal -> XsdProvider+UsAddress
+    XmlRuntime.CreateRecord("USAddress", 
+                            [| ("country",
+                                (country :> obj)) |], 
+                            [| ("TargetNamespace",
+                                (targetNamespace :> obj))
+                               ("TypeName",
+                                (typeName :> obj))
+                               ("{http://tempuri.org/po.xsd}name",
+                                (name :> obj))
+                               ("{http://tempuri.org/po.xsd}street",
+                                (street :> obj))
+                               ("{http://tempuri.org/po.xsd}city",
+                                (city :> obj))
+                               ("{http://tempuri.org/po.xsd}state",
+                                (state :> obj))
+                               ("{http://tempuri.org/po.xsd}zip",
+                                (zip :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+UsAddress
+    XmlElement.Create(xElement)
+
+    member City: string with get
+    let value = XmlRuntime.TryGetValue(XmlRuntime.GetChild(this, "{http://tempuri.org/po.xsd}city"))
+    TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)
+
+    member Country: string with get
+    let value = XmlRuntime.TryGetAttribute(this, "country")
+    TextRuntime.GetNonOptionalValue("Attribute country", TextRuntime.ConvertString(value), value)
+
+    member Name: string with get
+    let value = XmlRuntime.TryGetValue(XmlRuntime.GetChild(this, "{http://tempuri.org/po.xsd}name"))
+    TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)
+
+    member State: string with get
+    let value = XmlRuntime.TryGetValue(XmlRuntime.GetChild(this, "{http://tempuri.org/po.xsd}state"))
+    TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)
+
+    member Street: string with get
+    let value = XmlRuntime.TryGetValue(XmlRuntime.GetChild(this, "{http://tempuri.org/po.xsd}street"))
+    TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)
+
+    member TargetNamespace: string with get
+    ("http://tempuri.org/po.xsd" :> obj)
+
+    member TypeName: string with get
+    ("USAddress" :> obj)
+
+    member Zip: decimal with get
+    let value = XmlRuntime.TryGetValue(XmlRuntime.GetChild(this, "{http://tempuri.org/po.xsd}zip"))
+    TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertDecimal("en-GB", value), value)
+
+
+class XsdProvider+Item : FDR.XmlElement
+    new : partNum:string -> targetNamespace:string -> typeName:string -> productName:string -> quantity:string -> usPrice:decimal -> shipDate:System.DateTime option -> XsdProvider+Item
+    XmlRuntime.CreateRecord("Item", 
+                            [| ("partNum",
+                                (partNum :> obj)) |], 
+                            [| ("TargetNamespace",
+                                (targetNamespace :> obj))
+                               ("TypeName",
+                                (typeName :> obj))
+                               ("{http://tempuri.org/po.xsd}productName",
+                                (productName :> obj))
+                               ("{http://tempuri.org/po.xsd}quantity",
+                                (quantity :> obj))
+                               ("{http://tempuri.org/po.xsd}USPrice",
+                                (usPrice :> obj))
+                               ("{http://tempuri.org/po.xsd}shipDate",
+                                (shipDate :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+Item
+    XmlElement.Create(xElement)
+
+    member PartNum: string with get
+    let value = XmlRuntime.TryGetAttribute(this, "partNum")
+    TextRuntime.GetNonOptionalValue("Attribute partNum", TextRuntime.ConvertString(value), value)
+
+    member ProductName: string with get
+    let value = XmlRuntime.TryGetValue(XmlRuntime.GetChild(this, "{http://tempuri.org/po.xsd}productName"))
+    TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)
+
+    member Quantity: string with get
+    let value = XmlRuntime.TryGetValue(XmlRuntime.GetChild(this, "{http://tempuri.org/po.xsd}quantity"))
+    TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)
+
+    member ShipDate: System.DateTime option with get
+    XmlRuntime.ConvertOptional(this, "{http://tempuri.org/po.xsd}shipDate", new Func<_,_>(fun (t:XmlElement) -> 
+                                                                                             let value = XmlRuntime.TryGetValue(t)
+                                                                                             TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertDateTime("en-GB", value), value)))
+
+    member TargetNamespace: string with get
+    ("http://tempuri.org/po.xsd" :> obj)
+
+    member TypeName: string with get
+    ("Item2" :> obj)
+
+    member UsPrice: decimal with get
+    let value = XmlRuntime.TryGetValue(XmlRuntime.GetChild(this, "{http://tempuri.org/po.xsd}USPrice"))
+    TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertDecimal("en-GB", value), value)
+
+

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Xsd,xaml2006.xsd,True,False.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Xsd,xaml2006.xsd,True,False.expected
@@ -1,0 +1,274 @@
+class XsdProvider
+    static member AsyncGetSample: () -> XsdProvider+Schema async
+    let f = new Func<_,_>(fun (t:TextReader) -> XmlElement.Create(t))
+    TextRuntime.AsyncMap((IO.asyncReadTextAtRuntimeWithDesignTimeRules @"<RESOLUTION_FOLDER>" "" "XSD" "xaml2006.xsd"), f)
+
+    static member AsyncLoad: uri:string -> XsdProvider+Schema async
+    let f = new Func<_,_>(fun (t:TextReader) -> XmlElement.Create(t))
+    TextRuntime.AsyncMap((IO.asyncReadTextAtRuntime false @"<RESOLUTION_FOLDER>" "" "XSD" uri), f)
+
+    static member GetSample: () -> XsdProvider+Schema
+    XmlElement.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntimeWithDesignTimeRules @"<RESOLUTION_FOLDER>" "" "XSD" "xaml2006.xsd")))
+
+    static member Load: stream:System.IO.Stream -> XsdProvider+Schema
+    XmlElement.Create(((new StreamReader(stream)) :> TextReader))
+
+    static member Load: reader:System.IO.TextReader -> XsdProvider+Schema
+    XmlElement.Create(reader)
+
+    static member Load: uri:string -> XsdProvider+Schema
+    XmlElement.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false @"<RESOLUTION_FOLDER>" "" "XSD" uri)))
+
+    static member Parse: text:string -> XsdProvider+Schema
+    XmlElement.Create(((new StringReader(text)) :> TextReader))
+
+    static member ParseCode: text:string -> XsdProvider+Code
+    XmlElement.Create(let t = text
+                      let doc = XDocument.Parse(t)
+                      let t = IfThenElse (Call (None, op_Equality,
+                  [Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                             get_Root, [])),
+                                                 get_Name, [])), get_LocalName,
+                                     [])), ToLower, []), Value ("code")]),
+            Let (newRoot,
+                 NewObject (XElement,
+                            Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                                      get_Root,
+                                                                      [])),
+                                                          get_Name, [])),
+                                              get_Namespace, [])), GetName,
+                                  [Value ("root__")])),
+                 Sequential (Call (Some (newRoot), Add,
+                                   [Coerce (Call (Some (doc), get_Root, []),
+                                            Object)]),
+                             Let (newDoc,
+                                  NewObject (XDocument,
+                                             Call (Some (doc), get_Declaration,
+                                                   []), NewArray (Object)),
+                                  Sequential (Call (Some (newDoc), Add,
+                                                    [Coerce (newRoot, Object)]),
+                                              Call (Some (doc), ToString, []))))),
+            t)
+                      ((new StringReader(t)) :> TextReader))
+
+    static member ParseDCode: text:string -> XsdProvider+DCode
+    XmlElement.Create(let t = text
+                      let doc = XDocument.Parse(t)
+                      let t = IfThenElse (Call (None, op_Equality,
+                  [Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                             get_Root, [])),
+                                                 get_Name, [])), get_LocalName,
+                                     [])), ToLower, []), Value ("dcode")]),
+            Let (newRoot,
+                 NewObject (XElement,
+                            Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                                      get_Root,
+                                                                      [])),
+                                                          get_Name, [])),
+                                              get_Namespace, [])), GetName,
+                                  [Value ("root__")])),
+                 Sequential (Call (Some (newRoot), Add,
+                                   [Coerce (Call (Some (doc), get_Root, []),
+                                            Object)]),
+                             Let (newDoc,
+                                  NewObject (XDocument,
+                                             Call (Some (doc), get_Declaration,
+                                                   []), NewArray (Object)),
+                                  Sequential (Call (Some (newDoc), Add,
+                                                    [Coerce (newRoot, Object)]),
+                                              Call (Some (doc), ToString, []))))),
+            t)
+                      ((new StringReader(t)) :> TextReader))
+
+    static member ParseDXData: text:string -> XsdProvider+DXData
+    XmlElement.Create(let t = text
+                      let doc = XDocument.Parse(t)
+                      let t = IfThenElse (Call (None, op_Equality,
+                  [Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                             get_Root, [])),
+                                                 get_Name, [])), get_LocalName,
+                                     [])), ToLower, []), Value ("dxdata")]),
+            Let (newRoot,
+                 NewObject (XElement,
+                            Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                                      get_Root,
+                                                                      [])),
+                                                          get_Name, [])),
+                                              get_Namespace, [])), GetName,
+                                  [Value ("root__")])),
+                 Sequential (Call (Some (newRoot), Add,
+                                   [Coerce (Call (Some (doc), get_Root, []),
+                                            Object)]),
+                             Let (newDoc,
+                                  NewObject (XDocument,
+                                             Call (Some (doc), get_Declaration,
+                                                   []), NewArray (Object)),
+                                  Sequential (Call (Some (newDoc), Add,
+                                                    [Coerce (newRoot, Object)]),
+                                              Call (Some (doc), ToString, []))))),
+            t)
+                      ((new StringReader(t)) :> TextReader))
+
+    static member ParseXData: text:string -> XsdProvider+XData
+    XmlElement.Create(let t = text
+                      let doc = XDocument.Parse(t)
+                      let t = IfThenElse (Call (None, op_Equality,
+                  [Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                             get_Root, [])),
+                                                 get_Name, [])), get_LocalName,
+                                     [])), ToLower, []), Value ("xdata")]),
+            Let (newRoot,
+                 NewObject (XElement,
+                            Call (Some (Call (Some (Call (Some (Call (Some (doc),
+                                                                      get_Root,
+                                                                      [])),
+                                                          get_Name, [])),
+                                              get_Namespace, [])), GetName,
+                                  [Value ("root__")])),
+                 Sequential (Call (Some (newRoot), Add,
+                                   [Coerce (Call (Some (doc), get_Root, []),
+                                            Object)]),
+                             Let (newDoc,
+                                  NewObject (XDocument,
+                                             Call (Some (doc), get_Declaration,
+                                                   []), NewArray (Object)),
+                                  Sequential (Call (Some (newDoc), Add,
+                                                    [Coerce (newRoot, Object)]),
+                                              Call (Some (doc), ToString, []))))),
+            t)
+                      ((new StringReader(t)) :> TextReader))
+
+
+class XsdProvider+Code : FDR.XmlElement
+    new : source:string -> type:string -> targetNamespace:string -> typeName:string -> XsdProvider+Code
+    XmlRuntime.CreateRecord("Code", 
+                            [| ("Source",
+                                (source :> obj))
+                               ("Type",
+                                (type :> obj)) |], 
+                            [| ("TargetNamespace",
+                                (targetNamespace :> obj))
+                               ("TypeName",
+                                (typeName :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+Code
+    XmlElement.Create(xElement)
+
+    member Source: string with get
+    let value = XmlRuntime.TryGetAttribute(this, "Source")
+    TextRuntime.GetNonOptionalValue("Attribute Source", TextRuntime.ConvertString(value), value)
+
+    member TargetNamespace: string with get
+    ("http://schemas.microsoft.com/winfx/2006/xaml" :> obj)
+
+    member Type: string with get
+    let value = XmlRuntime.TryGetAttribute(this, "Type")
+    TextRuntime.GetNonOptionalValue("Attribute Type", TextRuntime.ConvertString(value), value)
+
+    member TypeName: string with get
+    ("dCode" :> obj)
+
+
+class XsdProvider+DCode : FDR.XmlElement
+    new : source:string -> type:string -> targetNamespace:string -> typeName:string -> XsdProvider+DCode
+    XmlRuntime.CreateRecord("dCode", 
+                            [| ("Source",
+                                (source :> obj))
+                               ("Type",
+                                (type :> obj)) |], 
+                            [| ("TargetNamespace",
+                                (targetNamespace :> obj))
+                               ("TypeName",
+                                (typeName :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+DCode
+    XmlElement.Create(xElement)
+
+    member Source: string with get
+    let value = XmlRuntime.TryGetAttribute(this, "Source")
+    TextRuntime.GetNonOptionalValue("Attribute Source", TextRuntime.ConvertString(value), value)
+
+    member TargetNamespace: string with get
+    ("http://schemas.microsoft.com/winfx/2006/xaml" :> obj)
+
+    member Type: string with get
+    let value = XmlRuntime.TryGetAttribute(this, "Type")
+    TextRuntime.GetNonOptionalValue("Attribute Type", TextRuntime.ConvertString(value), value)
+
+    member TypeName: string with get
+    ("dCode" :> obj)
+
+
+class XsdProvider+DXData : FDR.XmlElement
+    new : targetNamespace:string -> typeName:string -> XsdProvider+DXData
+    XmlRuntime.CreateRecord("dXData", 
+                            [| |], 
+                            [| ("TargetNamespace",
+                                (targetNamespace :> obj))
+                               ("TypeName",
+                                (typeName :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+DXData
+    XmlElement.Create(xElement)
+
+    member TargetNamespace: string with get
+    ("http://schemas.microsoft.com/winfx/2006/xaml" :> obj)
+
+    member TypeName: string with get
+    ("dXData" :> obj)
+
+
+class XsdProvider+Schema : FDR.XmlElement
+    new : code:XsdProvider+Code -> xData:XsdProvider+XData -> dCode:XsdProvider+DCode -> dxData:XsdProvider+DXData -> frlrfSystemStringClassTopic:string -> XsdProvider+Schema
+    XmlRuntime.CreateRecord("Schema", 
+                            [| |], 
+                            [| ("Code",
+                                (code :> obj))
+                               ("XData",
+                                (xData :> obj))
+                               ("dCode",
+                                (dCode :> obj))
+                               ("dXData",
+                                (dxData :> obj))
+                               ("frlrfSystemStringClassTopic",
+                                (frlrfSystemStringClassTopic :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+Schema
+    XmlElement.Create(xElement)
+
+    member Code: XsdProvider+Code with get
+    XmlRuntime.GetChild(this, "Code")
+
+    member DCode: XsdProvider+DCode with get
+    XmlRuntime.GetChild(this, "dCode")
+
+    member DXData: XsdProvider+DXData with get
+    XmlRuntime.GetChild(this, "dXData")
+
+    member FrlrfSystemStringClassTopic: string with get
+    let value = XmlRuntime.TryGetValue(XmlRuntime.GetChild(this, "frlrfSystemStringClassTopic"))
+    TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)
+
+    member XData: XsdProvider+XData with get
+    XmlRuntime.GetChild(this, "XData")
+
+
+class XsdProvider+XData : FDR.XmlElement
+    new : targetNamespace:string -> typeName:string -> XsdProvider+XData
+    XmlRuntime.CreateRecord("XData", 
+                            [| |], 
+                            [| ("TargetNamespace",
+                                (targetNamespace :> obj))
+                               ("TypeName",
+                                (typeName :> obj)) |], "en-GB")
+
+    new : xElement:System.Xml.Linq.XElement -> XsdProvider+XData
+    XmlElement.Create(xElement)
+
+    member TargetNamespace: string with get
+    ("http://schemas.microsoft.com/winfx/2006/xaml" :> obj)
+
+    member TypeName: string with get
+    ("dXData" :> obj)
+
+

--- a/tests/FSharp.Data.Tests/Data/gpx.xsd
+++ b/tests/FSharp.Data.Tests/Data/gpx.xsd
@@ -1,0 +1,788 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns="http://www.topografix.com/GPX/1/1"
+	targetNamespace="http://www.topografix.com/GPX/1/1"
+	elementFormDefault="qualified">
+
+<xsd:annotation>
+ <xsd:documentation>
+  GPX schema version 1.1 - For more information on GPX and this schema, visit http://www.topografix.com/gpx.asp
+
+  GPX uses the following conventions: all coordinates are relative to the WGS84 datum.  All measurements are in metric units.
+ </xsd:documentation>
+</xsd:annotation>
+
+  <xsd:element name="gpx"	type="gpxType">
+    <xsd:annotation>
+      <xsd:documentation>
+		GPX is the root element in the XML file.
+	  </xsd:documentation>
+	</xsd:annotation>
+  </xsd:element>
+
+  <xsd:complexType name="gpxType">
+    <xsd:annotation>
+      <xsd:documentation>
+		GPX documents contain a metadata header, followed by waypoints, routes, and tracks.  You can add your own elements
+		to the extensions section of the GPX document.
+	  </xsd:documentation>
+	</xsd:annotation>
+	<xsd:sequence>
+	 <xsd:element name="metadata"	type="metadataType"	minOccurs="0">
+	  <xsd:annotation>
+	   <xsd:documentation>
+		Metadata about the file.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+	 <xsd:element name="wpt"			type="wptType"	minOccurs="0" maxOccurs="unbounded">
+	  <xsd:annotation>
+	   <xsd:documentation>
+		A list of waypoints.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+	 <xsd:element name="rte"			type="rteType"	minOccurs="0" maxOccurs="unbounded">
+	  <xsd:annotation>
+	   <xsd:documentation>
+		A list of routes.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+	 <xsd:element name="trk"			type="trkType"	minOccurs="0" maxOccurs="unbounded">
+	  <xsd:annotation>
+	   <xsd:documentation>
+		A list of tracks.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+	 <xsd:element name="extensions"	type="extensionsType"	minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>
+		You can add extend GPX by adding your own elements from another schema here.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+	</xsd:sequence>
+
+	<xsd:attribute name="version" type="xsd:string" use="required" fixed="1.1">
+     <xsd:annotation>
+      <xsd:documentation>
+		You must include the version number in your GPX document.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+	<xsd:attribute name="creator" type="xsd:string" use="required">
+     <xsd:annotation>
+      <xsd:documentation>
+		You must include the name or URL of the software that created your GPX document.  This allows others to
+		inform the creator of a GPX instance document that fails to validate.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:complexType name="metadataType">
+    <xsd:annotation>
+      <xsd:documentation>
+		Information about the GPX file, author, and copyright restrictions goes in the metadata section.  Providing rich,
+		meaningful information about your GPX files allows others to search for and use your GPS data.
+	  </xsd:documentation>
+	</xsd:annotation>
+    <xsd:sequence>	<!-- elements must appear in this order -->
+     <xsd:element name="name"		type="xsd:string"		minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>
+		The name of the GPX file.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+     <xsd:element name="desc"		type="xsd:string"		minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>
+		A description of the contents of the GPX file.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+     <xsd:element name="author"		type="personType"		minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>
+		The person or organization who created the GPX file.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+     <xsd:element name="copyright"	type="copyrightType"	minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>
+		Copyright and license information governing use of the file.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+     <xsd:element name="link"		type="linkType"			minOccurs="0" maxOccurs="unbounded">
+      <xsd:annotation>
+       <xsd:documentation>
+		URLs associated with the location described in the file.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+     <xsd:element name="time"		type="xsd:dateTime"		minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>
+		The creation date of the file.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+     <xsd:element name="keywords"	type="xsd:string"		minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>
+		Keywords associated with the file.  Search engines or databases can use this information to classify the data.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+     <xsd:element name="bounds"		type="boundsType"		minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>
+		Minimum and maximum coordinates which describe the extent of the coordinates in the file.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+
+	 <xsd:element name="extensions"	type="extensionsType"	minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>
+		You can add extend GPX by adding your own elements from another schema here.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="wptType">
+    <xsd:annotation>
+      <xsd:documentation>
+		wpt represents a waypoint, point of interest, or named feature on a map.
+	  </xsd:documentation>
+	</xsd:annotation>
+    <xsd:sequence>	<!-- elements must appear in this order -->
+	  <!-- Position info -->
+      <xsd:element name="ele"			type="xsd:decimal"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Elevation (in meters) of the point.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+      <xsd:element name="time"			type="xsd:dateTime"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Creation/modification timestamp for element. Date and time in are in Univeral Coordinated Time (UTC), not local time! Conforms to ISO 8601 specification for date/time representation. Fractional seconds are allowed for millisecond timing in tracklogs. 
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="magvar"		type="degreesType"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Magnetic variation (in degrees) at the point
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="geoidheight"	type="xsd:decimal"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Height (in meters) of geoid (mean sea level) above WGS84 earth ellipsoid.  As defined in NMEA GGA message.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+
+	  <!-- Description info -->
+	  <xsd:element name="name"			type="xsd:string"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			The GPS name of the waypoint. This field will be transferred to and from the GPS. GPX does not place restrictions on the length of this field or the characters contained in it. It is up to the receiving application to validate the field before sending it to the GPS.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="cmt"			type="xsd:string"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			GPS waypoint comment. Sent to GPS as comment. 
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="desc"			type="xsd:string"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			A text description of the element. Holds additional information about the element intended for the user, not the GPS.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="src"			type="xsd:string"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Source of data. Included to give user some idea of reliability and accuracy of data.  "Garmin eTrex", "USGS quad Boston North", e.g.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+      <xsd:element name="link"			type="linkType"			minOccurs="0" maxOccurs="unbounded">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Link to additional information about the waypoint.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="sym"			type="xsd:string"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Text of GPS symbol name. For interchange with other programs, use the exact spelling of the symbol as displayed on the GPS.  If the GPS abbreviates words, spell them out.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="type"			type="xsd:string"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Type (classification) of the waypoint.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+
+	  <!-- Accuracy info -->
+	  <xsd:element name="fix"			type="fixType"			minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Type of GPX fix.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="sat"			type="xsd:nonNegativeInteger"	minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Number of satellites used to calculate the GPX fix.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="hdop"			type="xsd:decimal"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Horizontal dilution of precision.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="vdop"			type="xsd:decimal"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Vertical dilution of precision.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="pdop"			type="xsd:decimal"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Position dilution of precision.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="ageofdgpsdata"	type="xsd:decimal"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Number of seconds since last DGPS update.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="dgpsid"		type="dgpsStationType"	minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			ID of DGPS station used in differential correction.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+
+	 <xsd:element name="extensions"		type="extensionsType"	minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>
+		You can add extend GPX by adding your own elements from another schema here.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+    </xsd:sequence>
+
+    <xsd:attribute name="lat"			type="latitudeType"		use="required">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		The latitude of the point.  This is always in decimal degrees, and always in WGS84 datum.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+    <xsd:attribute name="lon"			type="longitudeType"	use="required">
+	 <xsd:annotation>
+	  <xsd:documentation>
+      The longitude of the point.  This is always in decimal degrees, and always in WGS84 datum.
+    </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:complexType name="rteType">
+    <xsd:annotation>
+      <xsd:documentation>
+		rte represents route - an ordered list of waypoints representing a series of turn points leading to a destination.
+	  </xsd:documentation>
+	</xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"			type="xsd:string"	minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			GPS name of route.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="cmt"			type="xsd:string"	minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			GPS comment for route.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+      <xsd:element name="desc"			type="xsd:string"	minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Text description of route for user.  Not sent to GPS.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="src"			type="xsd:string"	minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Source of data. Included to give user some idea of reliability and accuracy of data.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+      <xsd:element name="link"			type="linkType"		minOccurs="0" maxOccurs="unbounded">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Links to external information about the route.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="number"		type="xsd:nonNegativeInteger"	minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			GPS route number.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="type"			type="xsd:string"	minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Type (classification) of route.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+
+	 <xsd:element name="extensions"		type="extensionsType"	minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>
+		You can add extend GPX by adding your own elements from another schema here.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+ 
+      <xsd:element name="rtept"	type="wptType" minOccurs="0" maxOccurs="unbounded">
+	  <xsd:annotation>
+	   <xsd:documentation>
+		A list of route points.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="trkType">
+    <xsd:annotation>
+      <xsd:documentation>
+		trk represents a track - an ordered list of points describing a path.
+	  </xsd:documentation>
+	</xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"			type="xsd:string"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			GPS name of track.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="cmt"			type="xsd:string"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			GPS comment for track.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+      <xsd:element name="desc"			type="xsd:string"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			User description of track.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="src"			type="xsd:string"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Source of data. Included to give user some idea of reliability and accuracy of data.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+      <xsd:element name="link"			type="linkType"			minOccurs="0" maxOccurs="unbounded">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Links to external information about track.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="number"		type="xsd:nonNegativeInteger"	minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			GPS track number.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+	  <xsd:element name="type"			type="xsd:string"		minOccurs="0">
+		<xsd:annotation>
+		  <xsd:documentation>
+			Type (classification) of track.
+		  </xsd:documentation>
+		</xsd:annotation>
+	  </xsd:element>
+
+	 <xsd:element name="extensions"	type="extensionsType"	minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>
+		You can add extend GPX by adding your own elements from another schema here.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+  
+     <xsd:element name="trkseg"		type="trksegType"		minOccurs="0" maxOccurs="unbounded">
+      <xsd:annotation>
+       <xsd:documentation>
+		A Track Segment holds a list of Track Points which are logically connected in order. To represent a single GPS track where GPS reception was lost, or the GPS receiver was turned off, start a new Track Segment for each continuous span of track data.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+ 
+  <xsd:complexType name="extensionsType">
+   <xsd:annotation>
+    <xsd:documentation>
+	 You can add extend GPX by adding your own elements from another schema here.
+    </xsd:documentation>
+   </xsd:annotation>
+    <xsd:sequence>
+	 <xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+	   <xsd:annotation>
+		<xsd:documentation>
+		 You can add extend GPX by adding your own elements from another schema here.
+		</xsd:documentation>
+	   </xsd:annotation>
+	 </xsd:any>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="trksegType">
+   <xsd:annotation>
+    <xsd:documentation>
+ 	 A Track Segment holds a list of Track Points which are logically connected in order. To represent a single GPS track where GPS reception was lost, or the GPS receiver was turned off, start a new Track Segment for each continuous span of track data.
+    </xsd:documentation>
+   </xsd:annotation>
+   <xsd:sequence>	<!-- elements must appear in this order -->
+	 <xsd:element name="trkpt"	type="wptType" minOccurs="0" maxOccurs="unbounded">
+      <xsd:annotation>
+       <xsd:documentation>
+		A Track Point holds the coordinates, elevation, timestamp, and metadata for a single point in a track.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+
+	 <xsd:element name="extensions"	type="extensionsType"	minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>
+		You can add extend GPX by adding your own elements from another schema here.
+	   </xsd:documentation>
+	  </xsd:annotation>
+	 </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="copyrightType">
+   <xsd:annotation>
+    <xsd:documentation>
+	 Information about the copyright holder and any license governing use of this file.  By linking to an appropriate license,
+	 you may place your data into the public domain or grant additional usage rights.
+    </xsd:documentation>
+   </xsd:annotation>
+   <xsd:sequence>	<!-- elements must appear in this order -->
+    <xsd:element name="year"		type="xsd:gYear"	minOccurs="0">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		Year of copyright.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:element>
+    <xsd:element name="license"		type="xsd:anyURI"	minOccurs="0">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		Link to external file containing license text.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:element>
+   </xsd:sequence>
+   <xsd:attribute name="author" type="xsd:string" use="required">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		Copyright holder (TopoSoft, Inc.)
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:complexType name="linkType">
+   <xsd:annotation>
+    <xsd:documentation>
+	 A link to an external resource (Web page, digital photo, video clip, etc) with additional information.
+    </xsd:documentation>
+   </xsd:annotation>
+   <xsd:sequence>	<!-- elements must appear in this order -->
+    <xsd:element name="text"		type="xsd:string"		minOccurs="0">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		Text of hyperlink.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:element>
+    <xsd:element name="type"		type="xsd:string"		minOccurs="0">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		Mime type of content (image/jpeg)
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:element>
+   </xsd:sequence>
+   <xsd:attribute name="href" type="xsd:anyURI" use="required">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		URL of hyperlink.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:complexType name="emailType">
+   <xsd:annotation>
+    <xsd:documentation>
+	 An email address.  Broken into two parts (id and domain) to help prevent email harvesting.
+    </xsd:documentation>
+   </xsd:annotation>
+   <xsd:attribute name="id"			type="xsd:string"		use="required">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		id half of email address (billgates2004)
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+   <xsd:attribute name="domain"		type="xsd:string"		use="required">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		domain half of email address (hotmail.com)
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:complexType name="personType">
+   <xsd:annotation>
+    <xsd:documentation>
+	 A person or organization.
+    </xsd:documentation>
+   </xsd:annotation>
+    <xsd:sequence>	<!-- elements must appear in this order -->
+      <xsd:element name="name"		type="xsd:string"		minOccurs="0">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		Name of person or organization.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:element>
+      <xsd:element name="email"		type="emailType"		minOccurs="0">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		Email address.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:element>
+      <xsd:element name="link"		type="linkType"			minOccurs="0">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		Link to Web site or other external information about person.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:element>
+	</xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="ptType">
+   <xsd:annotation>
+    <xsd:documentation>
+	 A geographic point with optional elevation and time.  Available for use by other schemas.
+    </xsd:documentation>
+   </xsd:annotation>
+   <xsd:sequence>	<!-- elements must appear in this order -->
+    <xsd:element name="ele"			type="xsd:decimal"		minOccurs="0">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		The elevation (in meters) of the point.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:element>
+    <xsd:element name="time"		type="xsd:dateTime"		minOccurs="0">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		The time that the point was recorded.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:element>
+   </xsd:sequence>
+    <xsd:attribute name="lat"			type="latitudeType"		use="required">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		The latitude of the point.  Decimal degrees, WGS84 datum.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+    <xsd:attribute name="lon"			type="longitudeType"	use="required">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		The latitude of the point.  Decimal degrees, WGS84 datum.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:complexType name="ptsegType">
+   <xsd:annotation>
+    <xsd:documentation>
+	 An ordered sequence of points.  (for polygons or polylines, e.g.)
+    </xsd:documentation>
+   </xsd:annotation>
+   <xsd:sequence>	<!-- elements must appear in this order -->
+	 <xsd:element name="pt"	type="ptType"	minOccurs="0" maxOccurs="unbounded">
+	   <xsd:annotation>
+		<xsd:documentation>
+		 Ordered list of geographic points.
+		</xsd:documentation>
+	   </xsd:annotation>
+	 </xsd:element>
+   </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="boundsType">
+   <xsd:annotation>
+    <xsd:documentation>
+	 Two lat/lon pairs defining the extent of an element.
+    </xsd:documentation>
+   </xsd:annotation>
+    <xsd:attribute name="minlat"		type="latitudeType"		use="required">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		The minimum latitude.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+    <xsd:attribute name="minlon"		type="longitudeType"	use="required">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		The minimum longitude.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+    <xsd:attribute name="maxlat"		type="latitudeType"		use="required">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		The maximum latitude.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+    <xsd:attribute name="maxlon"		type="longitudeType"	use="required">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		The maximum longitude.
+	  </xsd:documentation>
+	 </xsd:annotation>
+	</xsd:attribute>
+  </xsd:complexType>
+
+
+  <xsd:simpleType name="latitudeType">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		The latitude of the point.  Decimal degrees, WGS84 datum.
+	  </xsd:documentation>
+	 </xsd:annotation>
+    <xsd:restriction base="xsd:decimal">
+      <xsd:minInclusive value="-90.0"/>
+      <xsd:maxInclusive value="90.0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="longitudeType">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		The longitude of the point.  Decimal degrees, WGS84 datum.
+	  </xsd:documentation>
+	 </xsd:annotation>
+    <xsd:restriction base="xsd:decimal">
+      <xsd:minInclusive value="-180.0"/>
+      <xsd:maxExclusive value="180.0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="degreesType">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		Used for bearing, heading, course.  Units are decimal degrees, true (not magnetic).
+	  </xsd:documentation>
+	 </xsd:annotation>
+    <xsd:restriction base="xsd:decimal">
+      <xsd:minInclusive value="0.0"/>
+      <xsd:maxExclusive value="360.0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="fixType">
+	 <xsd:annotation>
+	  <xsd:documentation>
+		Type of GPS fix.  none means GPS had no fix.  To signify "the fix info is unknown, leave out fixType entirely. pps = military signal used
+	  </xsd:documentation>
+	 </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="none"/>
+      <xsd:enumeration value="2d"/>
+      <xsd:enumeration value="3d"/>
+      <xsd:enumeration value="dgps"/>
+      <xsd:enumeration value="pps"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="dgpsStationType">
+   <xsd:annotation>
+    <xsd:documentation>
+	 Represents a differential GPS station.
+    </xsd:documentation>
+   </xsd:annotation>
+    <xsd:restriction base="xsd:integer">
+      <xsd:minInclusive value="0"/>
+      <xsd:maxInclusive value="1023"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+</xsd:schema>

--- a/tests/FSharp.Data.Tests/Data/purchaseOrder.xsd
+++ b/tests/FSharp.Data.Tests/Data/purchaseOrder.xsd
@@ -1,0 +1,76 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://tempuri.org/po.xsd"
+xmlns="http://tempuri.org/po.xsd" elementFormDefault="qualified">
+  <xs:annotation>
+    <xs:documentation xml:lang="en">
+      Purchase order schema for Example.com.
+      Copyright 2000 Example.com. All rights reserved.
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="purchaseOrder" type="PurchaseOrderType"/>
+
+  <xs:element name="comment" type="xs:string"/>
+
+  <xs:complexType name="PurchaseOrderType">
+    <xs:sequence>
+      <xs:element name="shipTo" type="USAddress"/>
+      <xs:element name="billTo" type="USAddress"/>
+      <xs:element ref="comment" minOccurs="0"/>
+      <xs:element name="items"  type="Items"/>
+    </xs:sequence>
+    <xs:attribute name="orderDate" type="xs:date"/>
+  </xs:complexType>
+
+  <xs:complexType name="USAddress">
+    <xs:annotation>
+      <xs:documentation>
+        Purchase order schema for Example.Microsoft.com.
+        Copyright 2001 Example.Microsoft.com. All rights reserved.
+      </xs:documentation>
+      <xs:appinfo>
+        Application info.
+      </xs:appinfo>
+    </xs:annotation>
+
+    <xs:sequence>
+      <xs:element name="name"   type="xs:string"/>
+      <xs:element name="street" type="xs:string"/>
+      <xs:element name="city"   type="xs:string"/>
+      <xs:element name="state"  type="xs:string"/>
+      <xs:element name="zip"    type="xs:decimal"/>
+    </xs:sequence>
+    <xs:attribute name="country" type="xs:NMTOKEN"
+       fixed="US"/>
+  </xs:complexType>
+
+  <xs:complexType name="Items">
+    <xs:sequence>
+      <xs:element name="item" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="productName" type="xs:string"/>
+            <xs:element name="quantity">
+              <xs:simpleType>
+                <xs:restriction base="xs:positiveInteger">
+                  <xs:maxExclusive value="100"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:element>
+            <xs:element name="USPrice"    type="xs:decimal"/>
+            <xs:element ref="comment"   minOccurs="0"/>
+            <xs:element name="shipDate" type="xs:date" minOccurs="0"/>
+          </xs:sequence>
+          <xs:attribute name="partNum" type="SKU" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- Stock Keeping Unit, a code for identifying products -->
+  <xs:simpleType name="SKU">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\d{3}-[A-Z]{2}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+</xs:schema>

--- a/tests/FSharp.Data.Tests/Data/xaml2006.xsd
+++ b/tests/FSharp.Data.Tests/Data/xaml2006.xsd
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema targetNamespace="http://schemas.microsoft.com/winfx/2006/xaml" 
+    elementFormDefault="qualified" 
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml" 
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+    >
+    
+    <!-- Root element attributes -->
+    <xs:attribute name="Class" type="frlrfSystemStringClassTopic" />
+    <xs:attribute name="Subclass" type="frlrfSystemStringClassTopic" />
+    <xs:attribute name="TypeArguments" type="frlrfSystemStringClassTopic" />
+  
+
+    <!-- Attributes for things inside of a resource dictionary  -->
+    <xs:attribute name="Key" type="frlrfSystemStringClassTopic" />
+    
+    <!-- Attributes on any object tag -->
+    <xs:attribute name="Name" type="frlrfSystemStringClassTopic" />
+
+    <xs:attribute name="Language" type="frlrfSystemStringClassTopic" />
+  
+    <!-- Elements -->
+    <xs:element name="Code" type="dCode" />
+    <xs:element name="XData" type="dXData" />
+
+  <xs:complexType name="dCode" mixed="true">
+    <xs:attribute name="Source" type="frlrfSystemStringClassTopic" />
+    <xs:attribute name="Type" type="frlrfSystemStringClassTopic" />
+  </xs:complexType>
+  
+    <xs:complexType name="dXData" mixed="false">
+        <xs:choice minOccurs="1" maxOccurs="1">
+            <xs:any processContents="skip" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:simpleType name="frlrfSystemStringClassTopic" >
+        <xs:restriction base="xs:string" />
+    </xs:simpleType>
+</xs:schema>

--- a/tests/FSharp.Data.Tests/FSharp.Data.Tests.fsproj
+++ b/tests/FSharp.Data.Tests/FSharp.Data.Tests.fsproj
@@ -172,6 +172,9 @@
     <Content Include="Data\shared.xsd">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Data\gpx.xsd">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="Data/reddit.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/tests/FSharp.Data.Tests/FSharp.Data.Tests.fsproj
+++ b/tests/FSharp.Data.Tests/FSharp.Data.Tests.fsproj
@@ -191,11 +191,10 @@
     <Compile Include="CsvProvider.fs" />
     <Compile Include="XmlProvider.fs" />
     <Compile Include="JsonProvider.fs" />
-    <Compile Include="FreebaseProvider.fs" />
     <Compile Include="WorldBankProvider.fs" />
     <None Include="packages.config" />
     <None Include="app.config" />
-    <Compile Include="XsdProvider.fs" />    
+    <Compile Include="XsdProvider.fs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">


### PR DESCRIPTION
Existing code applied default qualified/unqualified element forms to the XSD itself, think they should actually be applied to the target/instance document, see http://www.w3.org/TR/xmlschema-0/#NS

Also tried to reduce some duplication (hopefully not removed too much?), and to respect namespaces in both schema and instance doc. 

I can now parse GPX xsd as mentioned in #57, added a bunch of tests of the namespace stuff.