### PR TITLE
Improved performance when parsing CDATA sections

### DIFF
--- a/src/Html/HtmlParser.fs
+++ b/src/Html/HtmlParser.fs
@@ -549,21 +549,23 @@ module internal HtmlParser =
             | current -> 
                 match new String(Array.append current (state.Pop(5))) with
                 | "DOCTYPE" -> docType state
-                | "[CDATA[" -> state.Cons("<![CDATA[".ToCharArray()); cData state
+                | "[CDATA[" -> state.Cons("<![CDATA[".ToCharArray()); cData 0 state
                 | _ -> bogusComment state
-        and cData (state:HtmlState) = 
-            if ((!state.Content).ToString().EndsWith("]]>"))
-            then 
-               state.InsertionMode := CDATAMode
-               state.Emit()
-            else 
-               match state.Peek() with
-               | ']' -> state.Cons();  cData state 
-               | '>' -> state.Cons();  cData state
-               | TextParser.EndOfFile _ -> 
-                    state.InsertionMode := CDATAMode
-                    state.Emit()
-               | _ -> state.Cons(); cData state
+        and cData i (state:HtmlState) =
+            match state.Peek() with
+            | ']' when i = 0 || i = 1 ->
+                state.Cons()
+                cData (i + 1) state
+            | '>' when i = 2 ->
+                state.Cons()
+                state.InsertionMode := CDATAMode
+                state.Emit()
+            | TextParser.EndOfFile _ ->
+                state.InsertionMode := CDATAMode
+                state.Emit()
+            | _ ->
+                state.Cons()
+                cData 0 state
         and docType state =
             match state.Peek() with
             | '>' -> 


### PR DESCRIPTION
My use-case involves parsing a HTML document with "large" CDATA sections (80KiB).

The existing implementation seemingly hanged but in truth was just progressing very slowly.

The problem seemed to be that for every CDATA character this was performed:

```fsharp
if ((!state.Content).ToString().EndsWith("]]>"))
````

ToString is implemented like this:

```fsharp
override x.ToString() = String(x.Contents |> List.rev |> List.toArray)
```

So for each CDATA character we reverse the current content, makes it into an array and then creates a string.

Instead I changed cData to accept a parameter which controls whether an end tag is being processed.

In addition, I added a unit test for the performance for parsing large CDATA sections. Also, it seems that the CDATA sub parser wasn't triggered for the current unit test (script tag seems to have special handling) so I modified the existing test.

I ran the tests with old and new parser and the only difference is that when I run the large CDATA test it doesn't finish in time.

For my use-case parsing large CDATA section is very important.

Regards,

Mårten


