### PR TITLE
Unify types for named XML nodes accross multiple samples

### DIFF
--- a/src/Xml/XmlProvider.fs
+++ b/src/Xml/XmlProvider.fs
@@ -46,7 +46,8 @@ type public XmlProvider(cfg:TypeProviderConfig) as this =
 
       let inferedType = using (IO.logTime "Inference" sample) <| fun _ ->
         samples
-        |> Seq.map (fun sampleXml -> XmlInference.inferType inferTypesFromValues cultureInfo (*allowEmptyValues*)false globalInference sampleXml)
+        |> Array.ofSeq
+        |> XmlInference.inferType inferTypesFromValues cultureInfo (*allowEmptyValues*)false globalInference
         |> Seq.fold (StructuralInference.subtypeInfered (*allowEmptyValues*)false) StructuralTypes.Top
 
       using (IO.logTime "TypeGeneration" sample) <| fun _ ->

--- a/tests/FSharp.Data.Tests/Data/Cars.xml
+++ b/tests/FSharp.Data.Tests/Data/Cars.xml
@@ -1,0 +1,7 @@
+﻿<Samples> 
+    <ArrayOfCar>
+      <Car><Type>Audi</Type></Car>
+      <Car><Type>BMW</Type></Car>
+    </ArrayOfCar>
+    <Car><Type>Trabant</Type></Car>
+</Samples>

--- a/tests/FSharp.Data.Tests/XmlProvider.fs
+++ b/tests/FSharp.Data.Tests/XmlProvider.fs
@@ -217,6 +217,23 @@ let ``Global inference with empty elements doesn't crash``() =
     child1.Inner.Value.C |> should equal "foo"
     child2.Inner |> should equal None
 
+type Cars = XmlProvider<"Data/Cars.xml", SampleIsList=true, Global=true>
+
+[<Test>]
+let ``Global inference unifies element types across multiple samples``() =
+  let readCars str = 
+    let doc = Cars.Parse(str)
+    match doc.Car, doc.ArrayOfCar with
+    | Some car, _ -> [ car.Type ]
+    | _, Some cars -> [ for c in cars.Cars -> c.Type ]
+    | _ -> []
+  
+  readCars "<Car><Type>Audi</Type></Car>" 
+  |> should equal ["Audi"]
+
+  readCars "<ArrayOfCar><Car><Type>Audi</Type></Car><Car><Type>BMW</Type></Car></ArrayOfCar>" 
+  |> should equal ["Audi"; "BMW"]
+
 type OneLetterXML = XmlProvider<"<A><B></B></A>"> // see https://github.com/fsharp/FSharp.Data/issues/256
 
 // Acronyms are renamed correctly; see https://github.com/fsharp/FSharp.Data/issues/309


### PR DESCRIPTION
This is addressing issue [discussed her eon StackOverflow](http://stackoverflow.com/questions/28515305/f-xml-data-parsing-a-subtype/28518022#28518022).

Basically, the global inference does not work on multiple samples, because we were processing the samples separately and then unifying the types. This change runs the global inference on the whole document (with multiple samples), so that the types are the same across multiple samples.