### PR TITLE
Add http status codes

### DIFF
--- a/src/Net/Http.fs
+++ b/src/Net/Http.fs
@@ -272,6 +272,134 @@ type HttpResponseWithStream =
     Headers : Map<string,string>
     Cookies : Map<string,string> }
 
+/// Constants for HTTP status codes.
+/// Based on https://en.wikipedia.org/wiki/List_of_HTTP_status_codes
+module HttpStatusCodes =
+    /// Continue - 100
+    let [<Literal>] Continue = 100
+    /// Switching Protocols - 101
+    let [<Literal>] SwitchingProtocols = 101
+    /// Processing - 102
+    let [<Literal>] Processing = 102
+    /// Early Hints - 103
+    let [<Literal>] EarlyHints = 103
+    /// OK - 200
+    let [<Literal>] OK = 200
+    /// Created - 201
+    let [<Literal>] Created = 201
+    /// Accepted - 202
+    let [<Literal>] Accepted = 202
+    /// Non-Authoritative Information - 203
+    let [<Literal>] NonauthoritativeInformation = 203
+    /// No Content - 204
+    let [<Literal>] NoContent = 204
+    /// Reset Content - 205
+    let [<Literal>] ResetContent = 205
+    /// Partial Content - 206
+    let [<Literal>] PartialContent = 206
+    /// Multi-Status - 207
+    let [<Literal>] Multistatus = 207
+    /// Already Reported - 208
+    let [<Literal>] AlreadyReported = 208
+    /// IM Used - 226
+    let [<Literal>] IMUsed = 226
+    /// Multiple Choices - 300
+    let [<Literal>] MultipleChoices = 300
+    /// Moved Permanently - 301
+    let [<Literal>] MovedPermanently = 301
+    /// Found - 302
+    let [<Literal>] Found = 302
+    /// See Other - 303
+    let [<Literal>] SeeOther = 303
+    /// Not Modified - 304
+    let [<Literal>] NotModified = 304
+    /// Use Proxy - 305
+    let [<Literal>] UseProxy = 305
+    /// Switch Proxy - 306
+    let [<Literal>] SwitchProxy = 306
+    /// Temporary Redirect - 307
+    let [<Literal>] TemporaryRedirect = 307
+    /// Permanent Redirect - 308
+    let [<Literal>] PermanentRedirect = 308
+    /// Bad Request - 400
+    let [<Literal>] BadRequest = 400
+    /// Unauthorized - 401
+    let [<Literal>] Unauthorized = 401
+    /// Payment Required - 402
+    let [<Literal>] PaymentRequired = 402
+    /// Forbidden - 403
+    let [<Literal>] Forbidden = 403
+    /// Not Found - 404
+    let [<Literal>] NotFound = 404
+    /// Method Not Allowed - 405
+    let [<Literal>] MethodNotAllowed = 405
+    /// Not Acceptable - 406
+    let [<Literal>] NotAcceptable = 406
+    /// Proxy Authentication Required - 407
+    let [<Literal>] ProxyAuthenticationRequired = 407
+    /// Request Timeout - 40
+    let [<Literal>] RequestTimeout = 408
+    /// Conflict - 409
+    let [<Literal>] Conflict = 409
+    /// Gone - 410
+    let [<Literal>] Gone = 410
+    /// Length Required - 411
+    let [<Literal>] LengthRequired = 411
+    /// Precondition Failed - 412
+    let [<Literal>] PreconditionFailed = 412
+    /// Payload Too Large - 413
+    let [<Literal>] PayloadTooLarge = 413
+    /// URI Too Long - 414
+    let [<Literal>] URITooLong = 414
+    /// Unsupported Media Type - 415
+    let [<Literal>] UnsupportedMediaType = 415
+    /// Range Not Satisfiable - 416
+    let [<Literal>] RangeNotSatisfiable = 416
+    /// Expectation Failed - 417
+    let [<Literal>] ExpectationFailed = 417
+    /// I'm a teapot - 418
+    let [<Literal>] ImATeapot = 418
+    /// Misdirected Request - 421
+    let [<Literal>] MisdirectedRequest = 421
+    /// Unprocessable Entity - 422
+    let [<Literal>] UnprocessableEntity = 422
+    /// Locked - 423
+    let [<Literal>] Locked = 423
+    /// Failed Dependency - 424
+    let [<Literal>] FailedDependency = 424
+    /// Upgrade Required - 426
+    let [<Literal>] UpgradeRequired = 426
+    /// Precondition Required - 428
+    let [<Literal>] PreconditionRequired = 428
+    /// Too Many Requests - 429
+    let [<Literal>] TooManyRequests = 429
+    /// Request Header Fields Too Large - 431
+    let [<Literal>] RequestHeaderFieldsTooLarge = 431
+    /// Unavailable For Legal Reasons - 451
+    let [<Literal>] UnavailableForLegalReasons = 451
+    /// Internal Server Error - 500
+    let [<Literal>] InternalServerError = 500
+    /// Not Implemented - 501
+    let [<Literal>] NotImplemented = 501
+    /// Bad Gateway - 502
+    let [<Literal>] BadGateway = 502
+    /// Service Unavailable - 503
+    let [<Literal>] ServiceUnavailable = 503
+    /// Gateway Timeout - 504
+    let [<Literal>] GatewayTimeout = 504
+    /// HTTP Version Not Supported - 505
+    let [<Literal>] HTTPVersionNotSupported = 505
+    /// Variant Also Negotiates - 506
+    let [<Literal>] VariantAlsoNegotiates = 506
+    /// Insufficient Storage - 507
+    let [<Literal>] InsufficientStorage = 507
+    /// Loop Detected - 508
+    let [<Literal>] LoopDetected = 508
+    /// Not Extended - 510
+    let [<Literal>] NotExtended = 510
+    /// Network Authentication Required - 511
+    let [<Literal>] NetworkAuthenticationRequired = 511
+
 /// Constants for common HTTP content types
 module HttpContentTypes =
     /// */*

--- a/tests/FSharp.Data.Tests/HttpIntegrationTests.fs
+++ b/tests/FSharp.Data.Tests/HttpIntegrationTests.fs
@@ -52,8 +52,8 @@ let ``should set everything correctly in the HTTP request`` ()=
 
 [<Test>]
 let ``should return the http status code for all response types`` () =
-    Http.Request("http://localhost:1235/TestServer/GoodStatusCode").StatusCode |> should equal 200
-    Http.Request("http://localhost:1235/TestServer/BadStatusCode", silentHttpErrors=true).StatusCode |> should equal 401
+    Http.Request("http://localhost:1235/TestServer/GoodStatusCode").StatusCode |> should equal HttpStatusCodes.OK
+    Http.Request("http://localhost:1235/TestServer/BadStatusCode", silentHttpErrors=true).StatusCode |> should equal HttpStatusCodes.Unauthorized
 
 [<Test>]
 let ``should return the entity body as a string`` () =
@@ -80,7 +80,7 @@ let ``cookies with protocol-prefixed domains should be handled`` () =
 
 [<Test>]
 let ``when called on a non-existant page returns 404`` () =
-    Http.Request("http://localhost:1235/TestServer/NoPage", silentHttpErrors=true).StatusCode |> should equal 404
+    Http.Request("http://localhost:1235/TestServer/NoPage", silentHttpErrors=true).StatusCode |> should equal HttpStatusCodes.NotFound
 
 [<Test>]
 let ``all of the manually-set request headers get sent to the server`` ()=
@@ -252,7 +252,7 @@ I am some file bytes
 --test--"""
     let body = Multipart("test", [ MultipartItem("file", "thing.txt", new MemoryStream(System.Text.Encoding.UTF8.GetBytes text) :> Stream) ])
     let response = Http.RequestStream("http://localhost:1235/TestServer/Multipart", silentHttpErrors = true, httpMethod = "Post", body = body)
-    response.StatusCode |> should equal 200
+    response.StatusCode |> should equal HttpStatusCodes.OK
     let contents = (new StreamReader(response.ResponseStream)).ReadToEnd() |> normalizeNewlines
     contents |> should equal (normalizeNewlines expected)
 #endif


### PR DESCRIPTION
Fixing https://github.com/fsharp/FSharp.Data/issues/1163.

I used the following script to generate most of the code:

```fsharp
#r "../../packages/FSharp.Data/lib/net45/FSharp.Data.dll"
#r "../../packages/FSharp.Data/lib/net45/FSharp.Data.DesignTime.dll"

open System
open System.Globalization
open FSharp.Data
open System.Text.RegularExpressions
open System.Text

let sc = new HtmlProvider<"https://en.wikipedia.org/wiki/List_of_HTTP_status_codes">()

/// Returns a string that represents the code
/// for a literal property.
let printLiteralCode (code:string) (name:string)  =
    let filterPunctuation = String.filter (Char.IsPunctuation >> not)
    let propName = 
        name.Split ' '
        |> Array.map (filterPunctuation >> CultureInfo.CurrentCulture.TextInfo.ToTitleCase)
        |> fun words -> String.Join("",words)
    sprintf
        """/// %s - %s
let [<Literal>] %s = %s""" name code propName code

let sb = StringBuilder()
let pattern = """([0-9]{3})\s([a-zA-Z\s'\-]+)\b"""

sc.Html.Descendants("dt")
|> Seq.iter(fun node ->
    let innerText = node.InnerText().Trim()
    let m = Regex.Match(innerText,pattern)
    if m.Groups.Count = 3 then
        let code = m.Groups.[1].Value
        let name = m.Groups.[2].Value
        ignore (sb.AppendLine (printLiteralCode code name))
)

System.IO.File.WriteAllText("/path/to/StatusCodes.fs", sb.ToString())
```