### PR TITLE
[Repo Assist] ci: update .NET SDK from 8.0.400 to 8.0.418 and align global.json

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core 8
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 8.0.400
+        dotnet-version: 8.0.418
     - name: Cache NuGet packages
       uses: actions/cache@v5
       with:
@@ -42,7 +42,7 @@ jobs:
     - name: Setup .NET Core 8
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 8.0.400
+        dotnet-version: 8.0.418
     - name: Cache NuGet packages
       uses: actions/cache@v5
       with:

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup .NET Core 8
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 8.0.400
+        dotnet-version: 8.0.418
     - name: Cache NuGet packages
       uses: actions/cache@v5
       with:

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.119",
-    "rollForward": "major"
+    "version": "8.0.418",
+    "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
- Bump dotnet-version from 8.0.400 to 8.0.418 (latest .NET 8 patch) in
  pull-requests.yml (windows and ubuntu jobs) and push-master.yml
- Update global.json version from 8.0.119 to 8.0.418 for consistency
- Change global.json rollForward from 'major' (which would allow .NET 9/10)
  to 'latestMinor' (stay within .NET 8.x, use latest available patch)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
