### PR TITLE
fix multipart multi-stream paging by only asking a stream for as much…

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 #### 2.4.5 - Unreleased
 * Add an optional parameter for the `System.Text.Encoding` to use when reading data to the CSV, HTML, and Json providers. This parameter is called `encoding` and should be present on all Load and AsyncLoad methods.
+* Fix handling of multipart form data payloads whose size exceeded ~80k bytes.
 
 #### 2.4.4 - January 20 2018
 * Fix parsing of unquoted HTML attributes containing URLs.


### PR DESCRIPTION
… of the requested count as it can provide

Fixes #1119  and #1077 for multipart payloads. Formdata payloads were not impacted, but I added some larger tests anyway.