### PR TITLE
Add Parse method to CsvProvider provided Row types

### DIFF
--- a/src/Csv/CsvProvider.fs
+++ b/src/Csv/CsvProvider.fs
@@ -92,6 +92,12 @@ type public CsvProvider(cfg:TypeProviderConfig) as this =
         let body = csvErasedType?CreateEmpty () (Expr.Var rowToStringArrayVar, paramValue, replacer.ToRuntime headers,  sampleCsv.NumberOfColumns, separators, quote)
         Expr.Let(rowToStringArrayVar, rowToStringArray, body)))
       csvType.AddMember(ctor) 
+
+      let parse = ProvidedMethod("Parse", [ProvidedParameter("text", typeof<string>)], rowType, IsStaticMethod = true)
+      parse.InvokeCode <- fun (Singleton text) -> 
+        let body = csvErasedType?ParseRow() (text, Expr.Var stringArrayToRowVar, separators, quote)
+        Expr.Let(stringArrayToRowVar, stringArrayToRow, body)
+      rowType.AddMember parse
        
       { GeneratedType = csvType
         RepresentationType = csvType

--- a/src/Csv/CsvRuntime.fs
+++ b/src/Csv/CsvRuntime.fs
@@ -226,6 +226,12 @@ type CsvFile<'RowType> private (rowToStringArray:Func<'RowType,string[]>, dispos
     if cacheRows then uncachedCsv.Cache() else uncachedCsv
 
   /// [omit]
+  [<EditorBrowsableAttribute(EditorBrowsableState.Never)>]
+  [<CompilerMessageAttribute("This method is intended for use in generated code only.", 10001, IsHidden=true, IsError=false)>]
+  static member ParseRow (text, stringArrayToRow: Func<obj,string[],'RowType>, separators, quote) =    
+    CsvReader.readCsvFile (new StringReader(text) :> TextReader) separators quote |> Seq.exactlyOne |> fst |> (fun x -> stringArrayToRow.Invoke(null, x))
+
+  /// [omit]
   new (stringArrayToRow:Func<obj,string[],'RowType>, rowToStringArray, readerFunc:Func<TextReader>, separators, quote, hasHeaders, ignoreErrors, skipRows) as this =
 
     // Track created Readers so that we can dispose of all of them

--- a/tests/FSharp.Data.Tests/CsvProvider.fs
+++ b/tests/FSharp.Data.Tests/CsvProvider.fs
@@ -403,3 +403,26 @@ let ``Can create new csv row with units of measure``() =
   let row = new CsvUom.Row("name", 3.5M<metre>, 27M<Data.UnitSystems.SI.UnitSymbols.s>)
   row.Distance |> should equal 3.5M<metre>
   
+type RowTy = SimpleWithStrCsv.Row 
+
+[<Test>]
+let ``Parse single row``() = 
+  let row = SimpleWithStrCsv.Row.Parse("""false,"Quoted, col", 31""")
+
+  row.Column1 |> should equal false
+  row.ColumnB |> should equal "Quoted, col"
+  row.Column3 |> should equal 31
+
+[<Test>]
+let ``Parse single row with trailing newline``() = 
+  let row = SimpleWithStrCsv.Row.Parse("false,abc, 31\n")
+
+  row.Column1 |> should equal false
+  row.ColumnB |> should equal "abc"
+  row.Column3 |> should equal 31
+
+[<Test>]
+[<ExpectedException(typeof<ArgumentException>)>]
+let ``Parse 2 rows with Row.Parse throws``() = 
+  SimpleWithStrCsv.Row.Parse("""false,abc, 31
+true, def, 42""")


### PR DESCRIPTION
For #752.

Guess I need to regenerate signature tests but putting this up for comment. In particular, I don't like the implementation, but this seemed more convenient (to put on `CsvFile<>`); and I'm not sure what the best option is for multi-row input. To throw or just take the 1st line?