### PR TITLE
[Repo Assist] Update fsdocs-tool to 22.0.0-alpha.3 and FSharp.Formatting 22.0.0-alpha.3

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "fsdocs-tool": {
-      "version": "20.0.1",
+      "version": "22.0.0-alpha.3",
       "commands": [
         "fsdocs"
       ],

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -13,10 +13,10 @@ jobs:
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v6
-    - name: Setup .NET Core 8
+    - name: Setup .NET 10
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 8.0.418
+        dotnet-version: 10.0.201
     - name: Cache NuGet packages
       uses: actions/cache@v5
       with:
@@ -39,10 +39,10 @@ jobs:
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v6
-    - name: Setup .NET Core 8
+    - name: Setup .NET 10
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 8.0.418
+        dotnet-version: 10.0.201
     - name: Cache NuGet packages
       uses: actions/cache@v5
       with:

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - name: Setup .NET Core 8
+    - name: Setup .NET 10
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 8.0.418
+        dotnet-version: 10.0.201
     - name: Cache NuGet packages
       uses: actions/cache@v5
       with:

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.418",
+    "version": "10.0.201",
     "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
- Update fsdocs-tool from 20.0.1 to 22.0.0-alpha.3 (uses FSharp.Formatting 22.0.0-alpha.3)
- Update global.json SDK from 8.0.418 to 10.0.201 (required by fsdocs-tool 22.x)
- Update CI workflows to use .NET 10.0.201

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
