### PR TITLE
Fixes for #975: Some performance and memory leak issues fixed.

### DIFF
--- a/src/CommonProviderImplementation/Helpers.fs
+++ b/src/CommonProviderImplementation/Helpers.fs
@@ -210,7 +210,6 @@ module internal ProviderHelpers =
                   ResolutionFolder = resolutionFolder }
             
             let readText() = 
-                lazy(
                 use reader = 
                     asyncRead (Some (tp, fullTypeName)) resolver formatName encodingStr uri
                     |> Async.RunSynchronously
@@ -226,7 +225,7 @@ module internal ProviderHelpers =
                         else
                             line |> sb.AppendLine |> ignore
                             decr max
-                    sb.ToString())
+                    sb.ToString()
     
             try
               
@@ -235,10 +234,10 @@ module internal ProviderHelpers =
                         match webUrisCache.TryRetrieve uri.OriginalString with
                         | Some value -> value, true
                         | None ->
-                            let value = readText().Force()
+                            let value = readText()
                             webUrisCache.Set(uri.OriginalString, value)
                             value, true
-                    else readText().Force(), false
+                    else readText(), false
                     
                 { TypedSamples = parseFunc (Path.GetExtension uri.OriginalString) sample
                   SampleIsUri = true
@@ -308,8 +307,7 @@ module internal ProviderHelpers =
                         providedTypesCache.AddOrUpdate(key, CacheValue (providedType, fullKey), fun _ _ -> CacheValue (providedType, fullKey)) |> ignore
                         // Remove the cache entry in 10 seconds
                         async { do! Async.Sleep (10000)
-                                if providedTypesCache <> null then
-                                    providedTypesCache.TryRemove(key) |> ignore } |> Async.Start
+                                providedTypesCache.TryRemove(key) |> ignore } |> Async.Start
             providedType
       else 
           f() 

--- a/src/CommonRuntime/IO.fs
+++ b/src/CommonRuntime/IO.fs
@@ -169,14 +169,20 @@ type private Watcher(uri:Uri) =
         let alive = typeProviders.Exists(Predicate(function (TypeProviderReference _tp, _tn) -> true | _ -> false)) 
         if not alive then
             log ("Disposing watcher " + uri.OriginalString) 
-            watcher.Dispose()
+            if watcher <> null then
+                watcher.Dispose()
             true
         else
             false 
 
 open System.Collections.Generic
 
+#if FX_NO_CONCURRENT
 let private watchers = Dictionary<string,Watcher>()
+#else
+open System.Collections.Concurrent
+let private watchers = ConcurrentDictionary<string,Watcher>()
+#endif
 
 // sets up a filesystem watcher that calls the invalidate function whenever the file changes
 // adds the filesystem watcher to the list of objects to dispose by the type provider
@@ -194,7 +200,11 @@ let private watchForChanges (uri:Uri) (((tp:IDisposableTypeProvider), typeName) 
                    
             log (sprintf "Setting up watcher %s for %s [%d]" typeName uri.OriginalString tp.Id)
             let watcher = Watcher uri
+#if FX_NO_CONCURRENT
             watchers.Add(uri.OriginalString, watcher)
+#else
+            watchers.AddOrUpdate(uri.OriginalString, watcher, fun _ _ -> watcher) |> ignore
+#endif
             watcher
 
     watcher.Add key
@@ -203,7 +213,11 @@ let private watchForChanges (uri:Uri) (((tp:IDisposableTypeProvider), typeName) 
 
         if (match typeNameBeingDisposedOpt with None -> true | Some typeNameBeingDisposed -> typeName = typeNameBeingDisposed) then 
             if watcher.Remove tp typeName then
+#if FX_NO_CONCURRENT
                 watchers.Remove uri.OriginalString |> ignore
+#else
+                watchers.TryRemove(uri.OriginalString) |> ignore
+#endif
             
 #endif
     

--- a/src/Html/HtmlGenerator.fs
+++ b/src/Html/HtmlGenerator.fs
@@ -173,19 +173,16 @@ module internal HtmlGenerator =
 
         let htmlType = bindingContext.ProvidedTypeDefinition(asm, ns, typeName, Some typeof<HtmlDocument>, hideObjectMethods = true, nonNullable = true)
         
-        let containerTypes = Dictionary<string, ProvidedTypeDefinition>()
+        let containerTypes = System.Collections.Concurrent.ConcurrentDictionary<string, ProvidedTypeDefinition>()
 
         let getTypeName = typeNameGenerator()
 
         let getOrCreateContainer name = 
-            match containerTypes.TryGetValue(name) with
-            | true, t -> t
-            | false, _ ->
+            containerTypes.GetOrAdd(name, fun name ->
                 let containerType = bindingContext.ProvidedTypeDefinition(name + "Container", Some typeof<HtmlDocument>, hideObjectMethods = true, nonNullable = true)
                 htmlType.AddMember <| bindingContext.ProvidedProperty(name, containerType, getterCode = fun (Singleton doc) -> doc)
                 htmlType.AddMember containerType
-                containerTypes.Add(name, containerType)
-                containerType
+                containerType)
 
         for htmlObj in htmlObjects do
             match htmlObj with

--- a/src/Json/JsonGenerator.fs
+++ b/src/Json/JsonGenerator.fs
@@ -5,6 +5,7 @@ namespace ProviderImplementation
 
 open System
 open System.Collections.Generic
+open System.Collections.Concurrent
 open System.Reflection
 open Microsoft.FSharp.Quotations
 open FSharp.Data
@@ -28,11 +29,11 @@ type internal JsonGenerationContext =
     IJsonDocumentType : Type
     JsonValueType : Type
     JsonRuntimeType : Type
-    TypeCache : Dictionary<InferedType, ProvidedTypeDefinition>
+    TypeCache : ConcurrentDictionary<InferedType, ProvidedTypeDefinition>
     GenerateConstructors : bool }
   static member Create(cultureStr, tpType, bindingContext, ?uniqueNiceName, ?typeCache) =
     let uniqueNiceName = defaultArg uniqueNiceName (NameUtils.uniqueGenerator NameUtils.nicePascalName)
-    let typeCache = defaultArg typeCache (Dictionary())
+    let typeCache = defaultArg typeCache (ConcurrentDictionary())
     JsonGenerationContext.Create(cultureStr, tpType, bindingContext, uniqueNiceName, typeCache, true)
   static member Create(cultureStr, tpType, bindingContext, uniqueNiceName, typeCache, generateConstructors) =
     { CultureStr = cultureStr
@@ -92,12 +93,9 @@ module JsonTypeBuilder =
 
     let inferedType = normalize true inferedType
     let typ = 
-      match ctx.TypeCache.TryGetValue inferedType with
-      | true, typ -> typ
-      | _ -> 
+      ctx.TypeCache.GetOrAdd(inferedType, fun inferedType ->
         let typ = createType()
-        ctx.TypeCache.Add(inferedType, typ)
-        typ
+        typ)
 
     { ConvertedType = typ
       OptionalConverter = None

--- a/src/Net/Http.fs
+++ b/src/Net/Http.fs
@@ -375,9 +375,10 @@ module private HttpHelpers =
         interface IDisposable with
             member x.Dispose () = 
                 match res :> obj with
-                | :? IDisposable as res -> res.Dispose ()
+                | :? IDisposable as res when res <> null -> res.Dispose ()
                 | _ -> ()
-                responseStream.Dispose ()
+                if responseStream<>null then
+                    responseStream.Dispose ()
 
     /// consumes a stream asynchronously until the end
     /// and returns a memory stream with the full content

--- a/src/Xml/XmlGenerator.fs
+++ b/src/Xml/XmlGenerator.fs
@@ -5,6 +5,7 @@ namespace ProviderImplementation
 
 open System
 open System.Collections.Generic
+open System.Collections.Concurrent
 open System.IO
 open System.Reflection
 open System.Xml.Linq
@@ -30,8 +31,8 @@ type internal XmlGenerationContext =
       // to nameclash type names
       UniqueNiceName : string -> string 
       UnifyGlobally : bool
-      XmlTypeCache : Dictionary<string, XmlGenerationResult>
-      JsonTypeCache : Dictionary<InferedType, ProvidedTypeDefinition> }
+      XmlTypeCache : ConcurrentDictionary<string, XmlGenerationResult>
+      JsonTypeCache : ConcurrentDictionary<InferedType, ProvidedTypeDefinition> }
     static member Create(cultureStr, tpType, unifyGlobally, bindingContext) =
         let uniqueNiceName = NameUtils.uniqueGenerator NameUtils.nicePascalName
         uniqueNiceName "XElement" |> ignore
@@ -40,8 +41,8 @@ type internal XmlGenerationContext =
           BindingContext = bindingContext
           UniqueNiceName = uniqueNiceName
           UnifyGlobally = unifyGlobally
-          XmlTypeCache = Dictionary()
-          JsonTypeCache = Dictionary() }
+          XmlTypeCache = ConcurrentDictionary()
+          JsonTypeCache = ConcurrentDictionary() }
     member x.ConvertValue prop =
         let typ, _, conv, _ = ConversionsGenerator.convertStringValue "" x.CultureStr prop
         typ, conv
@@ -156,8 +157,8 @@ module internal XmlTypeBuilder =
         match inferedType with
        
         // If we already generated object for this type, return it
-        | InferedType.Record(Some nameWithNs, _, false) when ctx.XmlTypeCache.ContainsKey nameWithNs -> 
-            ctx.XmlTypeCache.[nameWithNs]
+        | InferedType.Record(Some nameWithNs, _, false) when fst(ctx.XmlTypeCache.TryGetValue nameWithNs) -> 
+            snd(ctx.XmlTypeCache.TryGetValue nameWithNs)
         
         // If the element does not have any children and always contains only primitive type
         // then we turn it into a primitive value of type such as int/string/etc.
@@ -175,8 +176,8 @@ module internal XmlTypeBuilder =
         | HeterogeneousRecords cases ->
        
             // Generate new choice type for the element
-            let objectTy = bindingContext.ProvidedTypeDefinition(ctx.UniqueNiceName "Choice", Some typeof<XmlElement>, hideObjectMethods = true, nonNullable = true)
-            ctx.ProvidedType.AddMember objectTy
+            let objectTyL = lazy(bindingContext.ProvidedTypeDefinition(ctx.UniqueNiceName "Choice", Some typeof<XmlElement>, hideObjectMethods = true, nonNullable = true))
+            ctx.ProvidedType.AddMemberDelayed(fun () -> objectTyL.Force())
        
             // to nameclash property names
             let makeUnique = NameUtils.uniqueGenerator NameUtils.nicePascalName
@@ -200,7 +201,8 @@ module internal XmlTypeBuilder =
                      bindingContext.ProvidedParameter(NameUtils.niceCamelName name, result.ConvertedType)) ]
 
             let properties, parameters = List.unzip members            
-            objectTy.AddMembers properties
+            let objectTy = objectTyL.Force()
+            objectTy.AddMembersDelayed (fun () -> properties)
 
             let cultureStr = ctx.CultureStr
 
@@ -211,12 +213,12 @@ module internal XmlTypeBuilder =
                     else
                         let arg = Expr.Coerce(arg, typeof<obj>)
                         <@@ XmlRuntime.CreateValue(nameWithNS, %%arg, cultureStr) @@>)
-                objectTy.AddMember ctor
+                objectTy.AddMemberDelayed(fun () -> ctor)
 
-            objectTy.AddMember <| 
+            objectTy.AddMemberDelayed <| (fun () -> 
               bindingContext.ProvidedConstructor(
                   [bindingContext.ProvidedParameter("xElement",typeof<XElement>)], 
-                  invokeCode = fun (Singleton arg) -> <@@ XmlElement.Create(%%arg:XElement) @@>)
+                  invokeCode = fun (Singleton arg) -> <@@ XmlElement.Create(%%arg:XElement) @@>))
 
             { ConvertedType = objectTy
               Converter = id }
@@ -226,15 +228,16 @@ module internal XmlTypeBuilder =
        
             let names = nameWithNS.Split [| '|' |] |> Array.map (fun nameWithNS -> XName.Get(nameWithNS).LocalName)
 
-            let objectTy = bindingContext.ProvidedTypeDefinition(ctx.UniqueNiceName names.[0],
+            let objectTy = lazy(bindingContext.ProvidedTypeDefinition(ctx.UniqueNiceName names.[0],
                                                                  Some typeof<XmlElement>, 
-                                                                 hideObjectMethods = true, nonNullable = true)
-            ctx.ProvidedType.AddMember objectTy
+                                                                 hideObjectMethods = true, nonNullable = true))
+            ctx.ProvidedType.AddMemberDelayed (fun () -> objectTy.Force())
        
             // If we unify types globally, then save type for this record
             if ctx.UnifyGlobally then
-                ctx.XmlTypeCache.Add(nameWithNS, { ConvertedType = objectTy 
-                                                   Converter = id })
+                let itm = { ConvertedType = objectTy.Force()
+                            Converter = id }
+                ctx.XmlTypeCache.AddOrUpdate(nameWithNS, itm, fun _ _ -> itm) |> ignore
                 
             // Split the properties into attributes and a 
             // special property representing the content
@@ -269,7 +272,7 @@ module internal XmlTypeBuilder =
                         // a choice type that is erased to 'option<string>' (for simplicity, assuming that
                         // the attribute is always optional)
                         let choiceTy = bindingContext.ProvidedTypeDefinition(ctx.UniqueNiceName (name + "Choice"), Some typeof<option<string>>, hideObjectMethods = true, nonNullable = true)
-                        ctx.ProvidedType.AddMember choiceTy
+                        ctx.ProvidedType.AddMemberDelayed(fun () -> choiceTy)
                 
                         for KeyValue(tag, typ) in types do 
                       
@@ -280,20 +283,20 @@ module internal XmlTypeBuilder =
                             | InferedType.Primitive(primTyp, unit, false) ->
                         
                                 let typ, conv = ctx.ConvertValue <| PrimitiveInferedProperty.Create(tag.NiceName, primTyp, true, unit)
-                                choiceTy.AddMember <|
+                                choiceTy.AddMemberDelayed <| (fun () -> 
                                     bindingContext.ProvidedProperty(tag.NiceName, typ , getterCode = fun (Singleton attrVal) -> 
-                                        attrVal |> Expr.Cast |> conv)
+                                        attrVal |> Expr.Cast |> conv))
 
                                 let typ, convBack = ctx.ConvertValueBack <| PrimitiveInferedProperty.Create(tag.NiceName, primTyp, false, unit)
-                                choiceTy.AddMember <|
+                                choiceTy.AddMemberDelayed <| (fun () -> 
                                     let parameter = bindingContext.ProvidedParameter("value", typ)
                                     bindingContext.ProvidedConstructor([parameter], invokeCode = fun (Singleton arg) -> 
-                                        arg |> convBack |> ProviderHelpers.some typeof<string> )
+                                        arg |> convBack |> ProviderHelpers.some typeof<string> ))
 
                             | _ -> failwithf "generateXmlType: A choice type of an attribute can only contain primitive types, got %A" typ
 
                         let defaultCtor = bindingContext.ProvidedConstructor([], invokeCode = fun _ -> <@@ option<string>.None @@>)
-                        choiceTy.AddMember defaultCtor
+                        choiceTy.AddMemberDelayed (fun () -> defaultCtor)
 
                         createMember choiceTy (fun x -> x :> Expr)
                 
@@ -397,13 +400,13 @@ module internal XmlTypeBuilder =
             let primitiveElemProperties, primitiveElemParameters = List.unzip primitiveResults
             let childElemNames, childElemProperties, childElemParameters = List.unzip3 childResults
 
-            objectTy.AddMembers (attrProperties @ primitiveElemProperties @ childElemProperties)
+            objectTy.Force().AddMembersDelayed (fun () -> (attrProperties @ primitiveElemProperties @ childElemProperties))
             
             let createConstrutor primitiveParam = 
                 let parameters = match primitiveParam with
                                  | Some primitiveParam -> attrParameters @ [primitiveParam] @ childElemParameters
                                  | None -> attrParameters @ childElemParameters
-                objectTy.AddMember <|                
+                objectTy.Force().AddMemberDelayed <| (fun () ->              
                     bindingContext.ProvidedConstructor(parameters, invokeCode = fun args -> 
                         let attributes = 
                             Expr.NewArray(typeof<string * obj>, 
@@ -429,7 +432,7 @@ module internal XmlTypeBuilder =
 
                         let cultureStr = ctx.CultureStr
                         <@@ XmlRuntime.CreateRecord(nameWithNS, %%attributes, %%elements, cultureStr) @@>
-                       )
+                       ))
             
             if primitiveElemParameters.Length = 0 then
                 createConstrutor None
@@ -437,13 +440,13 @@ module internal XmlTypeBuilder =
                 for primitiveParam in primitiveElemParameters do
                     createConstrutor (Some primitiveParam)
 
-            objectTy.AddMember <| 
+            objectTy.Force().AddMemberDelayed <| (fun () -> 
               bindingContext.ProvidedConstructor(
                   [bindingContext.ProvidedParameter("xElement", typeof<XElement>)], 
                   invokeCode = fun (Singleton arg) -> 
-                      <@@ XmlElement.Create(%%arg:XElement) @@>)
+                      <@@ XmlElement.Create(%%arg:XElement) @@>))
 
-            { ConvertedType = objectTy 
+            { ConvertedType = objectTy.Force()
               Converter = id }
        
         | _ -> failwithf "generateXmlType: Infered type should be record type: %A" inferedType

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Xml,HtmlBody.xml,False,False,,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Xml,HtmlBody.xml,False,False,,True.expected
@@ -1,30 +1,30 @@
 class XmlProvider : obj
-    static member AsyncGetSample: () -> XmlProvider+Div async
+    static member AsyncGetSample: () -> XmlProvider+Div2 async
     let f = new Func<_,_>(fun (t:TextReader) -> XmlElement.Create(t))
     TextRuntime.AsyncMap((IO.asyncReadTextAtRuntimeWithDesignTimeRules "<RESOLUTION_FOLDER>" "" "XML" "" "HtmlBody.xml"), f)
 
-    static member AsyncLoad: uri:string -> XmlProvider+Div async
+    static member AsyncLoad: uri:string -> XmlProvider+Div2 async
     let f = new Func<_,_>(fun (t:TextReader) -> XmlElement.Create(t))
     TextRuntime.AsyncMap((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "XML" "" uri), f)
 
-    static member GetSample: () -> XmlProvider+Div
+    static member GetSample: () -> XmlProvider+Div2
     XmlElement.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntimeWithDesignTimeRules "<RESOLUTION_FOLDER>" "" "XML" "" "HtmlBody.xml")))
 
-    static member Load: stream:System.IO.Stream -> XmlProvider+Div
+    static member Load: stream:System.IO.Stream -> XmlProvider+Div2
     XmlElement.Create(((new StreamReader(stream)) :> TextReader))
 
-    static member Load: reader:System.IO.TextReader -> XmlProvider+Div
+    static member Load: reader:System.IO.TextReader -> XmlProvider+Div2
     XmlElement.Create(reader)
 
-    static member Load: uri:string -> XmlProvider+Div
+    static member Load: uri:string -> XmlProvider+Div2
     XmlElement.Create(FSharpAsync.RunSynchronously((IO.asyncReadTextAtRuntime false "<RESOLUTION_FOLDER>" "" "XML" "" uri)))
 
-    static member Parse: text:string -> XmlProvider+Div
+    static member Parse: text:string -> XmlProvider+Div2
     XmlElement.Create(((new StringReader(text)) :> TextReader))
 
 
-class XmlProvider+Div : FDR.BaseTypes.XmlElement
-    new : id:string -> span:string -> divs:XmlProvider+Div2[] -> XmlProvider+Div
+class XmlProvider+Div2 : FDR.BaseTypes.XmlElement
+    new : id:string -> span:string -> divs:XmlProvider+Div[] -> XmlProvider+Div2
     XmlRuntime.CreateRecord("div", 
                             [| ("id",
                                 (id :> obj)) |], 
@@ -33,10 +33,10 @@ class XmlProvider+Div : FDR.BaseTypes.XmlElement
                                ("div",
                                 (divs :> obj)) |], "")
 
-    new : xElement:System.Xml.Linq.XElement -> XmlProvider+Div
+    new : xElement:System.Xml.Linq.XElement -> XmlProvider+Div2
     XmlElement.Create(xElement)
 
-    member Divs: XmlProvider+Div2[] with get
+    member Divs: XmlProvider+Div[] with get
     XmlRuntime.ConvertArray(this, "div", new Func<_,_>(id)))
 
     member Id: string with get
@@ -48,8 +48,8 @@ class XmlProvider+Div : FDR.BaseTypes.XmlElement
     TextRuntime.GetNonOptionalValue("Value", TextRuntime.ConvertString(value), value)
 
 
-class XmlProvider+Div2 : FDR.BaseTypes.XmlElement
-    new : id:string -> spans:string[] -> div:string option -> XmlProvider+Div2
+class XmlProvider+Div : FDR.BaseTypes.XmlElement
+    new : id:string -> spans:string[] -> div:string option -> XmlProvider+Div
     XmlRuntime.CreateRecord("div", 
                             [| ("id",
                                 (id :> obj)) |], 
@@ -58,7 +58,7 @@ class XmlProvider+Div2 : FDR.BaseTypes.XmlElement
                                ("div",
                                 (div :> obj)) |], "")
 
-    new : xElement:System.Xml.Linq.XElement -> XmlProvider+Div2
+    new : xElement:System.Xml.Linq.XElement -> XmlProvider+Div
     XmlElement.Create(xElement)
 
     member Div: string option with get

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Xml,JsonInXml.xml,True,False,,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Xml,JsonInXml.xml,True,False,,True.expected
@@ -38,7 +38,7 @@ class XmlProvider+PropertyBag : FDR.BaseTypes.XmlElement
 
 
 class XmlProvider+BlahData : FDR.BaseTypes.XmlElement
-    new : x:XmlProvider+X[] -> blahDataSomethingFoos:XmlProvider+BlahDataSomethingFoo[] -> blahDataSomethingFoo2:XmlProvider+BlahDataSomethingFoo2 -> blahDataSomethingFoo3:XmlProvider+BlahDataSomethingFoo4 -> blahDataSomethingFoo4:XmlProvider+BlahDataSomethingFoo3 option -> XmlProvider+BlahData
+    new : x:XmlProvider+X[] -> blahDataSomethingFoos:XmlProvider+BlahDataSomethingFoo[] -> blahDataSomethingFoo2:XmlProvider+BlahDataSomethingFoo3 -> blahDataSomethingFoo3:XmlProvider+BlahDataSomethingFoo4 -> blahDataSomethingFoo4:XmlProvider+BlahDataSomethingFoo2 option -> XmlProvider+BlahData
     XmlRuntime.CreateRecord("BlahData", 
                             [| |], 
                             [| ("X",
@@ -55,13 +55,13 @@ class XmlProvider+BlahData : FDR.BaseTypes.XmlElement
     new : xElement:System.Xml.Linq.XElement -> XmlProvider+BlahData
     XmlElement.Create(xElement)
 
-    member BlahDataSomethingFoo2: XmlProvider+BlahDataSomethingFoo2 with get
+    member BlahDataSomethingFoo2: XmlProvider+BlahDataSomethingFoo3 with get
     XmlRuntime.GetChild(this, "BlahDataSomethingFoo2")
 
     member BlahDataSomethingFoo3: XmlProvider+BlahDataSomethingFoo4 with get
     XmlRuntime.GetChild(this, "BlahDataSomethingFoo3")
 
-    member BlahDataSomethingFoo4: XmlProvider+BlahDataSomethingFoo3 option with get
+    member BlahDataSomethingFoo4: XmlProvider+BlahDataSomethingFoo2 option with get
     XmlRuntime.ConvertOptional(this, "BlahDataSomethingFoo4", new Func<_,_>(fun (t:XmlElement) -> XmlRuntime.GetJsonValue(t, "")))
 
     member BlahDataSomethingFoos: XmlProvider+BlahDataSomethingFoo[] with get
@@ -89,37 +89,14 @@ class XmlProvider+BlahDataSomethingFoo : FDR.BaseTypes.IJsonDocument
     JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertString("", value.JsonOpt), value.JsonOpt)
 
 
-class XmlProvider+BlahDataSomethingFoo2 : FDR.BaseTypes.XmlElement
-    new : number:int -> XmlProvider+BlahDataSomethingFoo2
-    XmlRuntime.CreateRecord("BlahDataSomethingFoo2", 
-                            [| |], 
-                            [| ("",
-                                (number :> obj)) |], "")
-
-    new : json:XmlProvider+BlahDataSomethingFoo3 -> XmlProvider+BlahDataSomethingFoo2
-    XmlRuntime.CreateRecord("BlahDataSomethingFoo2", 
-                            [| |], 
-                            [| ("",
-                                (json :> obj)) |], "")
-
-    new : xElement:System.Xml.Linq.XElement -> XmlProvider+BlahDataSomethingFoo2
-    XmlElement.Create(xElement)
-
-    member Json: XmlProvider+BlahDataSomethingFoo3 option with get
-    XmlRuntime.TryGetJsonValue(this, "")
-
-    member Number: int option with get
-    TextRuntime.ConvertInteger("", XmlRuntime.TryGetValue(this))
-
-
-class XmlProvider+BlahDataSomethingFoo3 : FDR.BaseTypes.IJsonDocument
-    new : somethingSchema:string -> results:XmlProvider+Results2 -> XmlProvider+BlahDataSomethingFoo3
+class XmlProvider+BlahDataSomethingFoo2 : FDR.BaseTypes.IJsonDocument
+    new : somethingSchema:string -> results:XmlProvider+Results2 -> XmlProvider+BlahDataSomethingFoo2
     JsonRuntime.CreateRecord([| ("Something.Schema",
                                  (somethingSchema :> obj))
                                 ("results",
                                  (results :> obj)) |], "")
 
-    new : jsonValue:JsonValue -> XmlProvider+BlahDataSomethingFoo3
+    new : jsonValue:JsonValue -> XmlProvider+BlahDataSomethingFoo2
     JsonDocument.Create(jsonValue, "")
 
     member Results: XmlProvider+Results2 with get
@@ -130,8 +107,31 @@ class XmlProvider+BlahDataSomethingFoo3 : FDR.BaseTypes.IJsonDocument
     JsonRuntime.GetNonOptionalValue(value.Path, JsonRuntime.ConvertString("", value.JsonOpt), value.JsonOpt)
 
 
+class XmlProvider+BlahDataSomethingFoo3 : FDR.BaseTypes.XmlElement
+    new : number:int -> XmlProvider+BlahDataSomethingFoo3
+    XmlRuntime.CreateRecord("BlahDataSomethingFoo2", 
+                            [| |], 
+                            [| ("",
+                                (number :> obj)) |], "")
+
+    new : json:XmlProvider+BlahDataSomethingFoo2 -> XmlProvider+BlahDataSomethingFoo3
+    XmlRuntime.CreateRecord("BlahDataSomethingFoo2", 
+                            [| |], 
+                            [| ("",
+                                (json :> obj)) |], "")
+
+    new : xElement:System.Xml.Linq.XElement -> XmlProvider+BlahDataSomethingFoo3
+    XmlElement.Create(xElement)
+
+    member Json: XmlProvider+BlahDataSomethingFoo2 option with get
+    XmlRuntime.TryGetJsonValue(this, "")
+
+    member Number: int option with get
+    TextRuntime.ConvertInteger("", XmlRuntime.TryGetValue(this))
+
+
 class XmlProvider+BlahDataSomethingFoo4 : FDR.BaseTypes.XmlElement
-    new : size:int -> value:XmlProvider+BlahDataSomethingFoo3 -> XmlProvider+BlahDataSomethingFoo4
+    new : size:int -> value:XmlProvider+BlahDataSomethingFoo2 -> XmlProvider+BlahDataSomethingFoo4
     XmlRuntime.CreateRecord("BlahDataSomethingFoo3", 
                             [| ("size",
                                 (size :> obj)) |], 
@@ -145,7 +145,7 @@ class XmlProvider+BlahDataSomethingFoo4 : FDR.BaseTypes.XmlElement
     let value = XmlRuntime.TryGetAttribute(this, "size")
     TextRuntime.GetNonOptionalValue("Attribute size", TextRuntime.ConvertInteger("", value), value)
 
-    member Value: XmlProvider+BlahDataSomethingFoo3 with get
+    member Value: XmlProvider+BlahDataSomethingFoo2 with get
     XmlRuntime.GetJsonValue(this, "")
 
 


### PR DESCRIPTION
The memory consumption of Visual Studio is still high, but not as high as before. Also, design time Visual Studio will respond a lot faster so it's not so painful to develop anymore. (And it will recover from XML file change.)
- Fixed some lock issues: a) changed some dictionaries to threadsafe ConcurrentDictionaries in assemblies that were ok to use Concurrent collections. b) not lock dictionaries itself but rather temp objects
- Added lazy-keywords to some functions that were constantly called multiple times with same parameters.
- Changed some AddMember generation to AddMemberDelayed to add performance on design time.

When I got latest version from master, all the test weren't passing, so this didn't broke those.
Fix for #975 
