### PR TITLE
Reduce impact of leaking type provider instances

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 3.0.3 - March 28 2019
+* Fix for excessive memory usage (hold TP instances weakly in file watcher callbacks)
+
 #### 3.0.1 - March 21 2019
 * Fix for excessive memory usage (incorprating latest TPSDK)
 


### PR DESCRIPTION
The F# tools appear to be leaking type provider instances from time to time.  Or, perhaps FSharp.Data is not de-registering file watcher callbacks correctly.

Either way, best practice is that file watcher callbacks do not hold strong handles to type providers.

