### PR TITLE
multipart/form-data must use CRLF line breaks

### DIFF
--- a/src/Net/Http.fs
+++ b/src/Net/Http.fs
@@ -1359,7 +1359,7 @@ module private HttpHelpers =
                 [ prefixedBoundary
                   HttpRequestHeaders.ContentDisposition("form-data", Some formField, Some fileName) |> printHeader
                   HttpRequestHeaders.ContentType contentType |> printHeader ]
-                |> String.concat Environment.NewLine
+                |> String.concat "\r\n"
             let headerStream =
                 let bytes = e.GetBytes headerpart
                 new MemoryStream(bytes) :> Stream


### PR DESCRIPTION
Fixes #1313
`Environment.NewLine` equals `\n` on unix like systems that leads to invalid payload with LF line breaks:
```
--define a custom boundary here<LF>
Content-Disposition: form-data; name="images"; filename="image0.png"<LF>
Content-Type: image/png<CRLF>
...
```

From https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html 

>  The boundary must be followed immediately either by another CRLF and the header fields for the next part, or by two CRLFs, in which case there are no header fields for the next part (and it is therefore assumed to be of Content-Type text/plain).