### PR TITLE
Handle serialization of odd float values

### DIFF
--- a/src/Json/JsonValue.fs
+++ b/src/Json/JsonValue.fs
@@ -63,10 +63,10 @@ type JsonValue =
       else "\":"
 
     let rec serialize indentation = function
-      | Null
-      | Float v when Double.IsInfinity v || Double.IsNaN v -> w.Write "null"
+      | Null -> w.Write "null"
       | Boolean b -> w.Write(if b then "true" else "false")
       | Number number -> w.Write number
+      | Float v when Double.IsInfinity v || Double.IsNaN v -> w.Write "null"
       | Float number -> w.Write number
       | String s ->
           w.Write "\""

--- a/src/Json/JsonValue.fs
+++ b/src/Json/JsonValue.fs
@@ -63,7 +63,8 @@ type JsonValue =
       else "\":"
 
     let rec serialize indentation = function
-      | Null -> w.Write "null"
+      | Null
+      | Float v when Double.IsInfinity v || Double.IsNaN v -> w.Write "null"
       | Boolean b -> w.Write(if b then "true" else "false")
       | Number number -> w.Write number
       | Float number -> w.Write number
@@ -98,8 +99,7 @@ type JsonValue =
   // Encode characters that are not valid in JS string. The implementation is based
   // on https://github.com/mono/mono/blob/master/mcs/class/System.Web/System.Web/HttpUtility.cs
   static member internal JsonStringEncodeTo (w:TextWriter) (value:string) =
-    if String.IsNullOrEmpty value then ()
-    else 
+    if not (String.IsNullOrEmpty value) then
       for i = 0 to value.Length - 1 do
         let c = value.[i]
         let ci = int c

--- a/tests/FSharp.Data.Tests/JsonValue.fs
+++ b/tests/FSharp.Data.Tests/JsonValue.fs
@@ -281,6 +281,21 @@ let ``Can serialize document with array, null and number``() =
     let json = JsonValue.Parse text
     json.ToString(JsonSaveOptions.DisableFormatting) |> should equal text
 
+[<Test>]
+let ``Serializes NaN as null``() =
+    let json = JsonValue.Float Double.NaN
+    json.ToString(JsonSaveOptions.DisableFormatting) |> should equal "null"
+
+[<Test>]
+let ``Serializes Infinity as null``() =
+    let json = JsonValue.Float Double.PositiveInfinity
+    json.ToString(JsonSaveOptions.DisableFormatting) |> should equal "null"
+
+[<Test>]
+let ``Serializes -Infinity as null``() =
+    let json = JsonValue.Float Double.NegativeInfinity
+    json.ToString(JsonSaveOptions.DisableFormatting) |> should equal "null"
+
 let normalize (str:string) =
   str.Replace("\r\n", "\n")
      .Replace("\r", "\n")

--- a/tests/FSharp.Data.Tests/JsonValue.fs
+++ b/tests/FSharp.Data.Tests/JsonValue.fs
@@ -281,19 +281,11 @@ let ``Can serialize document with array, null and number``() =
     let json = JsonValue.Parse text
     json.ToString(JsonSaveOptions.DisableFormatting) |> should equal text
 
-[<Test>]
-let ``Serializes NaN as null``() =
-    let json = JsonValue.Float Double.NaN
-    json.ToString(JsonSaveOptions.DisableFormatting) |> should equal "null"
-
-[<Test>]
-let ``Serializes Infinity as null``() =
-    let json = JsonValue.Float Double.PositiveInfinity
-    json.ToString(JsonSaveOptions.DisableFormatting) |> should equal "null"
-
-[<Test>]
-let ``Serializes -Infinity as null``() =
-    let json = JsonValue.Float Double.NegativeInfinity
+[<TestCase(Double.NaN)>]
+[<TestCase(Double.PositiveInfinity)>]
+[<TestCase(Double.NegativeInfinity)>]
+let ``Serializes special float value as null`` v =
+    let json = JsonValue.Float v
     json.ToString(JsonSaveOptions.DisableFormatting) |> should equal "null"
 
 let normalize (str:string) =


### PR DESCRIPTION
Unfortunately `System.Double.NaN`, `System.Double.PositiveInfinity` and `System.Double.NegativeInfinity` cause invalid JSON to be generated. These seem like special cases that shouldn't happen often but they are not disallowed by the type system.

I was using FsCheck to generate `JsonValue` instances and I noticed an array containing `NaN` which causes JSON parsers to error.

This change attempts to mimic the decisions already made in JavaScript, e.g.
``` javascript
$ node
> JSON.stringify(NaN)
'null'
> JSON.stringify(Infinity)
'null'
> JSON.stringify(-Infinity)
'null'
```