### PR TITLE
Fix assembly version generation

### DIFF
--- a/src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj
+++ b/src/FSharp.Data.DesignTime/FSharp.Data.DesignTime.fsproj
@@ -7,6 +7,7 @@
     <OtherFlags>--warnon:1182</OtherFlags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Net\Http.fs" />

--- a/src/FSharp.Data/FSharp.Data.fsproj
+++ b/src/FSharp.Data/FSharp.Data.fsproj
@@ -7,6 +7,7 @@
     <OtherFlags>--warnon:1182</OtherFlags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Net\Http.fs" />


### PR DESCRIPTION
The F# SDK seems to be overriding the assemblyinfo.fs values where they exist. Adding the `GenerateAssemblyInfo` flag set to false returns that file to its place of primacy.

Before: 
```
➜  FSharp.Data git:(fix-assembly-version) ✗ monop -r bin/Debug/net45/FSharp.Data.dll

Assembly Information:
FSharp.Data
Version=1.0.0.0
Culture=neutral
PublicKeyToken=null
```

After:
```
➜  FSharp.Data git:(fix-assembly-version) ✗ monop -r bin/Debug/net45/FSharp.Data.dll

Assembly Information:
FSharp.Data
Version=3.0.0.0
Culture=neutral
PublicKeyToken=null
```