### PR TITLE
[Repo Assist] ci: add GitHub Actions to Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,14 @@
 
 version: 2
 updates:
- - package-ecosystem: "devcontainers"
-   directory: "/"
-   schedule:
-     interval: weekly
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - "enhancement"


### PR DESCRIPTION
Extend Dependabot configuration to track GitHub Actions versions. The existing config only covered devcontainers; this adds weekly monitoring for all actions used in pull-requests.yml and push-master.yml (actions/checkout, actions/setup-dotnet, actions/cache, peaceiris/actions-gh-pages).

Also normalise indentation in dependabot.yml from 1-space to 2-space to match standard YAML style.