### PR TITLE
Optimize conversion of resizable array to native array

### DIFF
--- a/src/Json/JsonValue.fs
+++ b/src/Json/JsonValue.fs
@@ -297,7 +297,7 @@ type private JsonParser(jsonText:string, cultureInfo, tolerateErrors) =
             parseEllipsis() // tolerate ... or {...}
         ensure(i < s.Length && s.[i] = '}')
         i <- i + 1
-        JsonValue.Record(pairs |> Array.ofSeq)
+        JsonValue.Record(pairs.ToArray())
 
     and parseArray() =
         ensure(i < s.Length && s.[i] = '[')
@@ -316,7 +316,7 @@ type private JsonParser(jsonText:string, cultureInfo, tolerateErrors) =
             parseEllipsis() // tolerate ... or {...}
         ensure(i < s.Length && s.[i] = ']')
         i <- i + 1
-        JsonValue.Array(vals |> Seq.toArray)
+        JsonValue.Array(vals.ToArray())
 
     and parseLiteral(expected, r) =
         ensure(i+expected.Length < s.Length)


### PR DESCRIPTION
 - Simple tweak saves 47% of work in certain tests - we basically avoid
building two identical arrays.

There is some other stuff I'm working on that I'll try to get into a decent, tested form to submit, but this is by far the biggest win with no backward compatibility issues.