### PR TITLE
Fields containing double quotes should be enclosed in double-quotes

### DIFF
--- a/src/Csv/CsvRuntime.fs
+++ b/src/Csv/CsvRuntime.fs
@@ -335,7 +335,7 @@ type CsvFile<'RowType> private (rowToStringArray:Func<'RowType,string[]>, dispos
 
     for row in x.Rows do
       row |> rowToStringArray.Invoke |> writeLine (fun item -> 
-        if item.Contains separator || item.Contains "\n" then
+        if item.Contains separator || item.Contains quote || item.Contains "\n"  then
           writer.Write quote
           writer.Write (item.Replace(quote, doubleQuote))
           writer.Write quote

--- a/tests/FSharp.Data.Tests/CsvProvider.fs
+++ b/tests/FSharp.Data.Tests/CsvProvider.fs
@@ -473,3 +473,11 @@ let ``Multiline cells saved correctly``() =
     let csv = CsvProvider<csvWithMultilineCells>.GetSample()
     csv.Rows |> Seq.map (fun r -> r.Id, r.Text.Replace("\r", "")) |> Seq.toList |> should equal [1, "abc,"; 2, "def\nghi"]
     csv.SaveToString().Replace("\r", "") |> should equal (csvWithMultilineCells.Replace("\r", ""))
+
+[<Test>]
+let ``Fields with quotes should be quoted and escaped when saved``() =
+    let rowWithQuoteInField = new SimpleWithStrCsv.Row(true, "f\"oo", 1.3M)
+    let csv = new SimpleWithStrCsv([rowWithQuoteInField])
+    let roundTripped = SimpleWithStrCsv.Parse(csv.SaveToString())
+    let rowRoundTripped = roundTripped.Rows |> Seq.exactlyOne
+    rowRoundTripped |> should equal rowWithQuoteInField


### PR DESCRIPTION
according to RFC 4180:

> Fields containing line breaks (CRLF), double quotes, and commas
>        should be enclosed in double-quotes. 