### PR TITLE
Modified escaping of query string parameters

### DIFF
--- a/src/Net/Http.fs
+++ b/src/Net/Http.fs
@@ -1505,11 +1505,6 @@ type Http private() =
     static member internal EncodeFormData (query:string) =
         (WebUtility.UrlEncode query).Replace("+","%20")
 
-    // EscapeUriString doesn't encode the & and # characters which cause issues, but EscapeDataString encodes too much making the url hard to read
-    // So we use EscapeUriString and manually replace the two problematic characters
-    static member private EncodeUrlParam (param: string) = 
-        (Uri.EscapeUriString param).Replace("&", "%26").Replace("#", "%23")
-
     /// Appends the query parameters to the url, taking care of proper escaping
     static member internal AppendQueryToUrl(url:string, query) =
         match query with
@@ -1517,7 +1512,7 @@ type Http private() =
         | query ->
             url
             + if url.Contains "?" then "&" else "?"
-            + String.concat "&" [ for k, v in query -> Http.EncodeUrlParam k + "=" + Http.EncodeUrlParam v ]
+            + String.concat "&" [ for k, v in query -> Uri.EscapeDataString k + "=" + Uri.EscapeDataString v ]
 
     static member private InnerRequest
             (

--- a/tests/FSharp.Data.DesignTime.Tests/SignatureTestCases.config
+++ b/tests/FSharp.Data.DesignTime.Tests/SignatureTestCases.config
@@ -33,7 +33,6 @@ Xml,TypeInference.xml,false,false,,false,
 Xml,SampleAzureServiceManagement.xml,false,false,,true,
 Xml,TimeSpans.xml,false,false,,true,
 Xml,,false,false,,false,po.xsd
-Xml,,false,false,,false,http://europa.eu/rapid/conf/RSS20.xsd
 Xml,,false,false,,false,homonim.xsd
 Xml,,false,false,,false,IncludeFromWeb.xsd
 Json,WorldBank.json,false,WorldBank,,true

--- a/tests/FSharp.Data.Tests/Http.fs
+++ b/tests/FSharp.Data.Tests/Http.fs
@@ -185,4 +185,15 @@ let ``escaping of url parameters`` () =
     ]
 
     Http.AppendQueryToUrl(url, queryParams)
-    |> should equal "https://graph.microsoft.com/beta/me/insights/shared?$select=Property1,Property2/SubProperty,*&$filter=Subject%20eq%20'A?%20%26%20%23B%20=%20C/D'&$top=10&$expand=ExtendedProperties($filter=PropertyId%20eq%20'String%20%7B36FF76DC-215F-4246-9544-DAB709259CE8%7D%20Name%20Some/Property2.0')&$orderby=Property2%20desc"
+    |> should equal "https://graph.microsoft.com/beta/me/insights/shared?%24select=Property1%2CProperty2%2FSubProperty%2C%2A&%24filter=Subject%20eq%20%27A%3F%20%26%20%23B%20%3D%20C%2FD%27&%24top=10&%24expand=ExtendedProperties%28%24filter%3DPropertyId%20eq%20%27String%20%7B36FF76DC-215F-4246-9544-DAB709259CE8%7D%20Name%20Some%2FProperty2.0%27%29&%24orderby=Property2%20desc"
+
+[<Test>]
+let ``escaping of reserve characters in query`` () =
+    let url = "http://nevermind.com"
+    let queryParams = [
+        "key!", "v@lue1"
+        "key#", "value2&(value:/?#[]@*+,;=)"
+    ]
+
+    Http.AppendQueryToUrl(url, queryParams)
+    |> should equal "http://nevermind.com?key%21=v%40lue1&key%23=value2%26%28value%3A%2F%3F%23%5B%5D%40%2A%2B%2C%3B%3D%29"


### PR DESCRIPTION
fixes #1263 

Escape query strings using `Uri.EscapeDataString` instead of `Uri.EscapeUriString`, this should correctly escape all URI reserve characters so they can be used as literals in query strings.

- Updated failing test
- Added specific unit test