### PR TITLE
Add LINQPad samples to NuGet package

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -31,7 +31,7 @@ let description = """
   in your F# applications and scripts. It implements F# type providers for working with
   structured file formats (CSV, HTML, JSON and XML) and for accessing the WorldBank data.
   It also includes helpers for parsing CSV, HTML and JSON files and for sending HTTP requests."""
-let tags = "F# fsharp data typeprovider WorldBank CSV HTML JSON XML HTTP"
+let tags = "F# fsharp data typeprovider WorldBank CSV HTML JSON XML HTTP linqpad-samples"
 
 let gitOwner = "fsharp"
 let gitHome = "https://github.com/" + gitOwner

--- a/nuget/FSharp.Data.nuspec
+++ b/nuget/FSharp.Data.nuspec
@@ -58,6 +58,7 @@
     <file src="..\bin\portable259\FSharp.Data.xml" target="lib/portable-net45+netcore45+wpa81+wp8" />
     <file src="..\bin\portable259\FSharp.Data.DesignTime.dll" target="lib/portable-net45+netcore45+wpa81+wp8" />
     <file src="..\bin\portable259\FSharp.Data.DesignTime.pdb" target="lib/portable-net45+netcore45+wpa81+wp8" />
-    <file src="..\bin\portable259\FSharp.Data.DesignTime.xml" target="lib/portable-net45+netcore45+wpa81+wp8" />
+    <file src="..\bin\portable259\FSharp.Data.DesignTime.xml" target="lib/portable-net45+netcore45+wpa81+wp8" />        
+    <file src="linqpad-samples\*.*" target="linqpad-samples" />
   </files>
 </package>

--- a/nuget/linqpad-samples/GitHub.linq
+++ b/nuget/linqpad-samples/GitHub.linq
@@ -1,0 +1,19 @@
+<Query Kind="FSharpProgram">
+  <GACReference>FSharp.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</GACReference>
+  <Reference>&lt;ProgramFilesX86&gt;\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.0.0\FSharp.Core.dll</Reference>
+  <NuGetReference>FSharp.Data</NuGetReference>
+</Query>
+
+open FSharp.Data
+
+// Beware of rate limiting while running this sample: https://developer.github.com/v3/#rate-limiting
+type GitHub = JsonProvider<"https://api.github.com/repos/fsharp/FSharp.Data/issues">
+
+let topRecentlyUpdatedIssues = 
+    GitHub.GetSamples()
+    |> Seq.filter (fun issue -> issue.State = "open")
+    |> Seq.sortBy (fun issue -> System.DateTime.Now - issue.UpdatedAt)
+    |> Seq.truncate 5
+
+for issue in topRecentlyUpdatedIssues do
+    printfn "#%d %s" issue.Number issue.Title

--- a/nuget/linqpad-samples/Jira.linq
+++ b/nuget/linqpad-samples/Jira.linq
@@ -1,0 +1,15 @@
+<Query Kind="FSharpProgram">
+  <GACReference>FSharp.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</GACReference>
+  <Reference>&lt;ProgramFilesX86&gt;\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.0.0\FSharp.Core.dll</Reference>
+  <NuGetReference>FSharp.Data</NuGetReference>
+</Query>
+
+open FSharp.Data
+
+[<Literal>] 
+let apiUrl = "https://jira.atlassian.com/rest/api/2/search?filter=-4"  // all issues
+type Jira = JsonProvider<apiUrl>
+let jira = Jira.Load(apiUrl)
+
+let tickets = jira.Issues |> Array.map (fun ticket -> (ticket.Id, ticket.Fields.Summary))
+tickets |> Dump

--- a/nuget/linqpad-samples/TypeInference.linq
+++ b/nuget/linqpad-samples/TypeInference.linq
@@ -1,0 +1,27 @@
+<Query Kind="FSharpProgram">
+  <GACReference>FSharp.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</GACReference>
+  <Reference>&lt;ProgramFilesX86&gt;\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.0.0\FSharp.Core.dll</Reference>
+  <NuGetReference>FSharp.Data</NuGetReference>
+</Query>
+
+open FSharp.Data
+
+// The JsonProvider<...> takes one static parameter of type string. The parameter can be either a sample string or a sample file 
+// (relative to the current folder or online accessible via http or https). It is not likely that this could lead to ambiguities.
+type Simple = JsonProvider<""" { "name":"John", "age":94 } """>
+let simple = Simple.Parse(""" { "name":"Tomas", "age":4 } """)
+simple.Age |> Dump
+simple.Name |> Dump
+
+// A list may mix integers and floats. When the sample is a collection, the type provider generates a type 
+// that can be used to store all values in the sample. In this case, the resulting type is decimal, because one of the values is not an integer
+type Numbers = JsonProvider<""" [1, 2, 3, 3.14] """>
+Numbers.Parse(""" [1.2, 45.1, 98.2, 5] """) |> Dump
+
+// Other primitive types cannot be combined into a single type. For example, if the list contains numbers and strings. 
+// In this case, the provider generates two methods that can be used to get values that match one of the types:
+type Mixed = JsonProvider<""" [1, 2, "hello", "world"] """>
+let mixed = Mixed.Parse(""" [4, 5, "hello", "world" ] """)
+
+mixed.Numbers |> Seq.sum |> Dump
+mixed.Strings |> String.concat ", " |> Dump


### PR DESCRIPTION
LINQPad is excellent for prototyping and supports F#.
However, in free version, NuGet is only available for packages that include LINQPad samples: https://www.linqpad.net/nugetsamples.aspx

This PR:
* Makes FSharp.Data NuGet package visible in free LINQPad version
* Makes it easier to get started and play around with FSharp.Data