### PR TITLE
Call Abort() when we "manually" time out a request with StartChild.

### DIFF
--- a/src/Net/Http.fs
+++ b/src/Net/Http.fs
@@ -621,7 +621,8 @@ module private HttpHelpers =
                         try 
                             return! child
                         with
-                        | :? TimeoutException as exc -> 
+                        | :? TimeoutException as exc ->
+                            req.Abort() 
                             raise <| WebException("Timeout exceeded while getting response", exc, WebExceptionStatus.Timeout, null)
                             return Unchecked.defaultof<_>
                     }


### PR DESCRIPTION
When using the time out feature on StartChild to end an Async Http Request we also need to call Abort() on the HttpWebRequest. See [MSDN.](https://msdn.microsoft.com/en-us/library/system.net.httpwebrequest.abort(v=vs.110).aspx)

When StartChild times out and Abort is not called - the next request causes the ServicePoint to allocate a new connection as the timed out connection is still tied up (indefinitely). Eventually you will reach DefaultConnectionLimit and all requests return time outs. This issue is especially noticeable when DefaultConnectionLimit is set to a very low value. A work around is to call CloseConnectionGroup() on the ServicePoint as soon as a StartChild time out is thrown. 

Adding Abort() means a work around is no longer required.