### PR TITLE
Additional parsing for scripts

### DIFF
--- a/src/Html/HtmlParser.fs
+++ b/src/Html/HtmlParser.fs
@@ -462,6 +462,7 @@ module internal HtmlParser =
             match state.Peek() with
             | TextParser.EndOfFile _ -> data state
             | '/' -> state.Cons(); script state
+            | '\\' -> state.Cons(); state.Cons(); scriptRegex state
             | _ -> state.Cons(); scriptRegex state
         and scriptLessThanSign state =
             match state.Peek() with

--- a/src/Html/HtmlParser.fs
+++ b/src/Html/HtmlParser.fs
@@ -423,8 +423,40 @@ module internal HtmlParser =
         and script state =
             match state.Peek() with
             | TextParser.EndOfFile _ -> data state
+            | ''' -> state.Cons(); scriptSingleQuoteString state
+            | '"' -> state.Cons(); scriptDoubleQuoteString state
+            | '/' -> state.Cons(); scriptSlash state
             | '<' -> state.Pop(); scriptLessThanSign state
             | _ -> state.Cons(); script state
+        and scriptSingleQuoteString state =
+            match state.Peek() with
+            | ''' -> state.Cons(); script state
+            | _ -> state.Cons(); scriptSingleQuoteString state
+        and scriptDoubleQuoteString state =
+            match state.Peek() with
+            | '"' -> state.Cons(); script state
+            | _ -> state.Cons(); scriptDoubleQuoteString state
+        and scriptSlash state =
+            match state.Peek() with
+            | '/' -> state.Cons(); scriptSinleLineComment state
+            | '*' -> state.Cons(); scriptMultiLineComment state
+            | _ -> state.Cons(); scriptRegex state
+        and scriptMultiLineComment state =
+            match state.Peek() with
+            | '*' -> state.Cons(); scriptMultiLineCommentStar state
+            | _ -> state.Cons(); scriptMultiLineComment state
+        and scriptMultiLineCommentStar state =
+            match state.Peek() with
+            | '/' -> state.Cons(); script state
+            | _ -> scriptMultiLineComment state
+        and scriptSinleLineComment state =
+            match state.Peek() with
+            | '\n' -> state.Cons(); script state
+            | _ -> state.Cons(); scriptSinleLineComment state
+        and scriptRegex state =
+            match state.Peek() with
+            | '/' -> state.Cons(); script state
+            | _ -> state.Cons(); scriptRegex state
         and scriptLessThanSign state =
             match state.Peek() with
             | '/' -> state.Pop(); scriptEndTagOpen state

--- a/src/Html/HtmlParser.fs
+++ b/src/Html/HtmlParser.fs
@@ -430,10 +430,12 @@ module internal HtmlParser =
             | _ -> state.Cons(); script state
         and scriptSingleQuoteString state =
             match state.Peek() with
+            | TextParser.EndOfFile _ -> data state
             | ''' -> state.Cons(); script state
             | _ -> state.Cons(); scriptSingleQuoteString state
         and scriptDoubleQuoteString state =
             match state.Peek() with
+            | TextParser.EndOfFile _ -> data state
             | '"' -> state.Cons(); script state
             | _ -> state.Cons(); scriptDoubleQuoteString state
         and scriptSlash state =
@@ -443,18 +445,22 @@ module internal HtmlParser =
             | _ -> state.Cons(); scriptRegex state
         and scriptMultiLineComment state =
             match state.Peek() with
+            | TextParser.EndOfFile _ -> data state
             | '*' -> state.Cons(); scriptMultiLineCommentStar state
             | _ -> state.Cons(); scriptMultiLineComment state
         and scriptMultiLineCommentStar state =
             match state.Peek() with
+            | TextParser.EndOfFile _ -> data state
             | '/' -> state.Cons(); script state
             | _ -> scriptMultiLineComment state
         and scriptSingleLineComment state =
             match state.Peek() with
+            | TextParser.EndOfFile _ -> data state
             | '\n' -> state.Cons(); script state
             | _ -> state.Cons(); scriptSingleLineComment state
         and scriptRegex state =
             match state.Peek() with
+            | TextParser.EndOfFile _ -> data state
             | '/' -> state.Cons(); script state
             | _ -> state.Cons(); scriptRegex state
         and scriptLessThanSign state =

--- a/src/Html/HtmlParser.fs
+++ b/src/Html/HtmlParser.fs
@@ -442,7 +442,7 @@ module internal HtmlParser =
             match state.Peek() with
             | '/' -> state.Cons(); scriptSingleLineComment state
             | '*' -> state.Cons(); scriptMultiLineComment state
-            | _ -> state.Cons(); scriptRegex state
+            | _ -> scriptRegex state
         and scriptMultiLineComment state =
             match state.Peek() with
             | TextParser.EndOfFile _ -> data state
@@ -462,7 +462,10 @@ module internal HtmlParser =
             match state.Peek() with
             | TextParser.EndOfFile _ -> data state
             | '/' -> state.Cons(); script state
-            | '\\' -> state.Cons(); state.Cons(); scriptRegex state
+            | '\\' -> state.Cons(); scriptRegexBackslash state
+            | _ -> state.Cons(); scriptRegex state
+        and scriptRegexBackslash state =
+            match state.Peek() with
             | _ -> state.Cons(); scriptRegex state
         and scriptLessThanSign state =
             match state.Peek() with

--- a/src/Html/HtmlParser.fs
+++ b/src/Html/HtmlParser.fs
@@ -438,7 +438,7 @@ module internal HtmlParser =
             | _ -> state.Cons(); scriptDoubleQuoteString state
         and scriptSlash state =
             match state.Peek() with
-            | '/' -> state.Cons(); scriptSinleLineComment state
+            | '/' -> state.Cons(); scriptSingleLineComment state
             | '*' -> state.Cons(); scriptMultiLineComment state
             | _ -> state.Cons(); scriptRegex state
         and scriptMultiLineComment state =
@@ -449,10 +449,10 @@ module internal HtmlParser =
             match state.Peek() with
             | '/' -> state.Cons(); script state
             | _ -> scriptMultiLineComment state
-        and scriptSinleLineComment state =
+        and scriptSingleLineComment state =
             match state.Peek() with
             | '\n' -> state.Cons(); script state
-            | _ -> state.Cons(); scriptSinleLineComment state
+            | _ -> state.Cons(); scriptSingleLineComment state
         and scriptRegex state =
             match state.Peek() with
             | '/' -> state.Cons(); script state

--- a/tests/FSharp.Data.Tests/HtmlParser.fs
+++ b/tests/FSharp.Data.Tests/HtmlParser.fs
@@ -96,16 +96,30 @@ let ``Can handle attributes with no value``() =
         ]
     node.Attributes() |> should equal expected
 
-[<TestCase("var r =\"</script>\"")>]
-[<TestCase("var r ='</script>'")>]
-[<TestCase("var r =/</g")>]
+[<TestCase("var r = \"</script>\"")>]
+[<TestCase("var r = '</script>'")>]
+[<TestCase("var r = /</g")>]
+[<TestCase("""var r = /\/</g""")>]
+[<TestCase("""var r = /a\/</g""")>]
+[<TestCase("""var r = /\\/g""")>]
 [<TestCase("//</script>\n")>]
 [<TestCase("/*</script>*/")>]
 [<TestCase("/*</script>**/")>]
+[<TestCase("""/*
+</script>
+Test comment
+*/""")>]
 let ``Can handle special characters in scripts`` content =
     let html = sprintf "<script>%s</script>" content
     let node = HtmlNode.Parse html |> List.head
     let expected = HtmlNode.NewElement("script", [ HtmlNode.NewText content ])
+    node |> should equal expected
+
+[<Test>]
+let ``Can handle special characters in single line script comments`` () =
+    let html = "<script>//</script><body></body>"
+    let node = HtmlNode.Parse html |> List.head
+    let expected = HtmlNode.NewElement("script")
     node |> should equal expected
 
 [<Test>]

--- a/tests/FSharp.Data.Tests/HtmlParser.fs
+++ b/tests/FSharp.Data.Tests/HtmlParser.fs
@@ -96,6 +96,17 @@ let ``Can handle attributes with no value``() =
         ]
     node.Attributes() |> should equal expected
 
+[<TestCase("var r =\"</script>\"")>]
+[<TestCase("var r ='</script>'")>]
+[<TestCase("var r =/</g")>]
+[<TestCase("//</script>\n")>]
+[<TestCase("/*</script>*/")>]
+let ``Can handle special characters in scripts`` content =
+    let html = sprintf "<script>%s</script>" content
+    let node = HtmlNode.Parse html |> List.head
+    let expected = HtmlNode.NewElement("script", [ HtmlNode.NewText content ])
+    node |> should equal expected
+
 [<Test>]
 let ``Can parse tables from a simple html``() = 
     let html = """<html>

--- a/tests/FSharp.Data.Tests/HtmlParser.fs
+++ b/tests/FSharp.Data.Tests/HtmlParser.fs
@@ -101,6 +101,7 @@ let ``Can handle attributes with no value``() =
 [<TestCase("var r =/</g")>]
 [<TestCase("//</script>\n")>]
 [<TestCase("/*</script>*/")>]
+[<TestCase("/*</script>**/")>]
 let ``Can handle special characters in scripts`` content =
     let html = sprintf "<script>%s</script>" content
     let node = HtmlNode.Parse html |> List.head


### PR DESCRIPTION
Whilst investigating original issue I've found a few more cases when parser would mistake special characters for end tag sequence.