### PR TITLE
Add `JsonValue.TryParse`

### DIFF
--- a/src/Json/JsonValue.fs
+++ b/src/Json/JsonValue.fs
@@ -343,6 +343,13 @@ type JsonValue with
   static member Parse(text, [<Optional>] ?cultureInfo) =
     JsonParser(text, cultureInfo, false).Parse()
 
+  /// Attempts to parse the specified JSON string
+  static member TryParse(text, [<Optional>] ?cultureInfo) =
+    try
+      Some <| JsonParser(text, cultureInfo, false).Parse()
+    with
+      | _ -> None
+
   /// Loads JSON from the specified stream
   static member Load(stream:Stream, [<Optional>] ?cultureInfo) =
     use reader = new StreamReader(stream)

--- a/tests/FSharp.Data.Tests/JsonValue.fs
+++ b/tests/FSharp.Data.Tests/JsonValue.fs
@@ -201,6 +201,16 @@ let ``Can parse nested array``() =
     j.[1].[1] |> should equal (JsonValue.String "Clyde")
 
 [<Test>]
+let ``TryParse is None when a bad JSON value is given``() =
+    let j = JsonValue.TryParse "}{"
+    j |> should equal None
+
+[<Test>]
+let ``TryParse is Some of the correct JSON value when a good structure is given``() =
+    let j = JsonValue.TryParse """{ "foo": "bar" }"""
+    j |> should equal (Some (JsonValue.Record [| "foo", JsonValue.String "bar" |]))
+
+[<Test>]
 let ``Can serialize empty document``() =
     (JsonValue.Record [| |]).ToString(JsonSaveOptions.DisableFormatting)
     |> should equal "{}"


### PR DESCRIPTION
Perhaps the dumbest PR so I understand if this is rejected but, that being said, here it is!

My reasons for submitting it are
 - Wrapping in option helps with an functional style, rather than having exceptions and, selfishly
 - I write this same wrapper in every project that uses FSharp.Data.

Let me know your thoughts!