### PR TITLE
Fix for Issue #982: Http.Request fails with "part of the cookie is in…

### DIFF
--- a/src/Net/Http.fs
+++ b/src/Net/Http.fs
@@ -757,13 +757,11 @@ module internal CookieHandling =
             if startsWithIgnoreCase prefix str
             then str.Substring(prefix.Length)
             else str
-
-        [| for cookieStr in cookies do
+        let createCookie (cookieParts:string[]) =
             let cookie = Cookie()
-            cookieStr.Split ';'
-            |> Array.iteri (fun i cookiePart ->
+            cookieParts |> Array.iteri (fun i cookiePart ->
                 let cookiePart = cookiePart.Trim()
-                if i = 0 then
+                if i = 0 && cookiePart.Length > 0 then
                     let kvp = cookiePart.Split '='
                     if kvp.Length > 0 then
                         cookie.Name <- kvp.[0]
@@ -775,7 +773,7 @@ module internal CookieHandling =
                         cookie.Path <- kvp.[1]
                 elif cookiePart |> startsWithIgnoreCase "domain" then
                     let kvp = cookiePart.Split '='
-                    if kvp.Length > 1 then                                
+                    if kvp.Length > 1 then
                         let domain = 
                             kvp.[1] 
                             // remove spurious domain prefixes
@@ -788,14 +786,20 @@ module internal CookieHandling =
                 elif cookiePart |> equalsIgnoreCase "httponly" then
                     cookie.HttpOnly <- true
             )
-
-            if cookie.Domain = "" then
-                cookie.Domain <- responseUri.Host
-
-            let uriString = (if cookie.Secure then "https://" else "http://") + cookie.Domain.TrimStart('.') + cookie.Path
-            match Uri.TryCreate(uriString, UriKind.Absolute) with
-                    | true, uri -> yield uri, cookie
-                    | _ -> ()
+            cookie
+        [| for cookieStr in cookies do
+            let cookie = Cookie()
+            cookieStr.Split ';'
+            let parts = cookieStr.Split([|';'|],StringSplitOptions.RemoveEmptyEntries)
+            if parts.Length > 0 then
+                let cookie = createCookie parts
+                if cookie.Domain = "" then
+                    cookie.Domain <- responseUri.Host
+    
+                let uriString = (if cookie.Secure then "https://" else "http://") + cookie.Domain.TrimStart('.') + cookie.Path
+                match Uri.TryCreate(uriString, UriKind.Absolute) with
+                        | true, uri -> yield uri, cookie
+                        | _ -> ()
         |]
 
 /// Utilities for working with network via HTTP. Includes methods for downloading 


### PR DESCRIPTION
…valid"

The function getAllCookiesFromHeader has been changed so that cookies are not created for empty strings