### PR TITLE
Fix incorrect cookie value when it contains '=' sign

### DIFF
--- a/src/Net/Http.fs
+++ b/src/Net/Http.fs
@@ -1465,11 +1465,12 @@ module internal CookieHandling =
             |> Array.iteri (fun i cookiePart ->
                 let cookiePart = cookiePart.Trim()
                 if i = 0 then
-                    let kvp = cookiePart.Split '='
-                    if kvp.Length > 0 then
-                        cookie.Name <- kvp.[0]
-                        if kvp.Length > 1 then
-                            cookie.Value <- kvp.[1]
+                    let firstEqual = cookiePart.IndexOf '='
+                    if firstEqual > -1 then
+                        cookie.Name <- cookiePart.Substring(0, firstEqual)
+                        cookie.Value <- cookiePart.Substring(firstEqual + 1)
+                    else
+                        cookie.Name <- cookiePart                    
                 elif cookiePart |> startsWithIgnoreCase "path" then
                     let kvp = cookiePart.Split '='
                     if kvp.Length > 1 && kvp.[1] <> "" && kvp.[1] <> "/" then

--- a/tests/FSharp.Data.Tests/Http.fs
+++ b/tests/FSharp.Data.Tests/Http.fs
@@ -59,6 +59,16 @@ let ``Cookies with commas are parsed correctly`` () =
            "NSC_W.TJUFEFGFOEFS.OBTEBR.80", "ffffffffc3a08e3045525d5f4f58455e445a4a423660" |]
 
 [<Test>]
+let ``Cookies with '=' are parsed correctly`` () =
+    let uri = Uri "http://nevermind.com"
+    let cookieHeader = "IdSession=Qze9H7HpvcVoh/ANulOl6Z1P8Omd1cLb9FOLL5o2aOlDMn/dFJi+RWDAPHZ4nDmWeno2puyOTFM/P4yzZMQsPoJ1gvEaJqG54kerM6WW4bv6ql72/Tn3NnCZTaokm8uaboLICgckUM2J7KOx5iL8uGyTN/g04/jZKlP1HgyatQL6kCG4qCQUMrdqZjqkbgW3eCpeyeI9rXF1bNC8hsKaqJ37Du/oBvbIMUbgenogfjzmlCgtAzv4la2Eo8+3cvDHkKPnksCP8kt8JbyXECyXBOjPrpFjtYv9UUGfyhwqRTRNTmH5+5UAsDDFrYe+vonYiDwXel8TfK3AZhQGXcF598AVPVfB1RO5S/mt7faDS7cEfz14nUsYtaNAZcwH7gwm06VJUX5eWiZzlBGx4SVBkNzP0QhLM9AqNP889y9BmZ2JaGb3fJtCWL3MfzM23mbwSemcERkoV3v1rIH8mb6ZgGm0hyEbbtu/RegkLAgNO+YB6c0Os6Pv6OnK0So4xlNakchaWhl1eMfOf4Gx0miJv4o2XbmAmbSNYkybi3n8vz4="
+    let cookies =
+        CookieHandling.getAllCookiesFromHeader cookieHeader uri
+        |> Array.map (snd >> (fun c -> c.Name, c.Value))
+    cookies |> should equal
+        [| "IdSession", "Qze9H7HpvcVoh/ANulOl6Z1P8Omd1cLb9FOLL5o2aOlDMn/dFJi+RWDAPHZ4nDmWeno2puyOTFM/P4yzZMQsPoJ1gvEaJqG54kerM6WW4bv6ql72/Tn3NnCZTaokm8uaboLICgckUM2J7KOx5iL8uGyTN/g04/jZKlP1HgyatQL6kCG4qCQUMrdqZjqkbgW3eCpeyeI9rXF1bNC8hsKaqJ37Du/oBvbIMUbgenogfjzmlCgtAzv4la2Eo8+3cvDHkKPnksCP8kt8JbyXECyXBOjPrpFjtYv9UUGfyhwqRTRNTmH5+5UAsDDFrYe+vonYiDwXel8TfK3AZhQGXcF598AVPVfB1RO5S/mt7faDS7cEfz14nUsYtaNAZcwH7gwm06VJUX5eWiZzlBGx4SVBkNzP0QhLM9AqNP889y9BmZ2JaGb3fJtCWL3MfzM23mbwSemcERkoV3v1rIH8mb6ZgGm0hyEbbtu/RegkLAgNO+YB6c0Os6Pv6OnK0So4xlNakchaWhl1eMfOf4Gx0miJv4o2XbmAmbSNYkybi3n8vz4="|]
+
+[<Test>]
 let ``Web request's timeout is used`` () =
     let exc = Assert.Throws<System.Net.WebException> (fun () ->
         Http.Request("http://deelay.me/100?http://api.themoviedb.org/3/search/movie", customizeHttpRequest = (fun req -> req.Timeout <- 1; req)) |> ignore)


### PR DESCRIPTION
Http.fs cooking handling was calling split('='), removing all '=' from the string whereas the goal was just to split name and value. This bug was introduced in PR #945.

I added a test and reused code before #945 searching for firstEqual with indexOf. I kept a guard if it was not found (since it was the logic implemented with split('=')), but not sure to understand what is the intent (cookie with only a name ?)...