### PR TITLE
Do not use reflection only if it would fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ log.txt
 .paket/paket.exe
 paket-files
 *.ide
+*.bak
 .vs


### PR DESCRIPTION
I was tying to use F# Data on Azure with Suave using a setup similar to the one in the recent [Scot Hanselman's blog](https://github.com/shanselman/suavebootstrapper). The peculiar thing here is that this is just loading `app.fsx` using FAKE/F# Compiler Service and running it from the source code (which I quite like because it is super simple).

The problem here is that we are now running the design time component of F# Data on a machine that does not have anything installed and so it was failing to load `FSharp.Core.dll` version 4.3.0.0. I was running this via  FAKE which has correct binding redirects and I had 4.3.1.0 in the folder, but it was still failing.

The code was failing [here](https://github.com/fsharp/FSharp.Data/blob/master/src/CommonProviderImplementation/AssemblyReplacer.fs#L108) (1) _after_ we loaded the `FSharp.Data.dll` assembly using `ReflectionOnlyLoad` [here](https://github.com/fsharp/FSharp.Data/blob/master/src/CommonProviderImplementation/AssemblyResolver.fs#L118) (2). Now, the problem is that `ReflectionOnlyLoad` ignores binding redirects - and furthermore, (I think that) once it loads the assembly in (2), it does not give us any chance to fix the situation when it fails to get a type from it in (1).

So, this PR tests checks if we would be able to run the code in (2) using assembly loaded with the reflection only method - if yes, then it does not change anything. If getting a type would fail later, then it falls back to the `Assembly.Load` approach (which uses binding redirect and worked fine for me).

NOTE: I don't really understand how this works, so I'm not sure what consequences the change has. But I hope the check only applies in situations where the current approach will fail, so I hope it is OK!