### PR TITLE
Add support for escaped characters in the css selectors.

### DIFF
--- a/tests/FSharp.Data.Tests/HtmlCssSelectors.fs
+++ b/tests/FSharp.Data.Tests/HtmlCssSelectors.fs
@@ -450,5 +450,3 @@ let ``special characters can be escaped``() =
     selection |> should haveLength 1
     let values = selection |> List.map (fun n -> n.InnerText())
     values |> should equal ["Some text"]
-
-``Special characters can be escaped``()

--- a/tests/FSharp.Data.Tests/HtmlCssSelectors.fs
+++ b/tests/FSharp.Data.Tests/HtmlCssSelectors.fs
@@ -433,4 +433,22 @@ let ``has attribute Selector``() =
     let values = selection |> List.map (fun n -> n.AttributeValue("data"))
     values |> should equal ["test"]
 
+[<Test>]
+let ``special characters can be escaped``() =
+    let html =
+        """
+            <!doctype html>
+            <html lang="en">
+            <body>
+            <p id="has:column-and.dot">Some text</p>
+            <p id="ignore"/>
+            </body>
+            </html>
+        """
+        |> HtmlDocument.Parse
+    let selection = html.CssSelect "#has\\:column-and\\.dot"
+    selection |> should haveLength 1
+    let values = selection |> List.map (fun n -> n.InnerText())
+    values |> should equal ["Some text"]
 
+``Special characters can be escaped``()


### PR DESCRIPTION
Supports `\x` escaping where `x` is any character with the exception of CR, LF, FF and
a hexadecimal digit (per CSS 2.1 spec)