### PR TITLE
Safer assembly replacement - fix CSV provider in FsLab

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -35,9 +35,9 @@ GITHUB
       Octokit
   remote: fsprojects/FSharp.TypeProviders.StarterPack
   specs:
-    src/AssemblyReader.fs (9f0c159defa1d3d9cf554c44acd55fe5b231fb12)
-    src/AssemblyReaderReflection.fs (9f0c159defa1d3d9cf554c44acd55fe5b231fb12)
-    src/ProvidedTypes.fs (9f0c159defa1d3d9cf554c44acd55fe5b231fb12)
-    src/ProvidedTypes.fsi (9f0c159defa1d3d9cf554c44acd55fe5b231fb12)
-    src/ProvidedTypesContext.fs (9f0c159defa1d3d9cf554c44acd55fe5b231fb12)
-    src/ProvidedTypesTesting.fs (9f0c159defa1d3d9cf554c44acd55fe5b231fb12)
+    src/AssemblyReader.fs (56cd9eb1399c51ac6f05601cd7010bbe8261ef9a)
+    src/AssemblyReaderReflection.fs (56cd9eb1399c51ac6f05601cd7010bbe8261ef9a)
+    src/ProvidedTypes.fs (56cd9eb1399c51ac6f05601cd7010bbe8261ef9a)
+    src/ProvidedTypes.fsi (56cd9eb1399c51ac6f05601cd7010bbe8261ef9a)
+    src/ProvidedTypesContext.fs (56cd9eb1399c51ac6f05601cd7010bbe8261ef9a)
+    src/ProvidedTypesTesting.fs (56cd9eb1399c51ac6f05601cd7010bbe8261ef9a)

--- a/src/CommonProviderImplementation/AssemblyResolver.fs
+++ b/src/CommonProviderImplementation/AssemblyResolver.fs
@@ -40,7 +40,7 @@ let init (cfg : TypeProviderConfig) =
             WebRequest.DefaultWebProxy.Credentials <- CredentialCache.DefaultNetworkCredentials
         ProvidedTypes.ProvidedTypeDefinition.Logger := Some FSharp.Data.Runtime.IO.log
 
-    let bindingContext = ProvidedTypesContext.Create(cfg)
+    let bindingContext = ProvidedTypesContext.Create(cfg, [ "FSharp.Data.DesignTime", "FSharp.Data" ])
 
     let runtimeFSharpCoreVersion = bindingContext.TryGetFSharpCoreAssemblyVersion()
 


### PR DESCRIPTION
More about this here: https://github.com/fsprojects/FSharp.TypeProviders.StarterPack/pull/104

This is a fairly serious bug that means CSV provider does not work when used via FsLab. 

@ovatsus What are your current release plans? Do you think we could release this soon? (Sometime this week would be ideal.)