### PR TITLE
[WIP] Use the built-in mono support in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,8 @@
-language: objective-c
+language: csharp
 
-env:
-  global:
-    - MONO_VERSION=3.10.0
+sudo: false
 
-install:
-  - wget "http://download.mono-project.com/archive/${MONO_VERSION}/macos-10-x86/MonoFramework-MDK-${MONO_VERSION}.macos10.xamarin.x86.pkg"
-  - sudo installer -pkg "MonoFramework-MDK-${MONO_VERSION}.macos10.xamarin.x86.pkg" -target /
-
-script: 
+script:
   - ./build.sh CleanInternetCaches && ./build.sh All
 
 branches:


### PR DESCRIPTION
It seems that the mono support in Travis is now running using Mono 4.

 - See the log [generated here](https://travis-ci.org/fsprojects/FSharp.Control.AsyncSeq)
 - Which is done [using this Travis config](https://github.com/fsprojects/FSharp.Control.AsyncSeq/blob/master/.travis.yml)

This is an attempt to use the same mechanism for F# Data - sending a PR to see what happens when the Travis build is triggered like this!