### PR TITLE
Fix cssselector to work outside the body element

### DIFF
--- a/src/Html/HtmlCssSelectors.fs
+++ b/src/Html/HtmlCssSelectors.fs
@@ -382,7 +382,7 @@ module CssSelectorExtensions =
         /// Gets descendants matched by Css selector
         [<Extension>]
         static member CssSelect(doc:HtmlDocument, selector) = 
-            CssSelectorExtensions.Select [doc.Body()] selector
+            CssSelectorExtensions.Select [doc.Html()] selector
         
         /// Gets descendants matched by Css selector
         [<Extension>]

--- a/src/Html/HtmlOperations.fs
+++ b/src/Html/HtmlOperations.fs
@@ -678,6 +678,24 @@ module HtmlDocument =
         | [] -> None
         | body:: _ -> Some body
 
+    /// Finds the html element of the given document,
+    /// this throws an exception if no html element exists.
+    /// Parameters:
+    /// * x - The given document
+    let inline html (x:HtmlDocument) = 
+        match List.ofSeq <| descendantsNamed false ["html"] x with
+        | [] -> failwith "No element html found!"
+        | html:: _ -> html
+
+    /// Tries to find the html element of the given document.
+    /// Parameters:
+    /// * x - The given document
+    let inline tryGetHtml (x:HtmlDocument) = 
+        match List.ofSeq <| descendantsNamed false ["html"] x with
+        | [] -> None
+        | html:: _ -> Some html
+
+
 [<Extension>]
 /// Extension methods with operations on HTML documents
 type HtmlDocumentExtensions =
@@ -832,6 +850,17 @@ type HtmlDocumentExtensions =
     [<Extension>]
     static member TryGetBody(doc:HtmlDocument) = 
         HtmlDocument.tryGetBody doc
+
+    /// Finds the html element of the given document,
+    /// this throws an exception if no html element exists.
+    [<Extension>]
+    static member Html(doc:HtmlDocument) = 
+        HtmlDocument.html doc
+
+    /// Tries to find the html element of the given document.
+    [<Extension>]
+    static member TryGetHtml(doc:HtmlDocument) = 
+        HtmlDocument.tryGetHtml doc
 
 // --------------------------------------------------------------------------------------
 

--- a/tests/FSharp.Data.Tests/HtmlCssSelectors.fs
+++ b/tests/FSharp.Data.Tests/HtmlCssSelectors.fs
@@ -450,3 +450,19 @@ let ``special characters can be escaped``() =
     selection |> should haveLength 1
     let values = selection |> Seq.exactlyOne |> HtmlNode.innerText
     values |> should equal "Matched, has id and class"
+
+
+[<Test>]
+let ``selector outside body tag``() = 
+    let html = """<!doctype html>
+        <html lang="en">
+        <head>
+          <title>Page Title</title>
+        </head>
+        <body>
+        </body>
+        </html>""" |> HtmlDocument.Parse
+    let selection = html.CssSelect "title"
+    selection |> should haveLength 1
+    let values = selection |> List.map (fun n -> n.InnerText())
+    values |> should equal ["Page Title"]


### PR DESCRIPTION
Added  .Html and tryGetHtml functionality so that css selectors can be done from html tag level instead of body level