### PR TITLE
WIP :(first, nth, nth-last)-child support

### DIFF
--- a/src/Html/HtmlOperations.fs
+++ b/src/Html/HtmlOperations.fs
@@ -53,6 +53,11 @@ module HtmlNode =
         match n with
         | HtmlElement(name = name) -> name
         | _ -> ""
+
+    let position n =
+        match n with
+        | HtmlElement(position = position) -> position
+        | _ -> 0
         
     /// Gets all of the nodes immediately under this node
     let elements n =
@@ -232,7 +237,7 @@ module HtmlNode =
         let rec innerText' inRoot n =
             let exclusions = if inRoot then ["style"; "script"] else exclusions
             match n with
-            | HtmlElement(name, _, content) when List.forall ((<>) name) exclusions && not (isAriaHidden n) ->
+            | HtmlElement(name, _, content, _) when List.forall ((<>) name) exclusions && not (isAriaHidden n) ->
                 seq { for e in content do
                         match e with
                         | HtmlText(text) -> yield text
@@ -272,6 +277,11 @@ type HtmlNodeExtensions =
     [<Extension>]
     static member Name(n:HtmlNode) = 
         HtmlNode.name n
+
+    /// Gets the given node's position
+    [<Extension>]
+    static member Position(n:HtmlNode) = 
+        HtmlNode.position n
         
     /// Gets all of the nodes immediately under this node
     [<Extension>]

--- a/src/Html/HtmlParser.fs
+++ b/src/Html/HtmlParser.fs
@@ -28,7 +28,7 @@ type HtmlAttribute =
 /// Represents an HTML node. The names of elements are always normalized to lowercase
 type HtmlNode =
 
-    internal | HtmlElement of name:string * attributes:HtmlAttribute list * elements:HtmlNode list
+    internal | HtmlElement of name:string * attributes:HtmlAttribute list * elements:HtmlNode list * position:int
              | HtmlText of content:string
              | HtmlComment of content:string
              | HtmlCData of content:string
@@ -38,7 +38,7 @@ type HtmlNode =
     /// </summary>
     /// <param name="name">The name of the element</param>
     static member NewElement(name:string) =
-        HtmlElement(name.ToLowerInvariant(), [], [])
+        HtmlElement(name.ToLowerInvariant(), [], [], 0)
 
     /// <summary>
     /// Creates an html element
@@ -47,7 +47,7 @@ type HtmlNode =
     /// <param name="attrs">The HtmlAttribute(s) of the element</param>
     static member NewElement(name:string, attrs:seq<_>) =
         let attrs = attrs |> Seq.map HtmlAttribute.New |> Seq.toList
-        HtmlElement(name.ToLowerInvariant(), attrs, [])
+        HtmlElement(name.ToLowerInvariant(), attrs, [], 0)
 
     /// <summary>
     /// Creates an html element
@@ -55,7 +55,7 @@ type HtmlNode =
     /// <param name="name">The name of the element</param>
     /// <param name="children">The children elements of this element</param>
     static member NewElement(name:string, children:seq<_>) =
-        HtmlElement(name.ToLowerInvariant(), [], List.ofSeq children)
+        HtmlElement(name.ToLowerInvariant(), [], List.ofSeq children, 0)
 
 
     /// <summary>
@@ -66,7 +66,7 @@ type HtmlNode =
     /// <param name="children">The children elements of this element</param>
     static member NewElement(name:string, attrs:seq<_>, children:seq<_>) =        
         let attrs = attrs |> Seq.map HtmlAttribute.New |> Seq.toList
-        HtmlElement(name.ToLowerInvariant(), attrs, List.ofSeq children)
+        HtmlElement(name.ToLowerInvariant(), attrs, List.ofSeq children, 0)
 
     /// <summary>
     /// Creates a text content element
@@ -93,7 +93,7 @@ type HtmlNode =
                 sb.AppendLine() |> ignore
                 String(' ', indentation + plus) |> append
             match html with
-            | HtmlElement(name, attributes, elements) ->
+            | HtmlElement(name, attributes, elements, _) ->
                 let onlyText = elements |> List.forall (function HtmlText _ -> true | _ -> false)
                 if canAddNewLine && not onlyText then
                     newLine 0
@@ -691,52 +691,52 @@ module internal HtmlParser =
         !state.Tokens |> List.rev
 
     let private parse reader =
-        let canNotHaveChildren (name:string) = 
+        let canNotHaveChildren (name:string) =  
             match name with
             | "area" | "base" | "br" | "col" | "embed"| "hr" | "img" | "input" | "keygen" | "link" | "menuitem" | "meta" | "param" 
             | "source" | "track" | "wbr" -> true
             | _ -> false
-        let rec parse' docType elements expectedTagEnd parentTagName (tokens:HtmlToken list) =
+        let rec parse' docType elements expectedTagEnd parentTagName position (tokens:HtmlToken list) =
             match tokens with
-            | DocType dt :: rest -> parse' (dt.Trim()) elements expectedTagEnd parentTagName rest
+            | DocType dt :: rest -> parse' (dt.Trim()) elements expectedTagEnd parentTagName 0 rest
             | Tag(_, "br", []) :: rest ->
                 let t = HtmlText Environment.NewLine
-                parse' docType (t :: elements) expectedTagEnd parentTagName rest
+                parse' docType (t :: elements) expectedTagEnd parentTagName position rest
             | Tag(true, name, attributes) :: rest ->
-               let e = HtmlElement(name, attributes, [])
-               parse' docType (e :: elements) expectedTagEnd parentTagName rest
+               let e = HtmlElement(name, attributes, [], position)
+               parse' docType (e :: elements) expectedTagEnd parentTagName (position + 1) rest
             | Tag(false, name, attributes) :: rest when canNotHaveChildren name ->
-               let e = HtmlElement(name, attributes, [])
-               parse' docType (e :: elements) expectedTagEnd parentTagName rest
+               let e = HtmlElement(name, attributes, [], position)
+               parse' docType (e :: elements) expectedTagEnd parentTagName (position + 1) rest
             | Tag(_, name, attributes) :: rest ->
-                let dt, tokens, content = parse' docType [] name expectedTagEnd rest
-                let e = HtmlElement(name, attributes, content)
-                parse' dt (e :: elements) expectedTagEnd parentTagName tokens
+                let dt, tokens, content = parse' docType [] name expectedTagEnd 0 rest
+                let e = HtmlElement(name, attributes, content, position)
+                parse' dt (e :: elements) expectedTagEnd parentTagName (position + 1) tokens
             | TagEnd name :: _ when name <> expectedTagEnd && name = parentTagName ->
                 // insert missing closing tag
-                parse' docType elements expectedTagEnd parentTagName (TagEnd expectedTagEnd :: tokens)
+                parse' docType elements expectedTagEnd parentTagName position (TagEnd expectedTagEnd :: tokens)
             | TagEnd name :: rest when name <> expectedTagEnd && (name <> (new String(expectedTagEnd.ToCharArray() |> Array.rev))) -> 
                 // ignore this token if not the expected end tag (or it's reverse, eg: <li></il>)
-                parse' docType elements expectedTagEnd parentTagName rest
+                parse' docType elements expectedTagEnd parentTagName position rest
             | TagEnd _ :: rest -> 
                 docType, rest, List.rev elements
             | Text cont :: rest ->
                 if cont = "" then
                     // ignore this token
-                    parse' docType elements expectedTagEnd parentTagName rest
+                    parse' docType elements expectedTagEnd parentTagName position rest
                 else
                     let t = HtmlText cont
-                    parse' docType (t :: elements) expectedTagEnd parentTagName rest
+                    parse' docType (t :: elements) expectedTagEnd parentTagName position rest
             | Comment cont :: rest -> 
                 let c = HtmlComment cont
-                parse' docType (c :: elements) expectedTagEnd parentTagName rest
+                parse' docType (c :: elements) expectedTagEnd parentTagName position rest
             | CData cont :: rest -> 
                 let c = HtmlCData cont
-                parse' docType (c :: elements) expectedTagEnd parentTagName rest
+                parse' docType (c :: elements) expectedTagEnd parentTagName position rest
             | EOF :: _ -> docType, [], List.rev elements
             | [] -> docType, [], List.rev elements
         let tokens = tokenise reader 
-        let docType, _, elements = tokens |> parse' "" [] "" ""
+        let docType, _, elements = tokens |> parse' "" [] "" "" 0
         if List.isEmpty elements then
             failwith "Invalid HTML" 
         docType, elements
@@ -794,4 +794,4 @@ type HtmlNode with
     /// Parses the specified HTML string to a list of HTML nodes
     static member ParseRooted(rootName, text) = 
         use reader = new StringReader(text)
-        HtmlElement(rootName, [], HtmlParser.parseFragment reader)
+        HtmlElement(rootName, [], HtmlParser.parseFragment reader, 0)

--- a/src/Html/HtmlRuntime.fs
+++ b/src/Html/HtmlRuntime.fs
@@ -181,8 +181,8 @@ module HtmlRuntime =
                     let getContents contents = 
                         contents |> List.map (HtmlNode.innerTextExcluding ["table"; "ul"; "ol"; "dl"; "sup"; "sub"]) |> String.Concat |> normalizeWs
                     match cell with
-                    | HtmlElement("td", _, contents) -> Cell (false, getContents contents)
-                    | HtmlElement("th", _, contents) -> Cell (true, getContents contents)
+                    | HtmlElement("td", _, contents, _) -> Cell (false, getContents contents)
+                    | HtmlElement("th", _, contents, _) -> Cell (true, getContents contents)
                     | _ -> Empty
                 let col_i = ref colindex
                 while !col_i < res.[rowindex].Length && res.[rowindex].[!col_i] <> Empty do incr(col_i)

--- a/tests/FSharp.Data.Tests/HtmlCssSelectors.fs
+++ b/tests/FSharp.Data.Tests/HtmlCssSelectors.fs
@@ -450,3 +450,33 @@ let ``special characters can be escaped``() =
     selection |> should haveLength 1
     let values = selection |> Seq.exactlyOne |> HtmlNode.innerText
     values |> should equal "Matched, has id and class"
+
+[<Test>]
+let ``:first-child Selector``() =
+    let html =
+        """
+            <!doctype html>
+            <html lang="en">
+            <body>
+            <div>
+              <div>First child div</div>
+              <p>Second child paragraph</p>
+              <p>Third child paragraph</p>
+            </div>
+            <div>
+              <p>First child paragraph</p>
+              <p>Another second child paragraph</p>
+            </div>
+            <div>
+              <p>Yet another first child paragraph</p>
+              <p>Yet another second child paragraph</p>
+            </div>
+            </body>
+            </html>
+        """ |> HtmlDocument.Parse
+    let selection = html.CssSelect "p:first-child"
+    selection |> should haveLength 2
+    let values = selection |> Seq.map HtmlNode.innerText
+    values |> should equal ["First child paragraph";"Yet another first child paragraph"]
+
+let result = ``:first-child Selector``()


### PR DESCRIPTION
Opening this pull request mostly to start a discussion around adding support for `:first-child`, `:nth-child` and `nth-last-child`. The issue with implementing the support for these is the fact that they rely on the index position of the child in the parent node, and `FSharp.Data`'s `HtmlNode` has no such information. In this pull request I added a working implementation for `:first-child` using a newly added position attribute just as a trivial proof of concept, as I don't believe that's the right approach as it would mean that whoever is creating a `HtmlElement` would always have to specify a position.

Solutions include:
1)  Support a (optional?) parent node, this way the position could be extracted by getting parentNode.elements and index filter it to find the child node. This would be more in line with how HTML DOM works (ie. children having references to their parents). To me, this would be preferable than having a position as it would ensure the positional correctness even when if the structure changes. Also this removes the erroneous setting of position = 0 for dynamically created elements.
2) New methods for searching children/descendants, etc. that would returns a tuple of (index, node) instead of just node. This seems like a lot of work that would add a lot of complexity to the existing code.
3) The approach taken in the current pull request - although simple, it's conceptually wrong, I only did it for its simplicity.
4) ??

Would love to hear from you what's your preferred approach, perhaps there's an obvious one that I missed...

P.S. I know that `FSharp.Data` already supports jquery's `:even`, and `:odd`, but those work differently, they only care about the positional even/odd-ness of the matches list, not the actual position of the nodes in their respective parents.