### PR TITLE
thread encodings through the load methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ TestResult.xml
 log.csv
 log.txt
 .paket/paket.exe
+.paket/load
 paket-files
 *.ide
 *.bak

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 2.4.5 - Unreleased
+* Add an optional parameter for the `System.Text.Encoding` to use when reading data to the CSV, HTML, and Json providers. This parameter is called `encoding` and should be present on all Load and AsyncLoad methods.
+
 #### 2.4.4 - January 20 2018
 * Fix parsing of unquoted HTML attributes containing URLs.
 * Fixed HTTP form body url encoding.

--- a/docs/content/library/HtmlProvider.fsx
+++ b/docs/content/library/HtmlProvider.fsx
@@ -122,11 +122,11 @@ Chart.Bar stats
 
 (*** define-output:doctorWhoChart ***)
 let [<Literal>] DrWho = 
-  "http://en.wikipedia.org/wiki/List_of_Doctor_Who_serials"
+  "https://en.wikipedia.org/wiki/List_of_Doctor_Who_episodes_(1963%E2%80%931989)"
 
 let doctorWho = new HtmlProvider<DrWho>()
 
-// Get the average number of viewers for each doctor's series run
+// Get the average number of vi ewers for each doctor's series run
 let viewersByDoctor = 
   doctorWho.Tables.``Series overview``.Rows 
   |> Seq.groupBy (fun season -> season.Doctor)

--- a/docs/content/library/HtmlProvider.fsx
+++ b/docs/content/library/HtmlProvider.fsx
@@ -126,7 +126,7 @@ let [<Literal>] DrWho =
 
 let doctorWho = new HtmlProvider<DrWho>()
 
-// Get the average number of vi ewers for each doctor's series run
+// Get the average number of viewers for each doctor's series run
 let viewersByDoctor = 
   doctorWho.Tables.``Series overview``.Rows 
   |> Seq.groupBy (fun season -> season.Doctor)

--- a/docs/content/library/JsonProvider.fsx
+++ b/docs/content/library/JsonProvider.fsx
@@ -135,7 +135,7 @@ type People2 = JsonProvider<"""
     { "name":"Tomas" } ] """, SampleIsList=true>
 
 let person = People2.Parse("""{ "name":"Gustavo" }""")
-	
+
 (**
 	
 ## Loading WorldBank data

--- a/src/Csv/CsvFile.fs
+++ b/src/Csv/CsvFile.fs
@@ -93,10 +93,9 @@ and CsvFile private (readerFunc:Func<TextReader>, [<Optional>] ?separators, [<Op
 
   /// Loads CSV from the specified uri
   static member Load(uri:string, [<Optional>] ?separators, [<Optional>] ?quote, [<Optional>] ?hasHeaders, [<Optional>] ?ignoreErrors, [<Optional>] ?skipRows, [<Optional>] ?encoding) = 
-    CsvFile.AsyncLoad(uri, ?separators=separators, ?quote=quote, ?hasHeaders=hasHeaders, ?ignoreErrors=ignoreErrors, ?skipRows=skipRows) |> Async.RunSynchronously
+    CsvFile.AsyncLoad(uri, ?separators=separators, ?quote=quote, ?hasHeaders=hasHeaders, ?ignoreErrors=ignoreErrors, ?skipRows=skipRows, ?encoding=encoding) |> Async.RunSynchronously
 
   /// Loads CSV from the specified uri asynchronously
-  /// This doesn't actually load the file async, so why is it here? The `Async.RunSynchronously` ruins everything.
   static member AsyncLoad(uri:string, [<Optional>] ?separators, [<Optional>] ?quote, [<Optional>] ?hasHeaders, [<Optional>] ?ignoreErrors, [<Optional>] ?skipRows, [<Optional>] ?encoding) = async {
     let separators = defaultArg separators ""
     let separators = 

--- a/src/Csv/CsvFile.fs
+++ b/src/Csv/CsvFile.fs
@@ -10,6 +10,7 @@ open System.IO
 open System.Runtime.InteropServices
 open FSharp.Data.Runtime
 open FSharp.Data.Runtime.IO
+open System.Text
 
 [<StructuredFormatDisplay("{Columns}")>]
 /// Represents a CSV row.
@@ -91,25 +92,22 @@ and CsvFile private (readerFunc:Func<TextReader>, [<Optional>] ?separators, [<Op
     new CsvFile(readerFunc, ?separators=separators, ?quote=quote, ?hasHeaders=hasHeaders, ?ignoreErrors=ignoreErrors, ?skipRows=skipRows)
 
   /// Loads CSV from the specified uri
-  static member Load(uri:string, [<Optional>] ?separators, [<Optional>] ?quote, [<Optional>] ?hasHeaders, [<Optional>] ?ignoreErrors, [<Optional>] ?skipRows) = 
-    let separators = defaultArg separators ""    
-    let separators = 
-        if String.IsNullOrEmpty separators && uri.EndsWith(".tsv" , StringComparison.OrdinalIgnoreCase) 
-        then "\t" else separators
-    let readerFunc = Func<_>(fun () -> asyncReadTextAtRuntime false "" "" "CSV" "" uri |> Async.RunSynchronously)
-    new CsvFile(readerFunc, separators, ?quote=quote, ?hasHeaders=hasHeaders, ?ignoreErrors=ignoreErrors, ?skipRows=skipRows)
+  static member Load(uri:string, [<Optional>] ?separators, [<Optional>] ?quote, [<Optional>] ?hasHeaders, [<Optional>] ?ignoreErrors, [<Optional>] ?skipRows, [<Optional>] ?encoding) = 
+    CsvFile.AsyncLoad(uri, ?separators=separators, ?quote=quote, ?hasHeaders=hasHeaders, ?ignoreErrors=ignoreErrors, ?skipRows=skipRows) |> Async.RunSynchronously
 
   /// Loads CSV from the specified uri asynchronously
-  static member AsyncLoad(uri:string, [<Optional>] ?separators, [<Optional>] ?quote, [<Optional>] ?hasHeaders, [<Optional>] ?ignoreErrors, [<Optional>] ?skipRows) = async {
-    let separators = defaultArg separators ""    
+  /// This doesn't actually load the file async, so why is it here? The `Async.RunSynchronously` ruins everything.
+  static member AsyncLoad(uri:string, [<Optional>] ?separators, [<Optional>] ?quote, [<Optional>] ?hasHeaders, [<Optional>] ?ignoreErrors, [<Optional>] ?skipRows, [<Optional>] ?encoding) = async {
+    let separators = defaultArg separators ""
     let separators = 
         if String.IsNullOrEmpty separators && uri.EndsWith(".tsv" , StringComparison.OrdinalIgnoreCase)
         then "\t" else separators
-    let! reader = asyncReadTextAtRuntime false "" "" "CSV" "" uri
+    let encoding = defaultArg encoding Encoding.UTF8
+    let! reader = asyncReadTextAtRuntime false "" "" "CSV" encoding.WebName uri
     let firstTime = ref true
     let readerFunc = Func<_>(fun () ->  
       if firstTime.Value then firstTime := false; reader
-      else asyncReadTextAtRuntime false "" "" "CSV" "" uri |> Async.RunSynchronously)
+      else asyncReadTextAtRuntime false "" "" "CSV" encoding.WebName uri |> Async.RunSynchronously)
     return new CsvFile(readerFunc, separators, ?quote=quote, ?hasHeaders=hasHeaders, ?ignoreErrors=ignoreErrors, ?skipRows=skipRows)
   }
 

--- a/src/Html/HtmlParser.fs
+++ b/src/Html/HtmlParser.fs
@@ -8,6 +8,7 @@ open System.Text
 open System.Text.RegularExpressions
 open FSharp.Data
 open FSharp.Data.Runtime
+open System.Runtime.InteropServices
 
 // --------------------------------------------------------------------------------------
 
@@ -872,14 +873,15 @@ type HtmlDocument with
         HtmlParser.parseDocument reader
         
     /// Loads HTML from the specified uri asynchronously
-    static member AsyncLoad(uri:string) = async {
-        let! reader = IO.asyncReadTextAtRuntime false "" "" "HTML" "" uri
+    static member AsyncLoad(uri:string, [<Optional>] ?encoding) = async {
+        let encoding = defaultArg encoding Encoding.UTF8
+        let! reader = IO.asyncReadTextAtRuntime false "" "" "HTML" encoding.WebName uri
         return HtmlParser.parseDocument reader
     }
     
     /// Loads HTML from the specified uri
-    static member Load(uri:string) =
-        HtmlDocument.AsyncLoad(uri)
+    static member Load(uri:string, [<Optional>] ?encoding) =
+        HtmlDocument.AsyncLoad(uri, ?encoding=encoding)
         |> Async.RunSynchronously
 
 type HtmlNode with

--- a/src/Json/JsonValue.fs
+++ b/src/Json/JsonValue.fs
@@ -362,15 +362,16 @@ type JsonValue with
     JsonParser(text, cultureInfo, false).Parse()
 
   /// Loads JSON from the specified uri asynchronously
-  static member AsyncLoad(uri:string, [<Optional>] ?cultureInfo) = async {
-    let! reader = IO.asyncReadTextAtRuntime false "" "" "JSON" "" uri
+  static member AsyncLoad(uri:string, [<Optional>] ?cultureInfo, [<Optional>] ?encoding) = async {
+    let encoding = defaultArg encoding Encoding.UTF8
+    let! reader = IO.asyncReadTextAtRuntime false "" "" "JSON" encoding.WebName uri
     let text = reader.ReadToEnd()
     return JsonParser(text, cultureInfo, false).Parse()
   }
 
   /// Loads JSON from the specified uri
-  static member Load(uri:string, [<Optional>] ?cultureInfo) =
-    JsonValue.AsyncLoad(uri, ?cultureInfo=cultureInfo)
+  static member Load(uri:string, [<Optional>] ?cultureInfo, [<Optional>] ?encoding)=
+    JsonValue.AsyncLoad(uri, ?cultureInfo=cultureInfo, ?encoding=encoding)
     |> Async.RunSynchronously
 
   /// Parses the specified JSON string, tolerating invalid errors like trailing commans, and ignore content with elipsis ... or {...}

--- a/tests/FSharp.Data.Tests/Http.fs
+++ b/tests/FSharp.Data.Tests/Http.fs
@@ -71,19 +71,19 @@ let ``Cookies with '=' are parsed correctly`` () =
 [<Test>]
 let ``Web request's timeout is used`` () =
     let exc = Assert.Throws<System.Net.WebException> (fun () ->
-        Http.Request("http://deelay.me/100?http://api.themoviedb.org/3/search/movie", customizeHttpRequest = (fun req -> req.Timeout <- 1; req)) |> ignore)
+        Http.Request("http://httpstat.us/200?sleep=1000", customizeHttpRequest = (fun req -> req.Timeout <- 1; req)) |> ignore)
     Assert.AreEqual(typeof<TimeoutException>, exc.InnerException.GetType())
 
 [<Test>]
 let ``Timeout argument is used`` () =
     let exc = Assert.Throws<System.Net.WebException> (fun () ->
-        Http.Request("http://deelay.me/100?http://api.themoviedb.org/3/search/movie", timeout = 1) |> ignore)
+        Http.Request("http://httpstat.us/200?sleep=1000", timeout = 1) |> ignore)
     Assert.AreEqual(typeof<TimeoutException>, exc.InnerException.GetType())
 
 [<Test>]
 let ``Setting timeout in customizeHttpRequest overrides timeout argument`` () =
     let response =
-        Http.Request("http://deelay.me/100?http://httpstat.us/401?sleep=1000", silentHttpErrors = true,
+        Http.Request("http://httpstat.us/401?sleep=1000", silentHttpErrors = true,
             customizeHttpRequest = (fun req -> req.Timeout <- Threading.Timeout.Infinite; req), timeout = 1)
 
     response.StatusCode |> should equal 401


### PR DESCRIPTION
Should fix #871.

We do default to UTF8 if no encoding is specified, but now there are no longer any "" parameters passed as encodingStrings to the asyncReadTextAtRuntime function.