### PR TITLE
Fix issue #907 NRE

### DIFF
--- a/src/CommonProviderImplementation/AssemblyResolver.fs
+++ b/src/CommonProviderImplementation/AssemblyResolver.fs
@@ -37,7 +37,8 @@ let init (cfg : TypeProviderConfig) =
 
     if not initialized then
         initialized <- true
-        WebRequest.DefaultWebProxy.Credentials <- CredentialCache.DefaultNetworkCredentials
+        if WebRequest.DefaultWebProxy <> null then // avoid NRE
+            WebRequest.DefaultWebProxy.Credentials <- CredentialCache.DefaultNetworkCredentials
         ProvidedTypes.ProvidedTypeDefinition.Logger := Some FSharp.Data.Runtime.IO.log
 
     let bindingContext = cfg.GetTypeProviderBindingContext()


### PR DESCRIPTION
WebRequest.DefaultWebProxy is null in some environments. Setting the Credentials property was causing a NullReferenceException.