### PR TITLE
Fixes #830. CsvProvider - allowing data row to be ended with a single separator

### DIFF
--- a/src/Csv/CsvRuntime.fs
+++ b/src/Csv/CsvRuntime.fs
@@ -174,7 +174,15 @@ module private CsvHelpers =
     // Return data with parsed columns
     seq {
       for untypedRow, lineNumber in untypedRows do
-        if untypedRow.Length <> numberOfColumns then
+        let hasCorrectNumberOfColumns, untypedRow =
+          match untypedRow.Length with
+          | length when length = numberOfColumns -> true, untypedRow
+          //row is also valid when it ends with single separator 
+          | length when length = numberOfColumns + 1 && String.IsNullOrEmpty(untypedRow.[untypedRow.Length-1])
+            -> true, untypedRow.[..numberOfColumns-1]
+          | _ -> false, untypedRow
+       
+        if not hasCorrectNumberOfColumns then
           // Ignore rows with different number of columns when ignoreErrors is set to true
           if not ignoreErrors then
             let lineNumber = if hasHeaders then lineNumber else lineNumber + 1

--- a/tests/FSharp.Data.Tests/CsvProvider.fs
+++ b/tests/FSharp.Data.Tests/CsvProvider.fs
@@ -424,3 +424,39 @@ let ``Parse two rows``() =
   let rows = SimpleWithStrCsv.ParseRows("false,abc, 31\ntrue, def, 42")
   rows.Length |> should equal 2
   (new SimpleWithStrCsv(rows)).SaveToString() |> should equal ("Column1,ColumnB,Column3" + Environment.NewLine + "false,abc,31" + Environment.NewLine + "true, def,42" + Environment.NewLine)
+
+let [<Literal>] csvWithDataEndingWithSeparator = """
+Name|Company |Email|Password
+Johnson|ABC|johnson@abc.com|12345i|
+Yoda|XYZ|yoda@xyz.com|98123"""
+
+[<Test>]    
+let ``Accepts data rows ending with separator when header length matches to the row length``() = 
+  let csv = CsvProvider<csvWithDataEndingWithSeparator, Separators="|", IgnoreErrors=true>.GetSample()
+  let row1 = csv.Rows |> Seq.head
+  row1 |> should equal ("Johnson","ABC","johnson@abc.com","12345i")
+  let row2 = csv.Rows |> Seq.skip 1 |> Seq.head
+  row2 |> should equal ("Yoda","XYZ","yoda@xyz.com","98123")
+
+let [<Literal>] csvWithDataEndingWithSeparatorFollowedByContent = """
+Name|Company |Email|Password
+Doe|QWE|johnson@abc.com|32167|x@y.z
+Yoda|XYZ|yoda@xyz.com|98123"""
+
+[<Test>]
+let ``Rejects data rows ending with extra non-empty content``() = 
+  let csv = CsvProvider<csvWithDataEndingWithSeparatorFollowedByContent, Separators="|", IgnoreErrors=true>.GetSample()
+  let row = csv.Rows |> Seq.exactlyOne
+  row |> should equal ("Yoda","XYZ","yoda@xyz.com", 98123)
+
+let [<Literal>] csvWithDataEndingWithSeparatorFollowedBySeparators = """
+Name|Company |Email|Password
+Johnson|ABC|johnson@abc.com|12345i||||
+Doe|QWE|johnson@abc.com|32167|x@y.z||
+Yoda|XYZ|yoda@xyz.com|98123|"""
+
+[<Test>]
+let ``Rejects data rows ending with two or more separators when header length matches to the rest of the row length``() = 
+  let csv = CsvProvider<csvWithDataEndingWithSeparatorFollowedBySeparators, Separators="|", IgnoreErrors=true>.GetSample()
+  let row = csv.Rows |> Seq.exactlyOne
+  row |> should equal ("Yoda","XYZ","yoda@xyz.com", 98123)


### PR DESCRIPTION
Allowing users of CsvProvider to generate types from csv where data rows end by a single separator. 