### PR TITLE
Parse time spans

### DIFF
--- a/tests/FSharp.Data.Tests/Data/TimeSpans.json
+++ b/tests/FSharp.Data.Tests/Data/TimeSpans.json
@@ -1,0 +1,5 @@
+﻿{
+  "positiveWithDayWithFraction": "1:3:16:50.5",
+  "positiveWithoutDayWithoutFraction": "00:30:00",
+  "negativeWithDayWithFraction": "-1:3:16:50.5"
+}

--- a/tests/FSharp.Data.Tests/FSharp.Data.Tests.fsproj
+++ b/tests/FSharp.Data.Tests/FSharp.Data.Tests.fsproj
@@ -302,6 +302,7 @@
     <None Include="Data\SimpleHtmlLists.html">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="Data\TimeSpans.json" />
     <Content Include="Data/TypeInference.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/tests/FSharp.Data.Tests/JsonProvider.fs
+++ b/tests/FSharp.Data.Tests/JsonProvider.fs
@@ -493,6 +493,21 @@ let ``Can parse ISO 8601 dates in the specified culture``() =
     let dates = JsonProvider<"""{"birthdate": "01/02/2000"}""", Culture="pt-PT">.GetSample()
     dates.Birthdate.Month |> should equal 2
 
+type TimeSpanJSON = JsonProvider<"Data/TimeSpans.json">
+
+[<Test>]
+let ``Can parse time spans``() =
+    let timeSpans = TimeSpanJSON.GetSample()
+    timeSpans.PositiveWithDayWithFraction |> should equal (new TimeSpan(1, 3, 16, 50, 500))
+    timeSpans.PositiveWithoutDayWithoutFraction |> should equal (new TimeSpan(0, 30, 0))
+    timeSpans.NegativeWithDayWithFraction |> should equal (new TimeSpan(-1, 3, 16, 50, 500))
+
+[<Test>]
+[<SetCulture("fr")>]
+let ``Can parse time span in different culture``() =
+    let timeSpans = JsonProvider<"""{"frTimeSpan": "1:3:16:50,5"}""">.GetSample()
+    timeSpans.FrTimeSpan |> should equal (new TimeSpan(1, 3, 16, 50, 500))
+
 [<Test>]
 let ``Parsing of values wrapped in quotes should work on heterogenous values``() =
     let objs = JsonProvider<"""[{"a": "01/02/2000"}, {"a" : "3"}]""">.GetSamples()


### PR DESCRIPTION
This PR adds `TimeSpan` as primitive type.  
Basically everywhere `DateTime` is used I added similar logic for `TimeSpan`.
When writing tests I wasn't as ambitious as you (`DateTime` is really used a lot in different tests) and just created tests in `JsonValue` and `JsonProvider`. Some test cases in `InferenceTests.fs` might make sense. what do you say?
