### PR TITLE
Send JSON requests with content type charset set explicitly to UTF-8

### DIFF
--- a/src/Net/Http.fs
+++ b/src/Net/Http.fs
@@ -115,6 +115,10 @@ module HttpRequestHeaders =
     let ContentRange (range:string) = "Content-Range", range
     /// The MIME type of the body of the request (used with POST and PUT requests)
     let ContentType (contentType:string) = "Content-Type", contentType
+    /// The MIME type of the body of the request (used with POST and PUT requests) with an explicit charset
+    let ContentTypeWithCharset (contentType, charset) = "Content-Type", sprintf "%s; charset=%s" contentType charset
+    /// The MIME type of the body of the request (used with POST and PUT requests) with an explicit encoding
+    let ContentTypeWithEncoding (contentType, charset:Encoding) = ContentTypeWithCharset (contentType, charset.WebName)
     /// The date and time that the message was sent
     let Date (date:DateTime) = "Date", date.ToString("R", CultureInfo.InvariantCulture)
     /// Indicates that particular server behaviors are required by the client


### PR DESCRIPTION
Proposed fix.
Need an opinion on `ContentTypeWithCharset` vs `ContentTypeWithEncoding` - personally I prefer to have the latter so you can't accidentally provide charset string instead of content type string and vice versa, but debatable.