### PR TITLE
Fix test failure when machine time is not set to UTC

### DIFF
--- a/src/Net/Http.fs
+++ b/src/Net/Http.fs
@@ -561,9 +561,9 @@ module private HttpHelpers =
 #endif       
             | "if-match" -> req.Headers.[HeaderEnum.IfMatch] <- value
 #if FX_NO_WEBREQUEST_IFMODIFIEDSINCE
-            | "if-modified-since" -> if not (req?IfModifiedSince <- DateTime.ParseExact(value, "R", CultureInfo.InvariantCulture)) then req.Headers.[HeaderEnum.IfModifiedSince] <- value
+            | "if-modified-since" -> if not (req?IfModifiedSince <- DateTime.SpecifyKind(DateTime.ParseExact(value, "R", CultureInfo.InvariantCulture), DateTimeKind.Utc)) then req.Headers.[HeaderEnum.IfModifiedSince] <- value
 #else
-            | "if-modified-since" -> req.IfModifiedSince <- DateTime.ParseExact(value, "R", CultureInfo.InvariantCulture)
+            | "if-modified-since" -> req.IfModifiedSince <- DateTime.SpecifyKind(DateTime.ParseExact(value, "R", CultureInfo.InvariantCulture), DateTimeKind.Utc)
 #endif
             | "if-none-match" -> req.Headers.[HeaderEnum.IfNoneMatch] <- value
             | "if-range" -> req.Headers.[HeaderEnum.IfRange] <- value


### PR DESCRIPTION
When running the unit tests (as of commit 0b54be6) via `build.cmd all`, or via running the tests in `FSharp.Data.Tests.sln` on Windows 10, I get the following error:

1) Failed : FSharp.Data.Tests.HttpIntegrationTests.all of the manually-set request headers get sent to the server
  Expected: 2000-12-31 11:59:59.000
  But was:  2000-12-31 19:59:59.000
at FsUnit.TopLevelOperators.should[a,a](FSharpFunc`2 f, a x, Object y) in d:\GitHub\FsUnit\src\FsUnit.NUnit\FsUnit.fs:line 44
at FSharp.Data.Tests.HttpIntegrationTests.all of the manually-set request headers get sent to the server() in C:\Users\jas\Develop\Github\FSharp.Data\tests\FSharp.Data.Tests\HttpIntegrationTests.fs:line 131

The time is off by 8 hours, which is a clue, as I am on PST. Closer inspection reveals that the header field that fails the test is the "If-Modified-Since" field. However, the Date field, which is handled very similarly, passes its test. What is the difference? 

As it turns out, the difference is that in src/Net/Http.fs, for the "date" field, the Kind of DateTime is specified as UTC, whereas for the "if-modified-since" field, the DateTimeKind is left unspecified, which apparently lets the mock web server get creative with time zone offsets. 

Specifying "if-modified-since" as DateTimeKind.Utc fixes the issue.

