### PR TITLE
Avoid errors with cookie value not supported by RFC6265

### DIFF
--- a/src/Net/Http.fs
+++ b/src/Net/Http.fs
@@ -1489,12 +1489,13 @@ type Http private() =
                 [<Optional>] ?body,
                 [<Optional>] ?cookies,
                 [<Optional>] ?cookieContainer,
+                [<Optional>] ?silentCookieErrors,
                 [<Optional>] ?silentHttpErrors,
                 [<Optional>] ?responseEncodingOverride,
                 [<Optional>] ?customizeHttpRequest,
                 [<Optional>] ?timeout
             ) =
-        Http.InnerRequest(url, toHttpResponse (*forceText*)false, ?query=query, ?headers=headers, ?httpMethod=httpMethod, ?body=body, ?cookies=cookies, ?cookieContainer=cookieContainer,
+        Http.InnerRequest(url, toHttpResponse (*forceText*)false, ?query=query, ?headers=headers, ?httpMethod=httpMethod, ?body=body, ?cookies=cookies, ?cookieContainer=cookieContainer, ?silentCookieErrors=silentCookieErrors,
                           ?silentHttpErrors=silentHttpErrors, ?responseEncodingOverride=responseEncodingOverride, ?customizeHttpRequest=customizeHttpRequest, ?timeout = timeout)
 
     /// Download an HTTP web resource from the specified URL asynchronously
@@ -1511,13 +1512,14 @@ type Http private() =
                 [<Optional>] ?body,
                 [<Optional>] ?cookies,
                 [<Optional>] ?cookieContainer,
+                [<Optional>] ?silentCookieErrors,
                 [<Optional>] ?silentHttpErrors,
                 [<Optional>] ?responseEncodingOverride,
                 [<Optional>] ?customizeHttpRequest,
                 [<Optional>] ?timeout
             ) =
         async {
-            let! response = Http.InnerRequest(url, toHttpResponse (*forceText*)true, ?query=query, ?headers=headers, ?httpMethod=httpMethod, ?body=body, ?cookies=cookies, ?cookieContainer=cookieContainer,
+            let! response = Http.InnerRequest(url, toHttpResponse (*forceText*)true, ?query=query, ?headers=headers, ?httpMethod=httpMethod, ?body=body, ?cookies=cookies, ?cookieContainer=cookieContainer, ?silentCookieErrors = silentCookieErrors,
                                               ?silentHttpErrors=silentHttpErrors, ?responseEncodingOverride=responseEncodingOverride, ?customizeHttpRequest=customizeHttpRequest, ?timeout = timeout)
             return
                 match response.Body with
@@ -1539,6 +1541,7 @@ type Http private() =
                 [<Optional>] ?body,
                 [<Optional>] ?cookies,
                 [<Optional>] ?cookieContainer,
+                [<Optional>] ?silentCookieErrors,
                 [<Optional>] ?silentHttpErrors,
                 [<Optional>] ?customizeHttpRequest,
                 [<Optional>] ?timeout
@@ -1550,7 +1553,7 @@ type Http private() =
                      Headers = headers
                      Cookies = cookies }
         }
-        Http.InnerRequest(url, toHttpResponse, ?query=query, ?headers=headers, ?httpMethod=httpMethod, ?body=body, ?cookies=cookies, ?cookieContainer=cookieContainer,
+        Http.InnerRequest(url, toHttpResponse, ?query=query, ?headers=headers, ?httpMethod=httpMethod, ?body=body, ?cookies=cookies, ?cookieContainer=cookieContainer, ?silentCookieErrors=silentCookieErrors,
                           ?silentHttpErrors=silentHttpErrors, ?customizeHttpRequest=customizeHttpRequest, ?timeout = timeout)
 
     /// Download an HTTP web resource from the specified URL synchronously
@@ -1567,12 +1570,13 @@ type Http private() =
                 [<Optional>] ?body,
                 [<Optional>] ?cookies,
                 [<Optional>] ?cookieContainer,
+                [<Optional>] ?silentCookieErrors,
                 [<Optional>] ?silentHttpErrors,
                 [<Optional>] ?responseEncodingOverride,
                 [<Optional>] ?customizeHttpRequest,
                 [<Optional>] ?timeout
             ) =
-        Http.AsyncRequest(url, ?query=query, ?headers=headers, ?httpMethod=httpMethod, ?body=body, ?cookies=cookies, ?cookieContainer=cookieContainer,
+        Http.AsyncRequest(url, ?query=query, ?headers=headers, ?httpMethod=httpMethod, ?body=body, ?cookies=cookies, ?cookieContainer=cookieContainer,?silentCookieErrors=silentCookieErrors,
                           ?silentHttpErrors=silentHttpErrors, ?responseEncodingOverride=responseEncodingOverride, ?customizeHttpRequest=customizeHttpRequest, ?timeout=timeout)
         |> Async.RunSynchronously
 
@@ -1590,12 +1594,13 @@ type Http private() =
                 [<Optional>] ?body,
                 [<Optional>] ?cookies,
                 [<Optional>] ?cookieContainer,
+                [<Optional>] ?silentCookieErrors,
                 [<Optional>] ?silentHttpErrors,
                 [<Optional>] ?responseEncodingOverride,
                 [<Optional>] ?customizeHttpRequest,
                 [<Optional>] ?timeout
             ) =
-        Http.AsyncRequestString(url, ?query=query, ?headers=headers, ?httpMethod=httpMethod, ?body=body, ?cookies=cookies, ?cookieContainer=cookieContainer,
+        Http.AsyncRequestString(url, ?query=query, ?headers=headers, ?httpMethod=httpMethod, ?body=body, ?cookies=cookies, ?cookieContainer=cookieContainer, ?silentCookieErrors=silentCookieErrors,
                                 ?silentHttpErrors=silentHttpErrors, ?responseEncodingOverride=responseEncodingOverride, ?customizeHttpRequest=customizeHttpRequest, ?timeout=timeout)
         |> Async.RunSynchronously
 
@@ -1613,10 +1618,11 @@ type Http private() =
                 [<Optional>] ?body,
                 [<Optional>] ?cookies,
                 [<Optional>] ?cookieContainer,
+                [<Optional>] ?silentCookieErrors,
                 [<Optional>] ?silentHttpErrors,
                 [<Optional>] ?customizeHttpRequest,
                 [<Optional>] ?timeout
             ) =
-        Http.AsyncRequestStream(url, ?query=query, ?headers=headers, ?httpMethod=httpMethod, ?body=body, ?cookies=cookies, ?cookieContainer=cookieContainer,
+        Http.AsyncRequestStream(url, ?query=query, ?headers=headers, ?httpMethod=httpMethod, ?body=body, ?cookies=cookies, ?cookieContainer=cookieContainer, ?silentCookieErrors=silentCookieErrors,
                                 ?silentHttpErrors=silentHttpErrors, ?customizeHttpRequest=customizeHttpRequest, ?timeout=timeout)
         |> Async.RunSynchronously

--- a/src/Net/Http.fs
+++ b/src/Net/Http.fs
@@ -1329,7 +1329,10 @@ module internal CookieHandling =
         | Some cookieHeader ->
             getAllCookiesFromHeader cookieHeader responseUri
             |> Array.fold (fun cookies (uri, cookie) ->
-                cookieContainer.Add(uri, cookie)
+                if addCookiesInCookieContainer then
+                    try cookieContainer.Add(uri, cookie)
+                    with | :? CookieException as e ->
+                        if defaultArg silentCookieErrors false then () else raise e
                 cookies |> Map.add cookie.Name cookie.Value) cookiesFromCookieContainer
         | None -> cookiesFromCookieContainer
 

--- a/tests/FSharp.Data.Tests/Http.fs
+++ b/tests/FSharp.Data.Tests/Http.fs
@@ -70,6 +70,14 @@ let ``Cookies with '=' are parsed correctly`` () =
         [| "IdSession", "Qze9H7HpvcVoh/ANulOl6Z1P8Omd1cLb9FOLL5o2aOlDMn/dFJi+RWDAPHZ4nDmWeno2puyOTFM/P4yzZMQsPoJ1gvEaJqG54kerM6WW4bv6ql72/Tn3NnCZTaokm8uaboLICgckUM2J7KOx5iL8uGyTN/g04/jZKlP1HgyatQL6kCG4qCQUMrdqZjqkbgW3eCpeyeI9rXF1bNC8hsKaqJ37Du/oBvbIMUbgenogfjzmlCgtAzv4la2Eo8+3cvDHkKPnksCP8kt8JbyXECyXBOjPrpFjtYv9UUGfyhwqRTRNTmH5+5UAsDDFrYe+vonYiDwXel8TfK3AZhQGXcF598AVPVfB1RO5S/mt7faDS7cEfz14nUsYtaNAZcwH7gwm06VJUX5eWiZzlBGx4SVBkNzP0QhLM9AqNP889y9BmZ2JaGb3fJtCWL3MfzM23mbwSemcERkoV3v1rIH8mb6ZgGm0hyEbbtu/RegkLAgNO+YB6c0Os6Pv6OnK0So4xlNakchaWhl1eMfOf4Gx0miJv4o2XbmAmbSNYkybi3n8vz4="|]
 
 [<Test>]
+let ``Cookies with JSON are parsed correctly`` () =
+    let uri = Uri "http://nevermind.com"
+    let cookieHeader = "hab={\"echanges\":1,\"notifications\":1,\"messages\":1}"
+    let cookieContainer = System.Net.CookieContainer()
+    CookieHandling.getAllCookiesFromHeader cookieHeader uri
+    |> Array.iter cookieContainer.Add
+    
+[<Test>]
 let ``An empty cookie header is parsed correctly`` () =
     let uri = Uri "https://news.google.com/news?hl=en&ned=us&ie=UTF8&nolr=1&output=rss&q=FSharp&num=1000"
     let cookieHeader = ""


### PR DESCRIPTION
Fix partially #1040.
They are two ways to avoid the issue :

* Do not use CookieContainer in parameter (an internal one is used, but it avoids the issue)
* Or, if you don't care about the cookie that causes the issue, you can set optional silentCookieError parameter

Still if you need this malformed cookie (should be URL encoded by the server following RFC6265) and still want to have the facility to pass cookieContainer through several request to avoid manuel cookie management, then I don't have a solution.