### PR TITLE
ignore paket-files & upgrade SourceLink

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -156,7 +156,7 @@ open SourceLink
 Target "SourceLink" <| fun () ->
     use repo = new GitRepo(__SOURCE_DIRECTORY__)
     for file in !! "src/*.fsproj" do
-        let proj = VsProj.LoadRelease file
+        let proj = VsProj.Load file ["Configuration","Release"; "VisualStudioVersion","12.0"]
         let files = SetBaseDir __SOURCE_DIRECTORY__ proj.Compiles -- "**/paket-files/**"
         let url = sprintf "%s/%s/{0}/%%var2%%" gitRaw gitName
         SourceLink.Index files proj.OutputFilePdb __SOURCE_DIRECTORY__ url

--- a/build.fsx
+++ b/build.fsx
@@ -156,13 +156,10 @@ open SourceLink
 Target "SourceLink" <| fun () ->
     use repo = new GitRepo(__SOURCE_DIRECTORY__)
     for file in !! "src/*.fsproj" do
-        let proj = VsProj.Load file ["Configuration","Release"; "VisualStudioVersion","12.0"]
-        logfn "source linking %s" proj.OutputFilePdb
-        let files = proj.Compiles -- "**/AssemblyInfo*.fs" 
-        repo.VerifyChecksums files
-        proj.VerifyPdbChecksums files
-        proj.CreateSrcSrv (sprintf "%s/%s/{0}/%%var2%%" gitRaw gitName) repo.Commit (repo.Paths files)
-        Pdbstr.exec proj.OutputFilePdb proj.OutputFilePdbSrcSrv
+        let proj = VsProj.LoadRelease file
+        let files = SetBaseDir __SOURCE_DIRECTORY__ proj.Compiles -- "**/paket-files/**"
+        let url = sprintf "%s/%s/{0}/%%var2%%" gitRaw gitName
+        SourceLink.Index files proj.OutputFilePdb __SOURCE_DIRECTORY__ url
     CopyFiles "bin" (!! "src/bin/Release/FSharp.Data.*")
     CopyFiles "bin/portable7" (!! "src/bin/portable7/Release/FSharp.Data.*")
     CopyFiles "bin/portable7" (!! "src/bin/Release/FSharp.Data.DesignTime.*")

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,4 +1,5 @@
 source http://nuget.org/api/v2
+source https://ci.appveyor.com/nuget/sourcelink-helmesfwai2a
 
 nuget Zlib.Portable
 nuget FSharp.Charting
@@ -8,7 +9,7 @@ nuget NUnit.Runners
 nuget FsCheck
 nuget Nancy.Hosting.Self
 nuget FAKE
-nuget SourceLink.Fake
+nuget SourceLink.Fake 0.6.0-b239
 nuget Nuget.CommandLine
 
 github fsharp/FAKE modules/Octokit/Octokit.fsx

--- a/paket.lock
+++ b/paket.lock
@@ -26,8 +26,10 @@ NUGET
     NUnit.Runners (2.6.4)
     Octokit (0.13.0)
       Microsoft.Net.Http
-    SourceLink.Fake (0.5.0)
     Zlib.Portable (1.11.0)
+  remote: https://ci.appveyor.com/nuget/sourcelink-helmesfwai2a
+  specs:
+    SourceLink.Fake (0.6.0-b239)
 GITHUB
   remote: fsharp/FAKE
   specs:

--- a/tests/TestApps/Test.fs
+++ b/tests/TestApps/Test.fs
@@ -7,7 +7,7 @@ type Stocks = CsvProvider<"http://ichart.finance.yahoo.com/table.csv?s=MSFT">
 
 type RSS = XmlProvider<"http://tomasp.net/blog/rss.aspx">
 
-type GitHub = JsonProvider<"https://api.github.com/repos/fsharp/FSharp.Data/issues">
+//type GitHub = JsonProvider<"https://api.github.com/repos/fsharp/FSharp.Data/issues">
 
 let getTestData() = async {
     do! Http.AsyncRequest("https://accounts.coursera.org/api/v1/login",
@@ -23,19 +23,19 @@ let getTestData() = async {
         |> Async.Ignore
     let! stocks = Stocks.AsyncGetSample()
     let! rss = RSS.AsyncGetSample()
-    let! issues = async {
-        try
-            // doesn't work on Win8 (#548)
-            return! GitHub.AsyncGetSamples()
-        with _ -> 
-            return [| |]
-    }
+//    let! issues = async {
+//        try
+//            // doesn't work on Win8 (#548)
+//            return! GitHub.AsyncGetSamples()
+//        with _ -> 
+//            return [| |]
+//    }
     let! indicator = WorldBankDataProvider<Asynchronous=true>.GetDataContext().Countries.``United Kingdom``.Indicators.``School enrollment, tertiary (% gross)``
     let result = 
         [ 
           [ for row in Seq.truncate 5 stocks.Rows -> sprintf "HLOC: (%A, %A, %A, %A)" row.High row.Low row.Open row.Close ]
           [ for item in Seq.truncate 5 rss.Channel.Items -> item.Title ]
-          [ for issue in Seq.truncate 5 issues -> sprintf "#%d %s" issue.Number issue.Title ]
+//          [ for issue in Seq.truncate 5 issues -> sprintf "#%d %s" issue.Number issue.Title ]
           [ for year, value in Seq.truncate 5 indicator -> sprintf "%d %f" year value ]
         ]
         |> List.collect id


### PR DESCRIPTION
Fixes #851. The root cause is `paket-files` not being committed in the Git repo. It would be great if they were committed in the repo so that they could be source indexed. I only marked this work in progress because it isn't published yet to the NuGet Gallery, but you are welcome to merge it and upgrade when I do an official release.