### PR TITLE
Fixed undisposed writers in CSV saving

### DIFF
--- a/src/Csv/CsvRuntime.fs
+++ b/src/Csv/CsvRuntime.fs
@@ -347,18 +347,18 @@ type CsvFile<'RowType> private (rowToStringArray:Func<'RowType,string[]>, dispos
           writer.Write item)
 
   /// Saves CSV to the specified stream
-  member x.Save(stream:Stream, [<Optional>] ?separator, [<Optional>] ?quote) = 
-    let writer = new StreamWriter(stream)
+  member x.Save(stream:Stream, [<Optional>] ?separator, [<Optional>] ?quote) =
+    use writer = new StreamWriter(stream, System.Text.UTF8Encoding(false, true), 1024, true)
     x.Save(writer, ?separator=separator, ?quote=quote)
 
   /// Saves CSV to the specified file
-  member x.Save(path:string, [<Optional>] ?separator, [<Optional>] ?quote) = 
-    let writer = new StreamWriter(File.OpenWrite(path))
+  member x.Save(path:string, [<Optional>] ?separator, [<Optional>] ?quote) =
+    use writer = new StreamWriter(File.OpenWrite(path))
     x.Save(writer, ?separator=separator, ?quote=quote)
 
   /// Saves CSV to a string
-  member x.SaveToString([<Optional>] ?separator, [<Optional>] ?quote) = 
-     let writer = new StringWriter()
+  member x.SaveToString([<Optional>] ?separator, [<Optional>] ?quote) =
+     use writer = new StringWriter()
      x.Save(writer, ?separator=separator, ?quote=quote)
      writer.ToString()
 


### PR DESCRIPTION
This fixes a small bug where the CSV Save functions don't dispose the writers they use, and therefore leave stream flushing and potentially file handles open until garbage collection cleans up the writers. I've simply changed the `let writer`s to `use writers` to ensure they are disposed correctly.

One point that's worth some discussion: for the `Save(stream : Stream ...` overload, I've made it so that the save does not close the underlying stream. Instead, the writer flushes into it, but leaves it open. I chose to do this because I'm of the opinion that if I give a stream to something, I (the caller) own it and I will close and dispose it when I'm done with it. I don't expect `Save` to close and dispose it for me.
However this is not the default behaviour when you pass a Stream to a Writer, hence why I'm using a more complicated overload.