### PR TITLE
Updating license in nuspec

### DIFF
--- a/nuget/FSharp.Data.nuspec
+++ b/nuget/FSharp.Data.nuspec
@@ -6,7 +6,7 @@
     <version>@build.number@</version>
     <authors>@authors@</authors>
     <owners>@authors@</owners>
-    <licenseUrl>http://github.com/fsharp/FSharp.Data/blob/master/LICENSE.md</licenseUrl>
+    <license type="expression">Apache-2.0</license>
     <projectUrl>http://fsharp.github.io/FSharp.Data</projectUrl>
     <iconUrl>https://raw.github.com/fsharp/FSharp.Data/master/misc/logo.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
NuGet packages are moving away from using `licenseUrl` to a `license` field (see [this announcement](https://github.com/NuGet/Announcements/issues/32)).

The spec for the change is [here](https://github.com/NuGet/Home/wiki/Packaging-License-within-the-nupkg).

This change updates the FSharp.Data nuspec file to use the new format.