### PR TITLE
Use ISO-8601 dates in CSV and XML

### DIFF
--- a/src/Json/JsonRuntime.fs
+++ b/src/Json/JsonRuntime.fs
@@ -245,7 +245,7 @@ type JsonRuntime =
     | :? Array                   as v -> JsonValue.Array [| for elem in v -> JsonRuntime.ToJsonValue cultureInfo elem |]
 
     | :? string                  as v -> JsonValue.String v
-    | :? DateTime                as v -> v.ToString(cultureInfo) |> JsonValue.String
+    | :? DateTime                as v -> v.ToString("O", cultureInfo) |> JsonValue.String
     | :? int                     as v -> JsonValue.Number(decimal v)
     | :? int64                   as v -> JsonValue.Number(decimal v)
     | :? float                   as v -> JsonValue.Number(decimal v)

--- a/src/Xml/XmlRuntime.fs
+++ b/src/Xml/XmlRuntime.fs
@@ -201,7 +201,7 @@ type XmlRuntime =
             | _ ->
                 match v with
                 | :? string        as v -> v
-                | :? DateTime      as v -> strWithCulture v
+                | :? DateTime      as v -> v.ToString("O", cultureInfo)
                 | :? int           as v -> strWithCulture v
                 | :? int64         as v -> strWithCulture v
                 | :? float         as v -> strWithCulture v

--- a/tests/FSharp.Data.Tests/JsonProvider.fs
+++ b/tests/FSharp.Data.Tests/JsonProvider.fs
@@ -576,8 +576,8 @@ let ``Can construct complex objects``() =
   "assignee": null,
   "milestone": null,
   "comments": 2,
-  "created_at": "03/15/2013 00:00:00",
-  "updated_at": "03/16/2013 00:00:00",
+  "created_at": "2013-03-15T00:00:00.0000000",
+  "updated_at": "2013-03-16T00:00:00.0000000",
   "closed_at": null,
   "pull_request": {
     "html_url": null,

--- a/tests/FSharp.Data.Tests/XmlProvider.fs
+++ b/tests/FSharp.Data.Tests/XmlProvider.fs
@@ -447,11 +447,11 @@ let ``Can construct elements with namespaces and heterogeneous records``() =
   <title>title</title>
   <subtitle>subtitle</subtitle>
   <id>id</id>
-  <updated>04/27/2014 00:00:00</updated>
+  <updated>2014-04-27T00:00:00.0000000</updated>
   <entry>
     <title>title2</title>
     <id>id2</id>
-    <updated>04/28/2014 00:00:00</updated>
+    <updated>2014-04-28T00:00:00.0000000</updated>
     <summary>summary</summary>
     <author>
       <name>name</name>
@@ -471,7 +471,7 @@ let ``Can construct elements with heterogeneous records with primitives``() =
     let title = AtomSearch.Choice(title = "title")
     title.XElement.ToString() |> should equal """<title xmlns="http://www.w3.org/2005/Atom">title</title>"""
     let updated = AtomSearch.Choice(updated = DateTime(2000, 1, 1))
-    updated.XElement.ToString() |> should equal """<updated xmlns="http://www.w3.org/2005/Atom">01/01/2000 00:00:00</updated>"""
+    updated.XElement.ToString() |> should equal """<updated xmlns="http://www.w3.org/2005/Atom">2000-01-01T00:00:00.0000000</updated>"""
     let itemsPerPage = AtomSearch.Choice(2)
     itemsPerPage.XElement.ToString() |> should equal """<itemsPerPage xmlns="http://a9.com/-/spec/opensearch/1.1/">2</itemsPerPage>"""
     let entry = AtomSearch.Entry("id", 
@@ -487,10 +487,10 @@ let ``Can construct elements with heterogeneous records with primitives``() =
                                  AtomSearch.Author("name", "uri"))
     entry.XElement.ToString() |> normalize |> should equal (normalize """<entry xmlns="http://www.w3.org/2005/Atom">
   <id>id</id>
-  <published>02/02/2000 00:00:00</published>
+  <published>2000-02-02T00:00:00.0000000</published>
   <title>title</title>
   <content type="type">value</content>
-  <updated>03/03/2000 00:00:00</updated>
+  <updated>2000-03-03T00:00:00.0000000</updated>
   <metadata xmlns="http://api.twitter.com/">
     <result_type>resultType</result_type>
   </metadata>


### PR DESCRIPTION
 - Use the built in "Round-trip pattern" as documented here:
   https://msdn.microsoft.com/en-us/library/az4se3k1%28v=vs.110%29.aspx
 - Update tests to match new date-time format.