### PR TITLE
#1212 CssSelect fails when there is no html tag

### DIFF
--- a/src/Html/HtmlCssSelectors.fs
+++ b/src/Html/HtmlCssSelectors.fs
@@ -382,7 +382,7 @@ module CssSelectorExtensions =
         /// Gets descendants matched by Css selector
         [<Extension>]
         static member CssSelect(doc:HtmlDocument, selector) = 
-             CssSelectorExtensions.Select (doc.Elements()) selector
+            CssSelectorExtensions.Select (doc.Elements()) selector
         
         /// Gets descendants matched by Css selector
         [<Extension>]

--- a/src/Html/HtmlCssSelectors.fs
+++ b/src/Html/HtmlCssSelectors.fs
@@ -1,4 +1,4 @@
-﻿namespace FSharp.Data
+namespace FSharp.Data
 
 open System
 open FSharp.Data
@@ -382,7 +382,7 @@ module CssSelectorExtensions =
         /// Gets descendants matched by Css selector
         [<Extension>]
         static member CssSelect(doc:HtmlDocument, selector) = 
-            CssSelectorExtensions.Select [doc.Html()] selector
+             CssSelectorExtensions.Select (doc.Elements()) selector
         
         /// Gets descendants matched by Css selector
         [<Extension>]

--- a/src/Html/HtmlOperations.fs
+++ b/src/Html/HtmlOperations.fs
@@ -1,4 +1,4 @@
-﻿namespace FSharp.Data
+namespace FSharp.Data
 
 open System
 open FSharp.Data

--- a/tests/FSharp.Data.Tests/HtmlCssSelectors.fs
+++ b/tests/FSharp.Data.Tests/HtmlCssSelectors.fs
@@ -1,4 +1,4 @@
-﻿#if INTERACTIVE
+#if INTERACTIVE
 #r "../../bin/lib/net45/FSharp.Data.dll"
 #r "../../bin/typeproviders/fsharp41/net45/FSharp.Data.Experimental.dll"
 #r "../../packages/test/NUnit/lib/net45/nunit.framework.dll"
@@ -466,3 +466,50 @@ let ``selector outside body tag``() =
     selection |> should haveLength 1
     let values = selection |> List.map (fun n -> n.InnerText())
     values |> should equal ["Page Title"]
+
+[<Test>]
+let ``page without html tag``() = 
+    let html = """
+        <head>
+            <title>Page Title</title>
+        </head>
+        <body>
+            <div id="example" >Content<div>
+        </body>""" |> HtmlDocument.Parse
+    let titleSelection = html.CssSelect "title"
+    titleSelection |> should haveLength 1
+    let titleValue = titleSelection |> List.map (fun n -> n.InnerText())
+    titleValue |> should equal ["Page Title"]
+    let divSelection = html.CssSelect "#example"
+    divSelection |> should haveLength 1
+    let divValue = divSelection |> List.map (fun n -> n.InnerText())
+    divValue |> should equal ["Content"]
+
+[<Test>]
+let ``page without html and head tags``() = 
+    let html = """
+        <body>
+            <div id="example" >Content<div>
+        </body>""" |> HtmlDocument.Parse
+    let selection = html.CssSelect "#example"
+    selection |> should haveLength 1
+    let values = selection |> List.map (fun n -> n.InnerText())
+    values |> should equal ["Content"]
+
+[<Test>]
+let ``page without html, head and body tags``() = 
+    let html = """
+        <div>
+            <div id="example">Content</div>
+            <div class="example">more content</div>
+        </div>
+        """ |> HtmlDocument.Parse
+
+    let firstDivSelection = html.CssSelect "#example"
+    firstDivSelection |> should haveLength 1
+    let firstDivValue = firstDivSelection |> List.map (fun n -> n.InnerText())
+    firstDivValue |> should equal ["Content"]
+    let secondDivSelection = html.CssSelect ".example"
+    secondDivSelection |> should haveLength 1
+    let secondDivValue = secondDivSelection |> List.map (fun n -> n.InnerText())
+    secondDivValue |> should equal ["more content"]

--- a/tests/FSharp.Data.Tests/HtmlParser.fs
+++ b/tests/FSharp.Data.Tests/HtmlParser.fs
@@ -1,4 +1,4 @@
-﻿#if INTERACTIVE
+#if INTERACTIVE
 #r "../../bin/lib/net45/FSharp.Data.dll"
 #r "../../packages/test/NUnit/lib/net45/nunit.framework.dll"
 #r "../../packages/test/FsUnit/lib/net46/FsUnit.NUnit.dll"
@@ -563,6 +563,21 @@ let ``Can handle html with doctype and xml namespaces``() =
                       "xmlns", "http://www.w3.org/1999/xhtml" ], 
                     [ HtmlNode.NewElement("body", [ HtmlNode.NewText "content" ]) ]) ])
     expected |> should equal htmlDoc
+
+[<Test>]
+let ``Can handle html without html tag``() = 
+   let html = """<body>
+       <div>no html-tag</div>
+       </body>"""
+
+   let htmlDoc = HtmlDocument.Parse html
+    
+   let expected = 
+       HtmlDocument.New 
+           [ HtmlNode.NewElement
+                 ("body", 
+                  [ HtmlNode.NewElement("div", [ HtmlNode.NewText "no html-tag" ])]) ]
+   expected |> should equal htmlDoc
 
 [<Test>]
 let ``Can find header when nested in a div``() = 


### PR DESCRIPTION
Fix for #1212 

When calling `CssSelect` on an `HtmlDocument`, it first selects the html tag and applies the selector to that to find matching descendants. But if the `HtmlDocument` doesn't have an html tag this fails and according to the [HTML Specificaton](https://html.spec.whatwg.org/multipage/syntax.html#optional-tags) this is valid.
I changed the implementation of  `CssSelect(doc:HtmlDocument, selector)` from `doc.Html()` to `doc.Elements()` in order to apply the selector to all the root tags of the document. If the root tag is html, then it will work as before, but now it will also work if you have a page that omits it and therefore has multiple root tags, like for example:
```
 <head>
    <title>Hello</title>
  </head>
  <body>
    <p>Welcome to this example.</p>
  </body>
```

Please let me know if there are any issues with this fix or if there is anything I can improve.