### PR TITLE
Remove obsolete special-case root value parsing.

### DIFF
--- a/src/Json/JsonValue.fs
+++ b/src/Json/JsonValue.fs
@@ -181,14 +181,6 @@ type private JsonParser(jsonText:string) =
         | 'n' -> parseLiteral("null", JsonValue.Null)
         | _ -> throw()
 
-    and parseRootValue() =
-        skipWhitespace()
-        ensure(i < s.Length)
-        match s.[i] with
-        | '{' -> parseObject()
-        | '[' -> parseArray()
-        | _ -> throw()
-
     and parseString() =
         ensure(i < s.Length && s.[i] = '"')
         i <- i + 1
@@ -302,7 +294,7 @@ type private JsonParser(jsonText:string) =
 
     // Start by parsing the top-level value
     member x.Parse() =
-        let value = parseRootValue()
+        let value = parseValue()
         skipWhitespace()
         if i <> s.Length then
             throw()
@@ -311,7 +303,7 @@ type private JsonParser(jsonText:string) =
     member x.ParseMultiple() =
         seq {
             while i <> s.Length do
-                yield parseRootValue()
+                yield parseValue()
                 skipWhitespace()
         }
 

--- a/src/Json/JsonValue.fs
+++ b/src/Json/JsonValue.fs
@@ -286,7 +286,7 @@ type private JsonParser(jsonText:string) =
         JsonValue.Array(vals.ToArray())
 
     and parseLiteral(expected, r) =
-        ensure(i+expected.Length < s.Length)
+        ensure(i+expected.Length <= s.Length)
         for j in 0 .. expected.Length - 1 do
             ensure(s.[i+j] = expected.[j])
         i <- i + expected.Length

--- a/tests/FSharp.Data.Tests/JsonValue.fs
+++ b/tests/FSharp.Data.Tests/JsonValue.fs
@@ -412,12 +412,13 @@ let ``Can parse various JSON documents``() =
             """{"a":[]  ,"b":{}}"""                 , Some <| Record [|"a",Array [||];"b",Record [||]|]
             """{"a":[],  "b":{}}"""                 , Some <| Record [|"a",Array [||];"b",Record [||]|]
             """{"a":[]  ,  "b":{}}"""               , Some <| Record [|"a",Array [||];"b",Record [||]|]
+            """0"""                                 , Some <| Float 0.
+            """1234"""                              , Some <| Float 1234.
+            """true"""                              , Some <| Boolean true
+            """false"""                             , Some <| Boolean false
+            """null"""                              , Some <| Null
+            """ "Test" """                          , Some <| String "Test"
             // Negative tests
-            """0"""                                 , None
-            """1234"""                              , None
-            """true"""                              , None
-            """false"""                             , None
-            """ "Test" """                          , None
             """[NaN]"""                             , None
             """[,]"""                               , None
             """[true,]"""                           , None


### PR DESCRIPTION
Quick stab at fixing #1261. Seems to work now with the second fix applied.