### PR TITLE
AssemblyReader fails to parse assembly attributes when using [<ReflectedDefinition>] 

### DIFF
--- a/src/CommonProviderImplementation/AssemblyReader.fs
+++ b/src/CommonProviderImplementation/AssemblyReader.fs
@@ -3416,10 +3416,13 @@ type ILTypeSigParser(tstring : string) =
                 let arity = 
                     while (int(here()) >= (int('0'))) && (int(here()) <= ((int('9')))) && (int(peek()) >= (int('0'))) && (int(peek()) <= ((int('9')))) do step()
                     System.Int32.Parse(take())
-                // skip the '['
-                drop()
-                // get the specializations
-                typeName+"`"+(arity.ToString()), Some(([| for _i in 0..arity-1 do yield x.ParseType() |]))
+                if here () = '[' then
+                    // skip the '['
+                    drop()
+                    // get the specializations
+                    typeName+"`"+(arity.ToString()), Some(([| for _i in 0..arity-1 do yield x.ParseType() |]))
+                else 
+                    typeName+"`"+(arity.ToString()), None
             else
                 typeName, None
 


### PR DESCRIPTION
pull request, possibly solving issue: #918