### PR TITLE
decrease cache time

### DIFF
--- a/src/CommonProviderImplementation/Helpers.fs
+++ b/src/CommonProviderImplementation/Helpers.fs
@@ -283,7 +283,7 @@ module internal ProviderHelpers =
                 else
                     failwithf "Cannot read sample %s from '%s': %s" formatName valueToBeParsedOrItsUri e.Message
     
-    let private providedTypesCache = createInMemoryCache (TimeSpan.FromMinutes 5.)
+    let private providedTypesCache = createInMemoryCache (TimeSpan.FromSeconds 30.0)
     let private activeDisposeActions = HashSet<_>()
 
     // Cache generated types for a short time, since VS invokes the TP multiple tiems


### PR DESCRIPTION
I'm convinced 5 minutes is too long to be caching these instances under many user edits which might recreate many type provider instances

I'm also sceptical about the cache in general, see #1253 - I'd much prefer this is scoped to a particular TP instance - but for now decreasing the cache time seems sensible.

This is all part of a range of work to try to reduce the impact of some memory problems we're seeing in when using F# tooling with FSharp.Data type providers