### PR TITLE
Fix StackOverflow exception caused by many ampersand and semicolins i…

### DIFF
--- a/src/FSharp.Data/FSharp.Data.fsproj
+++ b/src/FSharp.Data/FSharp.Data.fsproj
@@ -9,6 +9,9 @@
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
+    <Tailcalls>true</Tailcalls>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Net\Http.fs" />
     <Compile Include="..\CommonRuntime\IO.fs" />

--- a/tests/FSharp.Data.Tests/HtmlParser.fs
+++ b/tests/FSharp.Data.Tests/HtmlParser.fs
@@ -129,6 +129,19 @@ let ``Can handle attributes with no value``() =
         ]
     node.Attributes() |> should equal expected
 
+[<Test>]
+let ``Can handle long html encoded attributes without StackOverflow``() = 
+    let html =
+        HtmlNode.Parse (
+            let sb = new System.Text.StringBuilder()
+            sb.Append "<html><body><p attrib=\"" |> ignore
+            for i in 0 .. 50000 do sb.Append "&lt;br/&gt;" |> ignore
+            sb.Append "\">Test</p></html></body>" |> ignore
+            sb.ToString()
+        )
+    let result = html.Head.InnerText()
+    result |> should equal "Test"
+
 [<TestCase("var r = \"</script>\"")>]
 [<TestCase("var r = '</script>'")>]
 [<TestCase("var r = /</g")>]


### PR DESCRIPTION
…n attribute values

The original attributeValueCharRef function took a continutation parameter that was always a reference back to the caller. Splitting this into two functions (one where each case is handled) removes the non-tail recursive call.

This can occur if an html attribute has a bunch of encoded html inside of it