### PR TITLE
fix build - add DisableImplicitFSharpCoreReference

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can see the version history [here](RELEASE_NOTES.md).
 
 ## Building
 
-- Install .NET SDK 2.1.100 or higher
+- Install .NET SDK 2.1.401 or higher
 - Build FSharp.Data.sln and FSharp.Data.Tests.sln in Visual Studio 2017, Visual Studio 2017 for Mac (previously Xamarin Studio), or MonoDevelop. You can also use the FAKE script:
 
   * Windows: Run *build.cmd* 

--- a/build.fsx
+++ b/build.fsx
@@ -33,7 +33,7 @@ let gitOwner = "fsharp"
 let gitHome = "https://github.com/" + gitOwner
 let gitName = "FSharp.Data"
 
-let desiredSdkVersion = "2.1.100"
+let desiredSdkVersion = "2.1.401"
 let mutable sdkPath = None
 let getSdkPath() = (defaultArg sdkPath "dotnet")
 

--- a/src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj
+++ b/src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj
@@ -6,6 +6,7 @@
     <DefineConstants>NO_GENERATIVE;$(DefineConstants)</DefineConstants>
     <OtherFlags>--warnon:1182</OtherFlags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Net\Http.fs" />

--- a/src/FSharp.Data/FSharp.Data.fsproj
+++ b/src/FSharp.Data/FSharp.Data.fsproj
@@ -6,6 +6,7 @@
     <TargetFrameworks>netstandard2.0; net45</TargetFrameworks>
     <OtherFlags>--warnon:1182</OtherFlags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Net\Http.fs" />

--- a/tests/FSharp.Data.Tests/FSharp.Data.Tests.fsproj
+++ b/tests/FSharp.Data.Tests/FSharp.Data.Tests.fsproj
@@ -13,6 +13,7 @@
     <TargetLibraryFramework Condition="'$(TargetFramework)' == 'net461'">net45</TargetLibraryFramework>
     <TargetLibraryFramework Condition="'$(TargetFramework)' == 'netcoreapp2.0'">netstandard2.0</TargetLibraryFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Data/**/*.*">


### PR DESCRIPTION

I don't know what has changed but it seems that after upgrading to the .NET SDK 2.1.401 we now have to use

    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>

to disable the implicit FSharp.Core reference.  Previously this was disabled automatically if you have an FSharp.Core reference in your project file.
