### PR TITLE
Add support for escaped characters in the css selectors.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 #### 2.3.3 - Unreleased
-* Specify kind on Date header to UTC
+* Specify kind on Date header to UTC.
+* Support for escaping special characters in CSS selectors.
 
 #### 2.3.2 - July 24 2016
 * Add support for HTML entities with Unicode characters above 65535.

--- a/src/Html/HtmlCssSelectors.fs
+++ b/src/Html/HtmlCssSelectors.fs
@@ -51,6 +51,14 @@ module internal HtmlCssSelectors =
         let getOffset (t:List<char>) = 
             charCount - 1 - t.Length
 
+        let isCharacterEscapable (c:char) =
+            (* CSS 2.1: Any character (except a hexadecimal digit, linefeed,
+               carriage return, or form feed) can be escaped with a backslash to
+               remove its special meaning *)
+            let isHexadecimalDigit = Char.IsDigit(c) || (Char.ToLower(c) >= 'a' && Char.ToLower(c) <= 'f')
+            (isHexadecimalDigit || c = '\n' || c = '\f' || c = '\r')
+            |> not
+
         let rec readString acc = function
             | c :: t when Char.IsLetterOrDigit(c) || c.Equals('-') || c.Equals('_') 
                 || c.Equals('+') || c.Equals('/')
@@ -62,9 +70,8 @@ module internal HtmlCssSelectors =
                 else
                     inQuotes <- true
                     readString acc t
-            | '\\' :: '\'' :: t when inQuotes ->
-                readString (acc + ('\''.ToString())) t
-
+            | '\\' :: c :: t when isCharacterEscapable c ->
+                readString (acc + (c.ToString())) t
             | c :: t when inQuotes ->
                 readString (acc + (c.ToString())) t
             | c :: t -> acc, c :: t

--- a/tests/FSharp.Data.Tests/HtmlCssSelectors.fs
+++ b/tests/FSharp.Data.Tests/HtmlCssSelectors.fs
@@ -448,5 +448,5 @@ let ``special characters can be escaped``() =
         """ |> HtmlDocument.Parse
     let selection = html.CssSelect ".has-class#has-id-with\\:column-and\\.dot"
     selection |> should haveLength 1
-    let values = selection |> List.map (fun n -> n.InnerText()) |> Seq.exactlyOne
+    let values = selection |> Seq.exactlyOne |> HtmlNode.innerText
     values |> should equal "Matched, has id and class"

--- a/tests/FSharp.Data.Tests/HtmlCssSelectors.fs
+++ b/tests/FSharp.Data.Tests/HtmlCssSelectors.fs
@@ -433,4 +433,19 @@ let ``has attribute Selector``() =
     let values = selection |> List.map (fun n -> n.AttributeValue("data"))
     values |> should equal ["test"]
 
-
+[<Test>]
+let ``special characters can be escaped``() =
+    let html =
+        """
+            <!doctype html>
+            <html lang="en">
+            <body>
+            <p id="id-has:column-and.dot">Matched paragraph text</p>
+            <p id="ignore">Other text</p>
+            </body>
+            </html>
+        """ |> HtmlDocument.Parse
+    let selection = html.CssSelect "#id-has\\:column-and\\.dot"
+    selection |> should haveLength 1
+    let values = selection |> List.map (fun n -> n.InnerText())
+    values |> should equal ["Matched paragraph text"]

--- a/tests/FSharp.Data.Tests/HtmlCssSelectors.fs
+++ b/tests/FSharp.Data.Tests/HtmlCssSelectors.fs
@@ -440,12 +440,13 @@ let ``special characters can be escaped``() =
             <!doctype html>
             <html lang="en">
             <body>
-            <p id="id-has:column-and.dot">Matched paragraph text</p>
-            <p id="ignore">Other text</p>
+            <p id="has-id-with:column-and.dot" class="has-class">Matched, has id and class</p>
+            <p id="has-id-with:column-and.dot">Not matched, has id only</p>
+            <p id="ignore">Ignore</p>
             </body>
             </html>
         """ |> HtmlDocument.Parse
-    let selection = html.CssSelect "#id-has\\:column-and\\.dot"
+    let selection = html.CssSelect ".has-class#has-id-with\\:column-and\\.dot"
     selection |> should haveLength 1
-    let values = selection |> List.map (fun n -> n.InnerText())
-    values |> should equal ["Matched paragraph text"]
+    let values = selection |> List.map (fun n -> n.InnerText()) |> Seq.exactlyOne
+    values |> should equal "Matched, has id and class"


### PR DESCRIPTION
Supports ` \x` escaping where x is any character with the exception of `CR`, `LF`, `FF` and
a hexadecimal digit (per CSS 2.1 spec).