### PR TITLE
Fix html parsing for incomplete tags

### DIFF
--- a/src/Html/HtmlParser.fs
+++ b/src/Html/HtmlParser.fs
@@ -657,6 +657,7 @@ module internal HtmlParser =
         and tagName isEndTag state =
             match state.Peek() with
             | TextParser.Whitespace _ -> state.Pop(); beforeAttributeName state
+            | TextParser.EndOfFile _ -> state.EmitTag(isEndTag)
             | '/' -> state.Pop(); selfClosingStartTag state
             | '>' -> state.Pop(); state.EmitTag(isEndTag)
             | _ -> state.ConsTag(); tagName isEndTag state
@@ -684,6 +685,7 @@ module internal HtmlParser =
             | '>' -> state.Pop(); state.EmitTag(false)
             | TextParser.LetterDigit _ -> state.ConsAttrName(); attributeName state
             | TextParser.Whitespace _ -> afterAttributeName state
+            | TextParser.EndOfFile _ -> state.EmitTag(false)
             | _ -> state.ConsAttrName(); attributeName state
         and afterAttributeName state =
             match state.Peek() with
@@ -695,6 +697,7 @@ module internal HtmlParser =
         and beforeAttributeValue state =
             match state.Peek() with
             | TextParser.Whitespace _ -> state.Pop(); beforeAttributeValue state
+            | TextParser.EndOfFile _ -> state.EmitTag(false)
             | '/' -> state.Pop(); selfClosingStartTag state
             | '>' -> state.Pop(); state.EmitTag(false)
             | '"' -> state.Pop(); attributeValueQuoted '"' state

--- a/tests/FSharp.Data.Tests/HtmlParser.fs
+++ b/tests/FSharp.Data.Tests/HtmlParser.fs
@@ -907,3 +907,13 @@ let ``Parsing non-html content doesn't cause an infinite loop - Github-1264``() 
             HtmlNode.NewText content
         ]
     result |> should equal expected
+
+[<Test; Timeout(2000)>]
+let ``Can handle incomplete tags at end of file without creating an infinite loop``() =
+    let result = HtmlDocument.Parse """<html><head></head></html"""
+    let expected = 
+        HtmlDocument.New
+            [ HtmlNode.NewElement
+                ("html",
+                    [ HtmlNode.NewElement("head")])]
+    result |> should equal expected


### PR DESCRIPTION
fix for #1394
If the last tag of an html string wasn't closed with `>`, it would get stuck in an infinite loop. Adding pattern match cases for `EOF` that close the tag normally fixes it.
```fsharp
HtmlDocument.Parse("""<html></html""") // parses normally now
```
also added a test
