### PR TITLE
Refactor parse' to use tail recursion

### DIFF
--- a/src/Html/HtmlParser.fs
+++ b/src/Html/HtmlParser.fs
@@ -9,6 +9,7 @@ open System.Text.RegularExpressions
 open FSharp.Data
 open FSharp.Data.Runtime
 open System.Runtime.InteropServices
+open System.Collections.Generic
 
 // --------------------------------------------------------------------------------------
 
@@ -787,7 +788,18 @@ module internal HtmlParser =
                 TagEnd expectedTagEnd :: tokens
             | _ -> tokens
 
-        let rec parse' docType elements expectedTagEnd parentTagName (tokens:HtmlToken list) =
+
+        let rec parse' (callstack: Stack<string*HtmlNode list*string*string*string*HtmlAttribute list>) docType elements expectedTagEnd parentTagName (tokens:HtmlToken list) =
+            let parse' = parse' callstack
+
+            let recursiveReturn (dt, tokens, content) =
+                if callstack.Count = 0
+                then (dt, tokens, content)
+                else
+                    let _, elements, expectedTagEnd, parentTagName, name, attributes = callstack.Pop()
+                    let e = HtmlElement(name, attributes, content)
+                    parse' dt (e :: elements) expectedTagEnd parentTagName tokens
+
             match tokens with
             | DocType dt :: rest -> parse' (dt.Trim()) elements expectedTagEnd parentTagName rest
             | Tag(_, "br", []) :: rest ->
@@ -807,9 +819,8 @@ module internal HtmlParser =
                 parse' docType elements expectedTagEnd parentTagName (implicitlyCloseByEndTag expectedTagEnd tokens)
 
             | Tag(_, name, attributes) :: rest ->
-                let dt, tokens, content = parse' docType [] name expectedTagEnd rest
-                let e = HtmlElement(name, attributes, content)
-                parse' dt (e :: elements) expectedTagEnd parentTagName tokens
+                (docType, elements, expectedTagEnd, parentTagName, name, attributes) |> callstack.Push
+                parse' docType [] name expectedTagEnd rest
             | TagEnd name :: _ when name <> expectedTagEnd && name = parentTagName ->
                 // insert missing closing tag
                 parse' docType elements expectedTagEnd parentTagName (TagEnd expectedTagEnd :: tokens)
@@ -817,7 +828,7 @@ module internal HtmlParser =
                 // ignore this token if not the expected end tag (or it's reverse, eg: <li></il>)
                 parse' docType elements expectedTagEnd parentTagName rest
             | TagEnd _ :: rest -> 
-                docType, rest, List.rev elements
+                recursiveReturn (docType, rest, List.rev elements)
             | Text cont :: rest ->
                 if cont = "" then
                     // ignore this token
@@ -831,10 +842,10 @@ module internal HtmlParser =
             | CData cont :: rest -> 
                 let c = HtmlCData cont
                 parse' docType (c :: elements) expectedTagEnd parentTagName rest
-            | EOF :: _ -> docType, [], List.rev elements
-            | [] -> docType, [], List.rev elements
+            | EOF :: _ -> recursiveReturn (docType, [], List.rev elements)
+            | [] -> recursiveReturn (docType, [], List.rev elements)
         let tokens = tokenise reader 
-        let docType, _, elements = tokens |> parse' "" [] "" ""
+        let docType, _, elements = tokens |> parse' (new Stack<_>()) "" [] "" ""
         if List.isEmpty elements then
             failwith "Invalid HTML" 
         docType, elements


### PR DESCRIPTION
There's one non-tail-recursive call, which is the one when stepping into a tag
to parse its children.  This change adds a manual callstack to the function
onto which we push the variables in the closure before continuing to the
child tokens.  Then in the places where we were returning, call a helper
to pop the stack and include the logic that originally followed the recursive call.

This should represent no change in behavior, only a resiliency against
StackOverflowException.