### PR TITLE
Issue #1167

### DIFF
--- a/src/CommonRuntime/NameUtils.fs
+++ b/src/CommonRuntime/NameUtils.fs
@@ -72,10 +72,10 @@ let niceCamelName (s:string) =
 ///     let n1 = makeUnique "sample-name"
 ///     let n2 = makeUnique "sample-name"
 ///
-let uniqueGenerator niceName =
+let uniqueGenerator (niceName:string->string) =
   let set = new HashSet<_>()
   fun name ->
-    let mutable name:String = niceName name
+    let mutable name = niceName name
     if name.Length = 0 then name <- "Unnamed"
     while set.Contains name do 
       let mutable lastLetterPos = String.length name - 1

--- a/src/CommonRuntime/NameUtils.fs
+++ b/src/CommonRuntime/NameUtils.fs
@@ -75,7 +75,8 @@ let niceCamelName (s:string) =
 let uniqueGenerator niceName =
   let set = new HashSet<_>()
   fun name ->
-    let mutable name = niceName name
+    let mutable name:String = niceName name
+    if name.Length = 0 then name <- "Unnamed"
     while set.Contains name do 
       let mutable lastLetterPos = String.length name - 1
       while Char.IsDigit name.[lastLetterPos] && lastLetterPos > 0 do


### PR DESCRIPTION
Issue: Crashes when loading an html page with a table with a zero length name 

Fix: If uniqueGenerator is passed a name value of length 0 the name is defaulted to 'Unnamed'. 