### PR TITLE
Fix for issue #989: Dr. Who in Trouble

### DIFF
--- a/tests/FSharp.Data.DesignTime.Tests/expected/Html,doctor_who2.html,False,False,.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Html,doctor_who2.html,False,False,.expected
@@ -614,19 +614,25 @@ class HtmlProvider+TablesContainer : FDR.BaseTypes.HtmlDocument
     member Table26: HtmlProvider+Table26 with get
     let rowConverter = new Func<_,_>(fun (row:string[]) -> 
                                         let value = TextConversions.AsString(row.[0])
-                                        TextRuntime.GetNonOptionalValue("Awards for Doctor Who", TextRuntime.ConvertString(value), value))
+                                        TextRuntime.GetNonOptionalValue("Awards for Doctor Who", TextRuntime.ConvertString(value), value),
+                                        let value = TextConversions.AsString(row.[1])
+                                        TextRuntime.GetNonOptionalValue("Awards for Doctor Who 2", TextRuntime.ConvertString(value), value))
     HtmlTable<_>.Create(rowConverter, this, "Table26", true)
 
     member Table28: HtmlProvider+Table28 with get
     let rowConverter = new Func<_,_>(fun (row:string[]) -> 
                                         let value = TextConversions.AsString(row.[0])
-                                        TextRuntime.GetNonOptionalValue("BAFTA TV Award for Best Drama Series", TextRuntime.ConvertString(value), value))
+                                        TextRuntime.GetNonOptionalValue("BAFTA TV Award for Best Drama Series", TextRuntime.ConvertString(value), value),
+                                        let value = TextConversions.AsString(row.[1])
+                                        TextRuntime.GetNonOptionalValue("BAFTA TV Award for Best Drama Series 2", TextRuntime.ConvertString(value), value))
     HtmlTable<_>.Create(rowConverter, this, "Table28", true)
 
     member Table30: HtmlProvider+Table30 with get
     let rowConverter = new Func<_,_>(fun (row:string[]) -> 
                                         let value = TextConversions.AsString(row.[0])
-                                        TextRuntime.GetNonOptionalValue("Hugo Award for Best Dramatic Presentation, Short Form", TextRuntime.ConvertString(value), value))
+                                        TextRuntime.GetNonOptionalValue("Hugo Award for Best Dramatic Presentation, Short Form", TextRuntime.ConvertString(value), value),
+                                        let value = TextConversions.AsString(row.[1])
+                                        TextRuntime.GetNonOptionalValue("Hugo Award for Best Dramatic Presentation, Short Form 2", TextRuntime.ConvertString(value), value))
     HtmlTable<_>.Create(rowConverter, this, "Table30", true)
 
     member Table32: HtmlProvider+Table32 with get
@@ -640,7 +646,9 @@ class HtmlProvider+TablesContainer : FDR.BaseTypes.HtmlDocument
     member Table34: HtmlProvider+Table34 with get
     let rowConverter = new Func<_,_>(fun (row:string[]) -> 
                                         let value = TextConversions.AsString(row.[0])
-                                        TextRuntime.GetNonOptionalValue("Saturn Award for Best Television Presentation", TextRuntime.ConvertString(value), value))
+                                        TextRuntime.GetNonOptionalValue("Saturn Award for Best Television Presentation", TextRuntime.ConvertString(value), value),
+                                        let value = TextConversions.AsString(row.[1])
+                                        TextRuntime.GetNonOptionalValue("Saturn Award for Best Television Presentation 2", TextRuntime.ConvertString(value), value))
     HtmlTable<_>.Create(rowConverter, this, "Table34", true)
 
     member ``Theme music``: HtmlProvider+ThemeMusic with get
@@ -973,19 +981,28 @@ class HtmlProvider+Table24+Row : string * string
     (let _,t2 = this in t2)
 
 
-class HtmlProvider+Table26+Row : string
+class HtmlProvider+Table26+Row : string * string
     member ``Awards for Doctor Who``: string with get
-    this
+    (let t1,_ = this in t1)
+
+    member ``Awards for Doctor Who 2``: string with get
+    (let _,t2 = this in t2)
 
 
-class HtmlProvider+Table28+Row : string
+class HtmlProvider+Table28+Row : string * string
     member ``BAFTA TV Award for Best Drama Series``: string with get
-    this
+    (let t1,_ = this in t1)
+
+    member ``BAFTA TV Award for Best Drama Series 2``: string with get
+    (let _,t2 = this in t2)
 
 
-class HtmlProvider+Table30+Row : string
+class HtmlProvider+Table30+Row : string * string
     member ``Hugo Award for Best Dramatic Presentation, Short Form``: string with get
-    this
+    (let t1,_ = this in t1)
+
+    member ``Hugo Award for Best Dramatic Presentation, Short Form 2``: string with get
+    (let _,t2 = this in t2)
 
 
 class HtmlProvider+Table32+Row : string * string
@@ -996,9 +1013,12 @@ class HtmlProvider+Table32+Row : string * string
     (let _,t2 = this in t2)
 
 
-class HtmlProvider+Table34+Row : string
+class HtmlProvider+Table34+Row : string * string
     member ``Saturn Award for Best Television Presentation``: string with get
-    this
+    (let t1,_ = this in t1)
+
+    member ``Saturn Award for Best Television Presentation 2``: string with get
+    (let _,t2 = this in t2)
 
 
 class HtmlProvider+ThemeMusic+Row : string * string

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Html,us_presidents_wikipedia.html,False,False,.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Html,us_presidents_wikipedia.html,False,False,.expected
@@ -284,7 +284,9 @@ class HtmlProvider+TablesContainer : FDR.BaseTypes.HtmlDocument
                                         let value = TextConversions.AsString(row.[0])
                                         TextRuntime.GetNonOptionalValue("Presidents of the United States", TextRuntime.ConvertString(value), value),
                                         let value = TextConversions.AsString(row.[1])
-                                        TextRuntime.GetNonOptionalValue("Presidents of the United States 2", TextRuntime.ConvertString(value), value))
+                                        TextRuntime.GetNonOptionalValue("Presidents of the United States 2", TextRuntime.ConvertString(value), value),
+                                        let value = TextConversions.AsString(row.[2])
+                                        TextRuntime.GetNonOptionalValue("Presidents of the United States 3", TextRuntime.ConvertString(value), value))
     HtmlTable<_>.Create(rowConverter, this, "Table10", true)
 
     member Table12: HtmlProvider+Table12 with get
@@ -298,7 +300,9 @@ class HtmlProvider+TablesContainer : FDR.BaseTypes.HtmlDocument
     member Table6: HtmlProvider+Table6 with get
     let rowConverter = new Func<_,_>(fun (row:string[]) -> 
                                         let value = TextConversions.AsString(row.[0])
-                                        TextRuntime.GetNonOptionalValue("Topics related to List of Presidents of the United States", TextRuntime.ConvertString(value), value))
+                                        TextRuntime.GetNonOptionalValue("Topics related to List of Presidents of the United States", TextRuntime.ConvertString(value), value),
+                                        let value = TextConversions.AsString(row.[1])
+                                        TextRuntime.GetNonOptionalValue("Topics related to List of Presidents of the United States 2", TextRuntime.ConvertString(value), value))
     HtmlTable<_>.Create(rowConverter, this, "Table6", true)
 
     member Table8: HtmlProvider+Table8 with get
@@ -435,12 +439,15 @@ class HtmlProvider+LivingFormerPresidents+Row : string * string * string
     (let _,t2,_ = this in t2)
 
 
-class HtmlProvider+Table10+Row : string * string
+class HtmlProvider+Table10+Row : string * string * string
     member ``Presidents of the United States``: string with get
-    (let t1,_ = this in t1)
+    (let t1,_,_ = this in t1)
 
     member ``Presidents of the United States 2``: string with get
-    (let _,t2 = this in t2)
+    (let _,t2,_ = this in t2)
+
+    member ``Presidents of the United States 3``: string with get
+    (let _,_,t3 = this in t3)
 
 
 class HtmlProvider+Table12+Row : string * string
@@ -451,9 +458,12 @@ class HtmlProvider+Table12+Row : string * string
     (let _,t2 = this in t2)
 
 
-class HtmlProvider+Table6+Row : string
+class HtmlProvider+Table6+Row : string * string
     member ``Topics related to List of Presidents of the United States``: string with get
-    this
+    (let t1,_ = this in t1)
+
+    member ``Topics related to List of Presidents of the United States 2``: string with get
+    (let _,t2 = this in t2)
 
 
 class HtmlProvider+Table8+Row : string * string

--- a/tests/FSharp.Data.DesignTime.Tests/expected/Html,wimbledon_wikipedia.html,False,False,.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/Html,wimbledon_wikipedia.html,False,False,.expected
@@ -420,19 +420,25 @@ class HtmlProvider+TablesContainer : FDR.BaseTypes.HtmlDocument
     member Table10: HtmlProvider+Table10 with get
     let rowConverter = new Func<_,_>(fun (row:string[]) -> 
                                         let value = TextConversions.AsString(row.[0])
-                                        TextRuntime.GetNonOptionalValue("Wimbledon (Amateur Era)", TextRuntime.ConvertString(value), value))
+                                        TextRuntime.GetNonOptionalValue("Wimbledon (Amateur Era)", TextRuntime.ConvertString(value), value),
+                                        let value = TextConversions.AsString(row.[1])
+                                        TextRuntime.GetNonOptionalValue("Wimbledon (Amateur Era) 2", TextRuntime.ConvertString(value), value))
     HtmlTable<_>.Create(rowConverter, this, "Table10", true)
 
     member Table22: HtmlProvider+Table22 with get
     let rowConverter = new Func<_,_>(fun (row:string[]) -> 
                                         let value = TextConversions.AsString(row.[0])
-                                        TextRuntime.GetNonOptionalValue("Wimbledon (Open Era)", TextRuntime.ConvertString(value), value))
+                                        TextRuntime.GetNonOptionalValue("Wimbledon (Open Era)", TextRuntime.ConvertString(value), value),
+                                        let value = TextConversions.AsString(row.[1])
+                                        TextRuntime.GetNonOptionalValue("Wimbledon (Open Era) 2", TextRuntime.ConvertString(value), value))
     HtmlTable<_>.Create(rowConverter, this, "Table22", true)
 
     member Table30: HtmlProvider+Table30 with get
     let rowConverter = new Func<_,_>(fun (row:string[]) -> 
                                         let value = TextConversions.AsString(row.[0])
-                                        TextRuntime.GetNonOptionalValue("Wimbledon drawsheets", TextRuntime.ConvertString(value), value))
+                                        TextRuntime.GetNonOptionalValue("Wimbledon drawsheets", TextRuntime.ConvertString(value), value),
+                                        let value = TextConversions.AsString(row.[1])
+                                        TextRuntime.GetNonOptionalValue("Wimbledon drawsheets 2", TextRuntime.ConvertString(value), value))
     HtmlTable<_>.Create(rowConverter, this, "Table30", true)
 
     member Table31: HtmlProvider+Table31 with get
@@ -474,7 +480,9 @@ class HtmlProvider+TablesContainer : FDR.BaseTypes.HtmlDocument
     member Table34: HtmlProvider+Table34 with get
     let rowConverter = new Func<_,_>(fun (row:string[]) -> 
                                         let value = TextConversions.AsString(row.[0])
-                                        TextRuntime.GetNonOptionalValue("Grand Slam tournaments (Majors)", TextRuntime.ConvertString(value), value))
+                                        TextRuntime.GetNonOptionalValue("Grand Slam tournaments (Majors)", TextRuntime.ConvertString(value), value),
+                                        let value = TextConversions.AsString(row.[1])
+                                        TextRuntime.GetNonOptionalValue("Grand Slam tournaments (Majors) 2", TextRuntime.ConvertString(value), value))
     HtmlTable<_>.Create(rowConverter, this, "Table34", true)
 
     member Table36: HtmlProvider+Table36 with get
@@ -490,31 +498,41 @@ class HtmlProvider+TablesContainer : FDR.BaseTypes.HtmlDocument
     member Table38: HtmlProvider+Table38 with get
     let rowConverter = new Func<_,_>(fun (row:string[]) -> 
                                         let value = TextConversions.AsString(row.[0])
-                                        TextRuntime.GetNonOptionalValue("Grand Slam tournament champions", TextRuntime.ConvertString(value), value))
+                                        TextRuntime.GetNonOptionalValue("Grand Slam tournament champions", TextRuntime.ConvertString(value), value),
+                                        let value = TextConversions.AsString(row.[1])
+                                        TextRuntime.GetNonOptionalValue("Grand Slam tournament champions 2", TextRuntime.ConvertString(value), value))
     HtmlTable<_>.Create(rowConverter, this, "Table38", true)
 
     member Table39: HtmlProvider+Table39 with get
     let rowConverter = new Func<_,_>(fun (row:string[]) -> 
                                         let value = TextConversions.AsString(row.[0])
-                                        TextRuntime.GetNonOptionalValue("Australasian and Australian Championships / Australian Open", TextRuntime.ConvertString(value), value))
+                                        TextRuntime.GetNonOptionalValue("Australasian and Australian Championships / Australian Open", TextRuntime.ConvertString(value), value),
+                                        let value = TextConversions.AsString(row.[1])
+                                        TextRuntime.GetNonOptionalValue("Australasian and Australian Championships / Australian Open 2", TextRuntime.ConvertString(value), value))
     HtmlTable<_>.Create(rowConverter, this, "Table39", true)
 
     member Table40: HtmlProvider+Table40 with get
     let rowConverter = new Func<_,_>(fun (row:string[]) -> 
                                         let value = TextConversions.AsString(row.[0])
-                                        TextRuntime.GetNonOptionalValue("French Championships / French Open", TextRuntime.ConvertString(value), value))
+                                        TextRuntime.GetNonOptionalValue("French Championships / French Open", TextRuntime.ConvertString(value), value),
+                                        let value = TextConversions.AsString(row.[1])
+                                        TextRuntime.GetNonOptionalValue("French Championships / French Open 2", TextRuntime.ConvertString(value), value))
     HtmlTable<_>.Create(rowConverter, this, "Table40", true)
 
     member Table41: HtmlProvider+Table41 with get
     let rowConverter = new Func<_,_>(fun (row:string[]) -> 
                                         let value = TextConversions.AsString(row.[0])
-                                        TextRuntime.GetNonOptionalValue("The Championships, Wimbledon", TextRuntime.ConvertString(value), value))
+                                        TextRuntime.GetNonOptionalValue("The Championships, Wimbledon", TextRuntime.ConvertString(value), value),
+                                        let value = TextConversions.AsString(row.[1])
+                                        TextRuntime.GetNonOptionalValue("The Championships, Wimbledon 2", TextRuntime.ConvertString(value), value))
     HtmlTable<_>.Create(rowConverter, this, "Table41", true)
 
     member Table42: HtmlProvider+Table42 with get
     let rowConverter = new Func<_,_>(fun (row:string[]) -> 
                                         let value = TextConversions.AsString(row.[0])
-                                        TextRuntime.GetNonOptionalValue("U.S. National Championships / US Open", TextRuntime.ConvertString(value), value))
+                                        TextRuntime.GetNonOptionalValue("U.S. National Championships / US Open", TextRuntime.ConvertString(value), value),
+                                        let value = TextConversions.AsString(row.[1])
+                                        TextRuntime.GetNonOptionalValue("U.S. National Championships / US Open 2", TextRuntime.ConvertString(value), value))
     HtmlTable<_>.Create(rowConverter, this, "Table42", true)
 
     member Table44: HtmlProvider+Table44 with get
@@ -742,19 +760,28 @@ class HtmlProvider+Table1+Row : string * string
     (let _,t2 = this in t2)
 
 
-class HtmlProvider+Table10+Row : string
+class HtmlProvider+Table10+Row : string * string
     member ``Wimbledon (Amateur Era)``: string with get
-    this
+    (let t1,_ = this in t1)
+
+    member ``Wimbledon (Amateur Era) 2``: string with get
+    (let _,t2 = this in t2)
 
 
-class HtmlProvider+Table22+Row : string
+class HtmlProvider+Table22+Row : string * string
     member ``Wimbledon (Open Era)``: string with get
-    this
+    (let t1,_ = this in t1)
+
+    member ``Wimbledon (Open Era) 2``: string with get
+    (let _,t2 = this in t2)
 
 
-class HtmlProvider+Table30+Row : string
+class HtmlProvider+Table30+Row : string * string
     member ``Wimbledon drawsheets``: string with get
-    this
+    (let t1,_ = this in t1)
+
+    member ``Wimbledon drawsheets 2``: string with get
+    (let _,t2 = this in t2)
 
 
 class HtmlProvider+Table31+Row : int * int * int * int * System.Nullable<int> * System.Nullable<int> * System.Nullable<int> * System.Nullable<int> * System.Nullable<int> * System.Nullable<int>
@@ -821,9 +848,12 @@ class HtmlProvider+Table32+Row : int * int * int * int * System.Nullable<int> * 
     (let _,_,_,_,_,_,_,t8,_,_ = this in t8)
 
 
-class HtmlProvider+Table34+Row : string
+class HtmlProvider+Table34+Row : string * string
     member ``Grand Slam tournaments (Majors)``: string with get
-    this
+    (let t1,_ = this in t1)
+
+    member ``Grand Slam tournaments (Majors) 2``: string with get
+    (let _,t2 = this in t2)
 
 
 class HtmlProvider+Table36+Row : string * string * string
@@ -837,29 +867,44 @@ class HtmlProvider+Table36+Row : string * string * string
     (let _,_,t3 = this in t3)
 
 
-class HtmlProvider+Table38+Row : string
+class HtmlProvider+Table38+Row : string * string
     member ``Grand Slam tournament champions``: string with get
-    this
+    (let t1,_ = this in t1)
+
+    member ``Grand Slam tournament champions 2``: string with get
+    (let _,t2 = this in t2)
 
 
-class HtmlProvider+Table39+Row : string
+class HtmlProvider+Table39+Row : string * string
     member ``Australasian and Australian Championships / Australian Open``: string with get
-    this
+    (let t1,_ = this in t1)
+
+    member ``Australasian and Australian Championships / Australian Open 2``: string with get
+    (let _,t2 = this in t2)
 
 
-class HtmlProvider+Table40+Row : string
+class HtmlProvider+Table40+Row : string * string
     member ``French Championships / French Open``: string with get
-    this
+    (let t1,_ = this in t1)
+
+    member ``French Championships / French Open 2``: string with get
+    (let _,t2 = this in t2)
 
 
-class HtmlProvider+Table41+Row : string
+class HtmlProvider+Table41+Row : string * string
     member ``The Championships, Wimbledon``: string with get
-    this
+    (let t1,_ = this in t1)
+
+    member ``The Championships, Wimbledon 2``: string with get
+    (let _,t2 = this in t2)
 
 
-class HtmlProvider+Table42+Row : string
+class HtmlProvider+Table42+Row : string * string
     member ``U.S. National Championships / US Open``: string with get
-    this
+    (let t1,_ = this in t1)
+
+    member ``U.S. National Championships / US Open 2``: string with get
+    (let _,t2 = this in t2)
 
 
 class HtmlProvider+Table44+Row : string * string

--- a/tests/FSharp.Data.DesignTime.Tests/expected/WorldBank,World Development Indicators;Global Financial Development,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/WorldBank,World Development Indicators;Global Financial Development,True.expected
@@ -1343,6 +1343,12 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Adult literacy rate, population 15+ years, both sexes (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SE.ADT.LITR.ZS")
 
+    member ``Adults (ages 15+) and children (ages 0-14) newly infected with HIV``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SH.HIV.INCD.TL")
+
+    member ``Adults (ages 15+) newly infected with HIV``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SH.HIV.INCD")
+
     member ``Age dependency ratio (% of working-age population)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SP.POP.DPND")
 
@@ -1877,6 +1883,9 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Children (0-14) living with HIV``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SH.HIV.0014")
 
+    member ``Children (ages 0-14) newly infected with HIV``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SH.HIV.INCD.14")
+
     member ``Children in employment, female (% of female children ages 7-14)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SL.TLF.0714.FE.ZS")
 
@@ -2287,6 +2296,78 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
 
     member ``Ease of doing business index (1=most business-friendly regulations)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("IC.BUS.EASE.XQ")
+
+    member ``Educational attainment, at least competed lower secondary, population 25+, female (%) (cumulative)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SE.SEC.CUAT.LO.FE.ZS")
+
+    member ``Educational attainment, at least competed lower secondary, population 25+, male (%) (cumulative)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SE.SEC.CUAT.LO.MA.ZS")
+
+    member ``Educational attainment, at least competed lower secondary, population 25+, total (%) (cumulative)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SE.SEC.CUAT.LO.ZS")
+
+    member ``Educational attainment, at least competed post-secondary, population 25+, female (%) (cumulative)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SE.SEC.CUAT.PO.FE.ZS")
+
+    member ``Educational attainment, at least competed post-secondary, population 25+, male (%) (cumulative)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SE.SEC.CUAT.PO.MA.ZS")
+
+    member ``Educational attainment, at least competed post-secondary, population 25+, total (%) (cumulative)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SE.SEC.CUAT.PO.ZS")
+
+    member ``Educational attainment, at least competed upper secondary, population 25+, female (%) (cumulative)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SE.SEC.CUAT.UP.FE.ZS")
+
+    member ``Educational attainment, at least competed upper secondary, population 25+, male (%) (cumulative)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SE.SEC.CUAT.UP.MA.ZS")
+
+    member ``Educational attainment, at least competed upper secondary, population 25+, total (%) (cumulative)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SE.SEC.CUAT.UP.ZS")
+
+    member ``Educational attainment, at least completed primary, population 25+ years, female (%) (cumulative)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SE.PRM.CUAT.FE.ZS")
+
+    member ``Educational attainment, at least completed primary, population 25+ years, male (%) (cumulative)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SE.PRM.CUAT.MA.ZS")
+
+    member ``Educational attainment, at least completed primary, population 25+ years, total (%) (cumulative)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SE.PRM.CUAT.ZS")
+
+    member ``Educational attainment, competed Doctoral or equivalent, population 25+, female (%) (cumulative)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SE.TER.CUAT.DO.FE.ZS")
+
+    member ``Educational attainment, competed Doctoral or equivalent, population 25+, male (%) (cumulative)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SE.TER.CUAT.DO.MA.ZS")
+
+    member ``Educational attainment, competed Doctoral or equivalent, population 25+, total (%) (cumulative)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SE.TER.CUAT.DO.ZS")
+
+    member ``Educational attainment, competed at least Bachelor's or equivalent, population 25+, female (%) (cumulative)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SE.TER.CUAT.BA.FE.ZS")
+
+    member ``Educational attainment, competed at least Bachelor's or equivalent, population 25+, male (%) (cumulative)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SE.TER.CUAT.BA.MA.ZS")
+
+    member ``Educational attainment, competed at least Bachelor's or equivalent, population 25+, total (%) (cumulative)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SE.TER.CUAT.BA.ZS")
+
+    member ``Educational attainment, competed at least Master's or equivalent, population 25+, female (%) (cumulative)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SE.TER.CUAT.MS.FE.ZS")
+
+    member ``Educational attainment, competed at least Master's or equivalent, population 25+, male (%) (cumulative)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SE.TER.CUAT.MS.MA.ZS")
+
+    member ``Educational attainment, competed at least Master's or equivalent, population 25+, total (%) (cumulative)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SE.TER.CUAT.MS.ZS")
+
+    member ``Educational attainment, competed at least short-cycle tertiary, population 25+, female (%) (cumulative)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SE.TER.CUAT.ST.FE.ZS")
+
+    member ``Educational attainment, competed at least short-cycle tertiary, population 25+, male (%) (cumulative)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SE.TER.CUAT.ST.MA.ZS")
+
+    member ``Educational attainment, competed at least short-cycle tertiary, population 25+, total (%) (cumulative)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SE.TER.CUAT.ST.ZS")
 
     member ``Effective transition rate from primary to lower secondary general education, both sexes (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SE.SEC.PROG.ZS")
@@ -3116,6 +3197,9 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Immunization, DPT (% of children ages 12-23 months)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SH.IMM.IDPT")
 
+    member ``Immunization, HepB3 (% of one-year-old children)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SH.IMM.HEPB")
+
     member ``Immunization, measles (% of children ages 12-23 months)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SH.IMM.MEAS")
 
@@ -3166,6 +3250,9 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
 
     member ``Improved water source, urban (% of urban population with access)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SH.H2O.SAFE.UR.ZS")
+
+    member ``Incidence of HIV (% of uninfected population ages 15-49)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SH.HIV.INCD.ZS")
 
     member ``Incidence of tuberculosis (per 100,000 people)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SH.TBS.INCD")
@@ -4895,6 +4982,9 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Proportion of seats held by women in national parliaments (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SG.GEN.PARL.ZS")
 
+    member ``Proportion of women subjected to physical and/or sexual violence in the last 12 months ( % of women age 15-49)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SG.VAW.1549.ZS")
+
     member ``Provisions to nonperforming loans (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("GFDD.SI.07")
 
@@ -5678,6 +5768,9 @@ class WorldBankDataProvider+ServiceTypes+Indicators : FDR.WorldBank.Indicators
     member ``Wholesale price index (2010 = 100)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("FP.WPI.TOTL")
 
+    member ``Women participating in the three decisions (own health care, major household purchases, and visiting family) (% of women age 15-49)``: FDR.WorldBank.Indicator async with get
+    (this :> IIndicators).AsyncGetIndicator("SG.DMK.ALLD.FN.ZS")
+
     member ``Women who believe a husband is justified in beating his wife (any of five reasons) (%)``: FDR.WorldBank.Indicator async with get
     (this :> IIndicators).AsyncGetIndicator("SG.VAW.REAS.ZS")
 
@@ -5892,6 +5985,12 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
 
     member ``Adult literacy rate, population 15+ years, both sexes (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SE.ADT.LITR.ZS")
+
+    member ``Adults (ages 15+) and children (ages 0-14) newly infected with HIV``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SH.HIV.INCD.TL")
+
+    member ``Adults (ages 15+) newly infected with HIV``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SH.HIV.INCD")
 
     member ``Age dependency ratio (% of working-age population)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SP.POP.DPND")
@@ -6427,6 +6526,9 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Children (0-14) living with HIV``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SH.HIV.0014")
 
+    member ``Children (ages 0-14) newly infected with HIV``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SH.HIV.INCD.14")
+
     member ``Children in employment, female (% of female children ages 7-14)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SL.TLF.0714.FE.ZS")
 
@@ -6837,6 +6939,78 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
 
     member ``Ease of doing business index (1=most business-friendly regulations)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("IC.BUS.EASE.XQ")
+
+    member ``Educational attainment, at least competed lower secondary, population 25+, female (%) (cumulative)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SE.SEC.CUAT.LO.FE.ZS")
+
+    member ``Educational attainment, at least competed lower secondary, population 25+, male (%) (cumulative)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SE.SEC.CUAT.LO.MA.ZS")
+
+    member ``Educational attainment, at least competed lower secondary, population 25+, total (%) (cumulative)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SE.SEC.CUAT.LO.ZS")
+
+    member ``Educational attainment, at least competed post-secondary, population 25+, female (%) (cumulative)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SE.SEC.CUAT.PO.FE.ZS")
+
+    member ``Educational attainment, at least competed post-secondary, population 25+, male (%) (cumulative)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SE.SEC.CUAT.PO.MA.ZS")
+
+    member ``Educational attainment, at least competed post-secondary, population 25+, total (%) (cumulative)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SE.SEC.CUAT.PO.ZS")
+
+    member ``Educational attainment, at least competed upper secondary, population 25+, female (%) (cumulative)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SE.SEC.CUAT.UP.FE.ZS")
+
+    member ``Educational attainment, at least competed upper secondary, population 25+, male (%) (cumulative)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SE.SEC.CUAT.UP.MA.ZS")
+
+    member ``Educational attainment, at least competed upper secondary, population 25+, total (%) (cumulative)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SE.SEC.CUAT.UP.ZS")
+
+    member ``Educational attainment, at least completed primary, population 25+ years, female (%) (cumulative)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SE.PRM.CUAT.FE.ZS")
+
+    member ``Educational attainment, at least completed primary, population 25+ years, male (%) (cumulative)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SE.PRM.CUAT.MA.ZS")
+
+    member ``Educational attainment, at least completed primary, population 25+ years, total (%) (cumulative)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SE.PRM.CUAT.ZS")
+
+    member ``Educational attainment, competed Doctoral or equivalent, population 25+, female (%) (cumulative)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SE.TER.CUAT.DO.FE.ZS")
+
+    member ``Educational attainment, competed Doctoral or equivalent, population 25+, male (%) (cumulative)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SE.TER.CUAT.DO.MA.ZS")
+
+    member ``Educational attainment, competed Doctoral or equivalent, population 25+, total (%) (cumulative)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SE.TER.CUAT.DO.ZS")
+
+    member ``Educational attainment, competed at least Bachelor's or equivalent, population 25+, female (%) (cumulative)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SE.TER.CUAT.BA.FE.ZS")
+
+    member ``Educational attainment, competed at least Bachelor's or equivalent, population 25+, male (%) (cumulative)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SE.TER.CUAT.BA.MA.ZS")
+
+    member ``Educational attainment, competed at least Bachelor's or equivalent, population 25+, total (%) (cumulative)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SE.TER.CUAT.BA.ZS")
+
+    member ``Educational attainment, competed at least Master's or equivalent, population 25+, female (%) (cumulative)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SE.TER.CUAT.MS.FE.ZS")
+
+    member ``Educational attainment, competed at least Master's or equivalent, population 25+, male (%) (cumulative)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SE.TER.CUAT.MS.MA.ZS")
+
+    member ``Educational attainment, competed at least Master's or equivalent, population 25+, total (%) (cumulative)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SE.TER.CUAT.MS.ZS")
+
+    member ``Educational attainment, competed at least short-cycle tertiary, population 25+, female (%) (cumulative)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SE.TER.CUAT.ST.FE.ZS")
+
+    member ``Educational attainment, competed at least short-cycle tertiary, population 25+, male (%) (cumulative)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SE.TER.CUAT.ST.MA.ZS")
+
+    member ``Educational attainment, competed at least short-cycle tertiary, population 25+, total (%) (cumulative)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SE.TER.CUAT.ST.ZS")
 
     member ``Effective transition rate from primary to lower secondary general education, both sexes (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SE.SEC.PROG.ZS")
@@ -7666,6 +7840,9 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Immunization, DPT (% of children ages 12-23 months)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SH.IMM.IDPT")
 
+    member ``Immunization, HepB3 (% of one-year-old children)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SH.IMM.HEPB")
+
     member ``Immunization, measles (% of children ages 12-23 months)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SH.IMM.MEAS")
 
@@ -7716,6 +7893,9 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
 
     member ``Improved water source, urban (% of urban population with access)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SH.H2O.SAFE.UR.ZS")
+
+    member ``Incidence of HIV (% of uninfected population ages 15-49)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SH.HIV.INCD.ZS")
 
     member ``Incidence of tuberculosis (per 100,000 people)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SH.TBS.INCD")
@@ -9445,6 +9625,9 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
     member ``Proportion of seats held by women in national parliaments (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SG.GEN.PARL.ZS")
 
+    member ``Proportion of women subjected to physical and/or sexual violence in the last 12 months ( % of women age 15-49)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SG.VAW.1549.ZS")
+
     member ``Provisions to nonperforming loans (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("GFDD.SI.07")
 
@@ -10227,6 +10410,9 @@ class WorldBankDataProvider+ServiceTypes+IndicatorsDescriptions : FDR.WorldBank.
 
     member ``Wholesale price index (2010 = 100)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("FP.WPI.TOTL")
+
+    member ``Women participating in the three decisions (own health care, major household purchases, and visiting family) (% of women age 15-49)``: FDR.WorldBank.IndicatorDescription with get
+    (this :> IIndicatorsDescriptions).GetIndicator("SG.DMK.ALLD.FN.ZS")
 
     member ``Women who believe a husband is justified in beating his wife (any of five reasons) (%)``: FDR.WorldBank.IndicatorDescription with get
     (this :> IIndicatorsDescriptions).GetIndicator("SG.VAW.REAS.ZS")

--- a/tests/FSharp.Data.Tests/HtmlProvider.fs
+++ b/tests/FSharp.Data.Tests/HtmlProvider.fs
@@ -317,3 +317,30 @@ let ``List and Table with same nome don't clash``() =
     DoctorWho().Lists.``Reference websites``.Values.[0] |> should equal "Doctor Who on TARDIS Data Core, an external wiki"
     DoctorWho().Tables.``Reference websites``.Rows.[0].Awards |> should equal "Preceded by The Bill"
 
+[<Test>]
+let ``Count columns correctly in the presence of colspans (Bug 989)``() =
+    let html = HtmlProvider<"""
+            <html>
+                <head>
+                    <title>Title</title>
+                </head>
+                <body>
+                   <table>
+                            <tbody>
+                                <tr>
+                                    <th scope="col" colspan="2">Double</th>
+                                    <th scope="col" colspan="1">Single</th>
+                                </tr>
+                                <tr>
+                                    <td>Single</th>
+                                    <td colspan="2">Double</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </body>
+                </body>
+            </html>""">.GetSample()
+    let table = html.Tables.Table1
+    match table.Headers with
+    | None -> failwith "No headers found"
+    | Some headers -> headers |> should equal [| "Double"; "Double"; "Single" |]


### PR DESCRIPTION
Issue #989 is about the fact that the `Documentation generated correctly ("library/HtmlProvider.fsx")` test fails, because the `Viewers (millions) - Finale` column is missing. It is missing because the column count of the `Series overview` table  on https://en.wikipedia.org/wiki/List_of_Doctor_Who_serials is off by one. If you look at this table closely, you will notice that all the cells in the "Episodes" column have a colspan of 2, for no obvious reason. This causes the column count too be low by 1.

So the fix is to account for the colspans when determining the number of columns in a table.
