### PR TITLE
Convenience function for Basic Auth

### DIFF
--- a/src/Net/Http.fs
+++ b/src/Net/Http.fs
@@ -87,6 +87,12 @@ module HttpRequestHeaders =
     let Allow (methods:string) = "Allow", methods
     /// Authentication credentials for HTTP authentication
     let Authorization (credentials:string) = "Authorization", credentials
+    /// Authentication header using Basic Auth encoding
+    let BasicAuth (username:string) (password:string) = 
+        let base64Encode (s:string) = 
+            let bytes = Encoding.UTF8.GetBytes(s)
+            Convert.ToBase64String(bytes)
+        sprintf "%s:%s" username password |> base64Encode |> sprintf "Basic %s" |>  Authorization 
     /// Used to specify directives that MUST be obeyed by all caching mechanisms along the request/response chain 
     let CacheControl (control:string) = "Cache-Control", control
     /// What type of connection the user-agent would prefer 


### PR DESCRIPTION
I've created a convenience function for sending http requests with Basic Auth.  Usage will look like:
```
Http.RequestString
  ( "http://httpbin.org/post", 
    headers = [ BasicAuth "user" "password" ],
    body = TextRequest """ {"test": 42} """)
```

I'm not 100% convinced this belongs in the HttpRequestHeaders module, since it actually uses the Authorization header that is already in there.  An alternative would be to have a function that simply returns the encoded string and leaves it to the consumer to pipe this into the Authorization header, something like
```
Http.RequestString
  ( "http://httpbin.org/post", 
    headers = [ BasicAuth "user" "password" |> Authorization ],
    body = TextRequest """ {"test": 42} """)
```
I'm not sure exactly where such a function would belong however.