### PR TITLE
Fix BuildTests & RunTests on Linux

### DIFF
--- a/tests/FSharp.Data.Tests/CsvProvider.fs
+++ b/tests/FSharp.Data.Tests/CsvProvider.fs
@@ -255,13 +255,13 @@ let ``AssumeMissingValues works when inferRows limit is reached``() =
     errorMessage |> should equal "Couldn't parse row 5 according to schema: Parent ID is missing"
 
     let rowWithMissingParentIdNullable = 
-        CsvProvider<"Data/AdWords.csv", InferRows=4, AssumeMissingValues=true>.GetSample().Rows
+        CsvProvider<const(__SOURCE_DIRECTORY__ + "/Data/Adwords.csv"), InferRows=4, AssumeMissingValues=true>.GetSample().Rows
         |> Seq.skip 4 |> Seq.head
     let parentId : Nullable<int> = rowWithMissingParentIdNullable.``Parent ID``
     parentId |> should equal null
 
     let rowWithMissingParentIdOptional = 
-        CsvProvider<"Data/AdWords.csv", InferRows=4, AssumeMissingValues=true, PreferOptionals=true>.GetSample().Rows
+        CsvProvider<const(__SOURCE_DIRECTORY__ + "/Data/Adwords.csv"), InferRows=4, AssumeMissingValues=true, PreferOptionals=true>.GetSample().Rows
         |> Seq.skip 4 |> Seq.head
     let parentId : Option<int> = rowWithMissingParentIdOptional.``Parent ID``
     parentId |> should equal None

--- a/tests/FSharp.Data.Tests/FSharp.Data.Tests.fsproj
+++ b/tests/FSharp.Data.Tests/FSharp.Data.Tests.fsproj
@@ -219,7 +219,7 @@
     <Content Include="Data/projects.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Content Include="Data/Contacts.json">
+    <Content Include="Data/contacts.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="Data/Dates.json">
@@ -284,7 +284,7 @@
     <None Include="Data\WikiData.json" />
     <None Include="Data\Empty.json" />
     <None Include="Data\projects.json" />
-    <None Include="Data\Contacts.json" />
+    <None Include="Data\contacts.json" />
     <None Include="Data\Dates.json" />
     <None Include="Data\WorldBank.json" />
     <None Include="Data\TwitterStream.json" />

--- a/tests/FSharp.Data.Tests/HtmlCharRefs.fs
+++ b/tests/FSharp.Data.Tests/HtmlCharRefs.fs
@@ -14,7 +14,7 @@ open FSharp.Data.HtmlNode
 open FSharp.Data.JsonExtensions
 
 let charRefsTestCases =
-    JsonValue.Load(__SOURCE_DIRECTORY__ + "/data/charrefs.json")?items.AsArray()
+    JsonValue.Load(__SOURCE_DIRECTORY__ + "/Data/charrefs.json")?items.AsArray()
     |> Array.map (fun x -> [| x?key.AsString(); x?characters.AsString() |])
 
 [<Test>]

--- a/tests/FSharp.Data.Tests/HtmlParser.fs
+++ b/tests/FSharp.Data.Tests/HtmlParser.fs
@@ -365,7 +365,7 @@ let ``Can handle html with doctype and xml namespaces``() =
 [<Test>]
 let ``Can find header when nested in a div``() = 
     let tables = 
-        HtmlDocument.Load "data/wimbledon_wikipedia.html"
+        HtmlDocument.Load "Data/wimbledon_wikipedia.html"
         |> getTables false
         |> List.map (fun t -> t.Name, t)
         |> Map.ofList
@@ -375,7 +375,7 @@ let ``Can find header when nested in a div``() =
 
 [<Test>]
 let ``Can parse tables imdb chart``() = 
-    let imdb = HtmlDocument.Load "data/imdb_chart.htm"
+    let imdb = HtmlDocument.Load "Data/imdb_chart.htm"
     let tables = imdb |> getTables false
     tables.Length |> should equal 2
     tables.[0].Name |> should equal "Top 250"
@@ -384,12 +384,12 @@ let ``Can parse tables imdb chart``() =
 
 [<Test>]
 let ``Can parse tables ebay cars``() = 
-    let ebay = HtmlDocument.Load "data/ebay_cars.htm"
+    let ebay = HtmlDocument.Load "Data/ebay_cars.htm"
     true |> should equal true
 
 [<Test>]
 let ``Does not crash when parsing us presidents``() = 
-    let table = HtmlDocument.Load "data/us_presidents_wikipedia.html" |> getTables false
+    let table = HtmlDocument.Load "Data/us_presidents_wikipedia.html" |> getTables false
     true |> should equal true
 
 [<Test>]
@@ -528,33 +528,33 @@ let ``Can parse code blocks``() =
 
 [<Test>]
 let ``Can parse national rail mobile site correctly``() = 
-    HtmlDocument.Load "data/UKDepartures.html"
+    HtmlDocument.Load "Data/UKDepartures.html"
     |> HtmlDocument.descendantsNamed false [ "li" ]
     |> Seq.length
     |> should equal 68
-    HtmlDocument.Load "data/UKLiveProgress.html"
+    HtmlDocument.Load "Data/UKLiveProgress.html"
     |> HtmlDocument.descendantsNamed false [ "li" ]
     |> Seq.length
     |> should equal 15
-    HtmlDocument.Load "data/UKDepartures.html"
+    HtmlDocument.Load "Data/UKDepartures.html"
     |> HtmlDocument.descendantsNamed false [ "li"; "hr" ]
     |> Seq.length
     |> should equal 69
-    HtmlDocument.Load "data/UKLiveProgress.html"
+    HtmlDocument.Load "Data/UKLiveProgress.html"
     |> HtmlDocument.descendantsNamed false [ "li"; "hr" ]
     |> Seq.length
     |> should equal 17
 
 [<Test>]
 let ``Can parse old zoopla site correctly``() = 
-    HtmlDocument.Load "data/zoopla.html"
+    HtmlDocument.Load "Data/zoopla.html"
     |> HtmlDocument.descendants false (fun x -> HtmlNode.hasName "li" x && HtmlNode.hasAttribute "itemtype" "http://schema.org/Place" x)
     |> Seq.length 
     |> should equal 100
 
 [<Test>]
 let ``Can parse new zoopla site correctly``() = 
-    HtmlDocument.Load "data/zoopla2.html"
+    HtmlDocument.Load "Data/zoopla2.html"
     |> HtmlDocument.descendants false (fun x -> HtmlNode.hasName "li" x && HtmlNode.hasAttribute "itemtype" "http://schema.org/Residence" x)
     |> Seq.length 
     |> should equal 10

--- a/tests/FSharp.Data.Tests/HtmlProvider.fs
+++ b/tests/FSharp.Data.Tests/HtmlProvider.fs
@@ -58,7 +58,7 @@ let ``Can create type for simple table``() =
     let table = SimpleHtml().Tables.Table
     table.Rows.[0].``Column 1`` |> should equal 1
 
-type MarketDepth = HtmlProvider<"data/marketdepth.htm">
+type MarketDepth = HtmlProvider<const(__SOURCE_DIRECTORY__ + "/Data/MarketDepth.htm")>
 
 [<Test>]
 let ``Can infer tables out of the market depth file``() =
@@ -68,7 +68,7 @@ let ``Can infer tables out of the market depth file``() =
 
 [<Test>]
 let ``NuGet table gets all rows``() =
-    let table = HtmlProvider<"data/NuGet.html">.GetSample().Tables.``Version History``
+    let table = HtmlProvider<const(__SOURCE_DIRECTORY__ + "/Data/NuGet.html")>.GetSample().Tables.``Version History``
     table.Rows.Length |> should equal 35
 
 [<Test>]
@@ -310,7 +310,7 @@ let ``Handles closing tag with number in script (Bug 800)``() =
     let data = html.Html.Descendants ["a"] |> Seq.toList
     data.Length |> should equal 4
 
-type DoctorWho = FSharp.Data.HtmlProvider<"data/doctor_who2.html">
+type DoctorWho = FSharp.Data.HtmlProvider<const(__SOURCE_DIRECTORY__ + "/Data/doctor_who2.html")>
 
 [<Test>]   
 let ``List and Table with same nome don't clash``() =

--- a/tests/FSharp.Data.Tests/Http.fs
+++ b/tests/FSharp.Data.Tests/Http.fs
@@ -16,7 +16,7 @@ open FSharp.Data.HttpRequestHeaders
 let ``Don't throw exceptions on http error`` () = 
     let response = Http.Request("http://api.themoviedb.org/3/search/movie", silentHttpErrors = true)
     response.StatusCode |> should equal 401
-    response.Body |> should equal (Text """{"status_message":"Invalid API key: You must be granted a valid key.","status_code":7}""")
+    response.Body |> should equal (Text """{"status_message":"Invalid API key: You must be granted a valid key.","success":false,"status_code":7}""")
 
 [<Test>]
 let ``Throw exceptions on http error`` () = 
@@ -26,7 +26,7 @@ let ``Throw exceptions on http error`` () =
             ""
         with e -> 
             e.Message
-    exn |> should contain """{"status_message":"Invalid API key: You must be granted a valid key.","status_code":7}"""
+    exn |> should contain """{"status_message":"Invalid API key: You must be granted a valid key.","success":false,"status_code":7}"""
 
 [<Test>]
 let ``If the same header is added multiple times, throws an exception`` () =
@@ -77,4 +77,4 @@ let ``Setting timeout in customizeHttpRequest overrides timeout argument`` () =
             customizeHttpRequest = (fun req -> req.Timeout <- Threading.Timeout.Infinite; req), timeout = 1)
     
     response.StatusCode |> should equal 401
-    response.Body |> should equal (Text """{"status_message":"Invalid API key: You must be granted a valid key.","status_code":7}""")
+    response.Body |> should equal (Text """{"status_message":"Invalid API key: You must be granted a valid key.","success":false,"status_code":7}""")


### PR DESCRIPTION
BuildTests and RunTests targets are failing due to path resolving issues and some incorrect-case paths.
