### PR TITLE
[Repo Assist] ci: add NuGet cache to release workflow

### DIFF
--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -20,6 +20,13 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.400
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/paket.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
     - name: Restore .NET local tools
       run: dotnet tool restore
     - name: Restore packages


### PR DESCRIPTION
The PR workflow has NuGet package caching but the release/publish workflow
does not. This adds the same cache step to speed up the release build.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
