### PR TITLE
Fix handling of excaped charaters in string literals within script tag

### DIFF
--- a/src/Html/HtmlParser.fs
+++ b/src/Html/HtmlParser.fs
@@ -427,11 +427,13 @@ module internal HtmlParser =
             match state.Peek() with
             | TextParser.EndOfFile _ -> data state
             | ''' -> state.Cons(); script state
+            | '\\' -> state.Cons(); state.Cons(); scriptSingleQuoteString state
             | _ -> state.Cons(); scriptSingleQuoteString state
         and scriptDoubleQuoteString state =
             match state.Peek() with
             | TextParser.EndOfFile _ -> data state
             | '"' -> state.Cons(); script state
+            | '\\' -> state.Cons(); state.Cons(); scriptDoubleQuoteString state
             | _ -> state.Cons(); scriptDoubleQuoteString state
         and scriptSlash state =
             match state.Peek() with

--- a/src/Html/HtmlParser.fs
+++ b/src/Html/HtmlParser.fs
@@ -427,13 +427,19 @@ module internal HtmlParser =
             match state.Peek() with
             | TextParser.EndOfFile _ -> data state
             | ''' -> state.Cons(); script state
-            | '\\' -> state.Cons(); state.Cons(); scriptSingleQuoteString state
+            | '\\' -> state.Cons(); scriptSingleQuoteStringBackslash state
             | _ -> state.Cons(); scriptSingleQuoteString state
         and scriptDoubleQuoteString state =
             match state.Peek() with
             | TextParser.EndOfFile _ -> data state
             | '"' -> state.Cons(); script state
-            | '\\' -> state.Cons(); state.Cons(); scriptDoubleQuoteString state
+            | '\\' -> state.Cons(); scriptDoubleQuoteStringBackslash state
+            | _ -> state.Cons(); scriptDoubleQuoteString state
+        and scriptSingleQuoteStringBackslash state =
+            match state.Peek() with
+            | _ -> state.Cons(); scriptSingleQuoteString state
+        and scriptDoubleQuoteStringBackslash state =
+            match state.Peek() with
             | _ -> state.Cons(); scriptDoubleQuoteString state
         and scriptSlash state =
             match state.Peek() with

--- a/tests/FSharp.Data.Tests/HtmlParser.fs
+++ b/tests/FSharp.Data.Tests/HtmlParser.fs
@@ -837,3 +837,14 @@ let ``Can create new CData element``() =
     HtmlNode.NewCData("some element content")
     |> string
     |> should equal "<![CDATA[some element content]]>"
+
+[<TestCase("""var ns="xmlns=\"http:\/\/test.com\"";""")>]
+[<TestCase("""var ns='xmlns=\'http:\/\/test.com\'';""")>]
+let ``Can handle escaped characters in a string inside script tag`` content =
+    let result = HtmlDocument.Parse (sprintf "<script>%s</script>" content)
+    let expected =
+        HtmlDocument.New
+            [ HtmlNode.NewElement("script",
+                [],
+                [ HtmlNode.NewText content ]) ]
+    result |> should equal expected


### PR DESCRIPTION
When parser is in a script mode and encounters " or ' it detects string literal and will consume characters until it finds matching " or ' correspondingly. However, " or ' can be escaped, so that they loose their original meaning and should be ignored by the parser at that point. Parser should look for next " or '.