### PR TITLE
Specify kind on Date header

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 2.3.3 - Unreleased
+* Specify kind on Date header to UTC
+
 #### 2.3.2 - July 24 2016
 * Add support for HTML entities with Unicode characters above 65535.
 * Improve resilience when parsing invalid Set-Cookie headers.

--- a/src/Net/Http.fs
+++ b/src/Net/Http.fs
@@ -543,9 +543,9 @@ module private HttpHelpers =
                 req.ContentType <- value
                 hasContentType := true
 #if FX_NO_WEBREQUEST_DATE
-            | "date" -> if not (req?Date <- DateTime.ParseExact(value, "R", CultureInfo.InvariantCulture)) then req.Headers.[HeaderEnum.Date] <- value
+            | "date" -> if not (req?Date <- DateTime.SpecifyKind(DateTime.ParseExact(value, "R", CultureInfo.InvariantCulture), DateTimeKind.Utc)) then req.Headers.[HeaderEnum.Date] <- value
 #else
-            | "date" -> req.Date <- DateTime.ParseExact(value, "R", CultureInfo.InvariantCulture)
+            | "date" -> req.Date <- DateTime.SpecifyKind(DateTime.ParseExact(value, "R", CultureInfo.InvariantCulture), DateTimeKind.Utc)
 #endif
 #if FX_NO_WEBREQUEST_EXPECT
             | "expect" -> if not (req?Expect <- value) then req.Headers.[HeaderEnum.Expect] <- value


### PR DESCRIPTION
> Otherwise it is assumed to be DateTimeKind.Local (local time)

https://msdn.microsoft.com/en-us/library/system.net.httpwebrequest.date(v=vs.110).aspx