### PR TITLE
[Repo Assist] ci: add job-level timeout-minutes to prevent runaway builds

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -10,6 +10,7 @@ jobs:
   build-windows:
 
     runs-on: windows-latest
+    timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET Core 8
@@ -35,6 +36,7 @@ jobs:
   build-ubuntu:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET Core 8

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -13,6 +13,7 @@ jobs:
   build:
 
     runs-on: windows-latest
+    timeout-minutes: 60
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Add timeout-minutes to all CI jobs:
- pull-requests.yml: 40 minutes per job (build + test typically takes ~10-15 min)
- push-master.yml: 60 minutes (includes docs generation, pack, publish)

Without timeouts a stalled job can consume GitHub Actions minutes
for up to 6 hours (the default).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
