### PR TITLE
Fix stability, resource, and correctness bugs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,22 @@
 # Release Notes
 
+## 8.2.0 - Jul 06 2026
+
+- Fix: HTML hexadecimal character references (`&#x41;`) are now decoded correctly; previously digit-only hex refs were parsed as decimal and refs containing `a`–`f` were left as literal text.
+- Fix: HTML table parsing clamps `colspan`/`rowspan` to the HTML spec limits (1000/65534) and no longer materializes unbounded ranges — malicious/malformed span attributes previously caused `OverflowException`, out-of-memory, or hangs.
+- Fix: `HtmlNode.ToString()` uses an explicit work stack, so deeply nested documents (which already parsed fine) no longer crash serialization with an uncatchable `StackOverflowException`.
+- Fix: `Http` multipart uploads no longer truncate when a source stream returns a partial read (e.g. network/gzip streams), and multipart parts of 2GB or more no longer overflow. User-supplied body streams are now disposed even when the upload faults.
+- Fix: `Http` `Range` headers in the RFC 7233 open-ended (`bytes=N-`) and suffix (`bytes=-N`) forms no longer throw `FormatException`.
+- Fix: `CsvFile.Rows` with `skipRows` re-applies the skip on repeated enumerations; previously the second enumeration returned garbage rows or threw.
+- Fix: `CsvFile.Save` now quotes headers, fields containing a lone `\r`, and fields containing any of the document's separators, so saved CSV round-trips correctly. `Save(TextWriter)` no longer disposes the caller-owned writer (it flushes instead).
+- Fix: JsonProvider-generated constructors no longer throw `OverflowException` for `NaN`, infinite, or very large `float` values; such values serialize through `JsonValue.Float`.
+- Fix: the JSON parser no longer silently swallows a stray `/` as whitespace (e.g. `[1, /2]` previously parsed as `[1, 2]`).
+- Fix: the in-memory cache no longer overflows `Int32` for expirations over ~24.8 days (which could crash the host process via an unhandled thread-pool exception), and a concurrently re-set entry can no longer be evicted by a stale expiration check. The file cache writes via temp-file-and-rename so concurrent readers never observe half-written entries.
+- Fix: file-watcher subscriptions are synchronized; concurrent subscribe/change events could corrupt the subscription dictionary and crash the IDE host at design time. Provider instance ids are now allocated with `Interlocked.Increment` and the design-time dispose-action set is locked.
+- Fix: the design-time web cache key now includes the `Encoding` (and row-limit) parameters, so two providers reading the same URL with different encodings no longer share the first decode.
+- Fix: WorldBank no longer caches HTTP-200 error bodies (which poisoned the cache for 30 days); invalid responses now go through the retry logic. Topics whose indicators are all filtered out by `Sources` return an empty collection instead of throwing `KeyNotFoundException`. Country/indicator codes are escaped with `Uri.EscapeDataString`, preventing URL path/query injection.
+- Fix: `XmlProvider` record creation no longer corrupts the structure when an intermediate path segment has the same name as the leaf (e.g. nested elements named `item`).
+
 ## 8.1.14 - May 09 2026
 
 - Eng: Remove manual `AssemblyInfo*.fs` files; use SDK-generated assembly attributes instead.

--- a/src/FSharp.Data.Csv.Core/CsvRuntime.fs
+++ b/src/FSharp.Data.Csv.Core/CsvRuntime.fs
@@ -104,6 +104,7 @@ module private CsvHelpers =
           LineIterator: IEnumerator<string[] * int>
           ColumnCount: int
           HasHeaders: bool
+          SkipRows: int
           Separators: string
           Quote: char }
 
@@ -111,11 +112,21 @@ module private CsvHelpers =
     /// is accessed and then will call 'nextSeq' each time for all future GetEnumerator calls
     type private ReentrantEnumerable<'T>(firstSeq: seq<'T>, nextSeq: unit -> seq<'T>) =
         let mutable first = true
+        let sync = obj ()
 
         interface seq<'T> with
             member x.GetEnumerator() =
-                if first then
-                    first <- false
+                // synchronized so concurrent enumerations cannot both claim 'firstSeq'
+                // and end up sharing one live reader
+                let isFirst =
+                    lock sync (fun () ->
+                        if first then
+                            first <- false
+                            true
+                        else
+                            false)
+
+                if isFirst then
                     firstSeq.GetEnumerator()
                 else
                     nextSeq().GetEnumerator()
@@ -165,6 +176,7 @@ module private CsvHelpers =
           LineIterator = linesIterator
           ColumnCount = numberOfColumns
           HasHeaders = hasHeaders
+          SkipRows = skipRows
           Separators = separators
           Quote = quote }
 
@@ -181,6 +193,7 @@ module private CsvHelpers =
           LineIterator = linesIterator
           ColumnCount = numberOfColumns
           HasHeaders = hasHeaders
+          SkipRows = skipRows
           Separators = separators
           Quote = quote }
         =
@@ -205,6 +218,8 @@ module private CsvHelpers =
         let nextSeq () =
             let reader: TextReader = newReader ()
             let csv = CsvReader.readCsvFile reader separators quote
+            // re-apply skipRows exactly like the first read did, then the header row
+            let csv = if skipRows > 0 then Seq.skip skipRows csv else csv
             if hasHeaders then Seq.skip 1 csv else csv
 
         let untypedRows = ReentrantEnumerable<_>(firstSeq, nextSeq)
@@ -459,8 +474,6 @@ type CsvFile<'RowType>
         let quote = (defaultArg quote x.Quote).ToString()
         let doubleQuote = quote + quote
 
-        use writer = writer
-
         // RFC 4180 (https://www.rfc-editor.org/rfc/rfc4180)
         // 2.  Definition of the CSV Format
         // Each record is located on a separated line, delimited by a line break CRLF
@@ -471,6 +484,22 @@ type CsvFile<'RowType>
             | null -> String.Empty
             | _ -> str
 
+        // quote fields containing any of the document's separators (not just the one
+        // used for saving), the quote char, or a line break (a bare CR also terminates
+        // a row when re-parsing, so it needs quoting like LF)
+        let charsNeedingQuoting =
+            (x.Separators + separator + quote + "\r\n").ToCharArray() |> Array.distinct
+
+        let writeEscaped (item: string) =
+            let item = item |> nullSafeguard
+
+            if item.IndexOfAny(charsNeedingQuoting) >= 0 then
+                writer.Write quote
+                writer.Write(item.Replace(quote, doubleQuote))
+                writer.Write quote
+            else
+                writer.Write item
+
         let writeLine writeItem (items: string[]) =
             for i = 0 to items.Length - 2 do
                 writeItem items.[i]
@@ -480,25 +509,15 @@ type CsvFile<'RowType>
             writer.WriteLine()
 
         match x.Headers with
-        | Some headers -> headers |> writeLine writer.Write
+        | Some headers -> headers |> writeLine writeEscaped
         | None -> ()
 
         for row in x.Rows do
-            row
-            |> rowToStringArray.Invoke
-            |> writeLine (fun item ->
-                let item = item |> nullSafeguard
+            row |> rowToStringArray.Invoke |> writeLine writeEscaped
 
-                if
-                    item.IndexOf(separator, StringComparison.Ordinal) >= 0
-                    || item.IndexOf(quote, StringComparison.Ordinal) >= 0
-                    || item.IndexOf('\n') >= 0
-                then
-                    writer.Write quote
-                    writer.Write(item.Replace(quote, doubleQuote))
-                    writer.Write quote
-                else
-                    writer.Write item)
+        // the writer is owned by the caller and must not be disposed here,
+        // but buffered output should be visible when Save returns
+        writer.Flush()
 
     /// Saves CSV to the specified stream
     member x.Save(stream: Stream, [<Optional>] ?separator, [<Optional>] ?quote) =

--- a/src/FSharp.Data.DesignTime/CommonProviderImplementation/Helpers.fs
+++ b/src/FSharp.Data.DesignTime/CommonProviderImplementation/Helpers.fs
@@ -85,10 +85,11 @@ type DisposableTypeProviderForNamespaces(config, ?assemblyReplacementMap) as x =
 
     static let mutable idCount = 0
 
-    let id = idCount
+    // IDE hosts can construct provider instances concurrently; an unsynchronized
+    // read-then-increment could hand two instances the same id, breaking the
+    // (fullTypeName, id) keys used for dispose actions and file watchers
+    let id = System.Threading.Interlocked.Increment(&idCount)
     let filesToWatch = Dictionary()
-
-    do idCount <- idCount + 1
 
     let dispose typeNameOpt =
         lock lockObj (fun () ->
@@ -317,12 +318,23 @@ module internal ProviderHelpers =
 
                     let sample =
                         if isWeb uri then
+                            // the cached value is the decoded (and possibly row-limited) text,
+                            // so the key must include everything that affects it, not just the URL
+                            let cacheKey =
+                                sprintf
+                                    "%s|encoding=%s|maxRows=%s"
+                                    uri.OriginalString
+                                    encodingStr
+                                    (match maxNumberOfRows with
+                                     | Some n -> string n
+                                     | None -> "")
+
                             let text =
-                                match webUrisCache.TryRetrieve(uri.OriginalString) with
+                                match webUrisCache.TryRetrieve(cacheKey) with
                                 | Some text -> text
                                 | None ->
                                     let text = readText ()
-                                    webUrisCache.Set(uri.OriginalString, text)
+                                    webUrisCache.Set(cacheKey, text)
                                     text
 
                             text
@@ -375,7 +387,9 @@ module internal ProviderHelpers =
 
         let setupDisposeAction providedType fileToWatch =
 
-            if activeDisposeActions.Add(fullTypeName, tp.Id) then
+            // synchronized: getOrCreateProvidedType can run concurrently on IDE threads
+            // and HashSet mutation is not thread-safe
+            if lock activeDisposeActions (fun () -> activeDisposeActions.Add(fullTypeName, tp.Id)) then
 
                 log "Setting up dispose action"
 

--- a/src/FSharp.Data.Html.Core/HtmlCharRefs.fs
+++ b/src/FSharp.Data.Html.Core/HtmlCharRefs.fs
@@ -2260,15 +2260,16 @@ module internal HtmlCharRefs =
 
             match delimeters with
             | ("&#", _) ->
-                let num =
+                let styles, num =
                     if discriminator <> 'x' then
-                        s.Substring(2, s.Length - 2)
+                        NumberStyles.Integer, s.Substring(2, s.Length - 2)
                     else
-                        s.Substring(3, s.Length - 3)
+                        NumberStyles.AllowHexSpecifier, s.Substring(3, s.Length - 3)
 
-                match UInt32.TryParse(num, NumberStyles.Integer, CultureInfo.InvariantCulture) with
+                match UInt32.TryParse(num, styles, CultureInfo.InvariantCulture) with
                 | true, i -> Number(i)
                 | false, _ -> Lookup(orig)
+            // legacy hex form without the '#', e.g. &x41;
             | ("&x", _) ->
                 let num = s.Substring(2, s.Length - 2)
 

--- a/src/FSharp.Data.Html.Core/HtmlNode.fs
+++ b/src/FSharp.Data.Html.Core/HtmlNode.fs
@@ -119,18 +119,24 @@ type HtmlNode =
     static member NewCData content = HtmlCData(content)
 
     override x.ToString() =
-        let rec serialize (sb: StringBuilder) indentation canAddNewLine insidePre html =
-            let append (str: string) = sb.Append str |> ignore
+        let sb = StringBuilder()
+        let append (str: string) = sb.Append str |> ignore
 
-            let appendEndTag name =
-                append "</"
-                append name
-                append ">"
+        let appendEndTag name =
+            append "</"
+            append name
+            append ">"
 
-            let newLine plus =
-                sb.AppendLine() |> ignore
-                sb.Append(' ', indentation + plus) |> ignore
+        let newLine indentation plus =
+            sb.AppendLine() |> ignore
+            sb.Append(' ', indentation + plus) |> ignore
 
+        // serialization uses an explicit work stack instead of call-stack recursion:
+        // the parser accepts arbitrarily deep documents (it uses its own stack), so
+        // ToString must not StackOverflow on them either
+        let work = System.Collections.Generic.Stack<unit -> unit>()
+
+        let rec serialize indentation canAddNewLine insidePre html =
             match html with
             | HtmlElement(name, attributes, elements) ->
                 let onlyText =
@@ -143,7 +149,7 @@ type HtmlNode =
                 let nowInsidePre = insidePre || isPreTag
 
                 if canAddNewLine && not insidePre && not (onlyText || isPreTag) then
-                    newLine 0
+                    newLine indentation 0
 
                 append "<"
                 append name
@@ -164,18 +170,23 @@ type HtmlNode =
                     append ">"
 
                     if not insidePre && not (onlyText || isPreTag) then
-                        newLine 2
+                        newLine indentation 2
 
-                    let mutable canAddNewLine = false
+                    // pushed first so it runs after all children are processed
+                    work.Push(fun () ->
+                        if not insidePre && not (onlyText || isPreTag) then
+                            newLine indentation 0
 
-                    for element in elements do
-                        serialize sb (indentation + 2) canAddNewLine nowInsidePre element
-                        canAddNewLine <- true
+                        appendEndTag name)
 
-                    if not insidePre && not (onlyText || isPreTag) then
-                        newLine 0
+                    // push children in reverse so they pop in document order;
+                    // only the first child is serialized with canAddNewLine = false
+                    let elements = List.toArray elements
 
-                    appendEndTag name
+                    for i in elements.Length - 1 .. -1 .. 0 do
+                        let element = elements.[i]
+                        let canAddNewLine = i > 0
+                        work.Push(fun () -> serialize (indentation + 2) canAddNewLine nowInsidePre element)
             | HtmlText str -> append str
             | HtmlComment str ->
                 append "<!--"
@@ -186,8 +197,11 @@ type HtmlNode =
                 append str
                 append "]]>"
 
-        let sb = StringBuilder()
-        serialize sb 0 false false x |> ignore
+        serialize 0 false false x
+
+        while work.Count > 0 do
+            work.Pop () ()
+
         sb.ToString()
 
     /// <exclude />

--- a/src/FSharp.Data.Html.Core/HtmlRuntime.fs
+++ b/src/FSharp.Data.Html.Core/HtmlRuntime.fs
@@ -288,11 +288,13 @@ module HtmlRuntime =
         index
         (table: HtmlNode, parents: HtmlNode list)
         =
+        // the HTML spec caps rowspan at 65534 and colspan at 1000; without the cap a
+        // malicious/malformed attribute overflows the column-count sum or allocates huge arrays
         let rowSpan cell =
-            max 1 (defaultArg (TextConversions.AsInteger CultureInfo.InvariantCulture cell?rowspan) 0)
+            min 65534 (max 1 (defaultArg (TextConversions.AsInteger CultureInfo.InvariantCulture cell?rowspan) 0))
 
         let colSpan cell =
-            max 1 (defaultArg (TextConversions.AsInteger CultureInfo.InvariantCulture cell?colspan) 0)
+            min 1000 (max 1 (defaultArg (TextConversions.AsInteger CultureInfo.InvariantCulture cell?colspan) 0))
 
         let rows =
             let header =
@@ -347,10 +349,9 @@ module HtmlRuntime =
                         while col_i < res.[rowindex].Length && res.[rowindex].[col_i] <> Empty do
                             col_i <- col_i + 1
 
-                        for j in [ col_i .. (col_i + colSpan cell - 1) ] do
-                            for i in [ rowindex .. (rowindex + rowSpan cell - 1) ] do
-                                if i < rows.Length && j < numberOfColumns then
-                                    res.[i].[j] <- data
+                        for j in col_i .. min (col_i + colSpan cell - 1) (numberOfColumns - 1) do
+                            for i in rowindex .. min (rowindex + rowSpan cell - 1) (rows.Length - 1) do
+                                res.[i].[j] <- data
 
                 let numberOfHeaderRows =
                     res |> Array.countWhile (Array.forall (fun cell -> cell.IsHeader))

--- a/src/FSharp.Data.Http/Http.fs
+++ b/src/FSharp.Data.Http/Http.fs
@@ -1471,19 +1471,15 @@ module internal HttpHelpers =
             match streams |> Seq.tryHead with
             | None -> 0
             | Some stream ->
-                let qty =
-                    if stream.CanSeek then
-                        min count (int stream.Length)
-                    else
-                        count
+                let read = stream.Read(buffer, offset, count)
 
-                let read = stream.Read(buffer, offset, qty)
-
-                if read < count then
+                if read = 0 then
+                    // only a zero-byte read signals the end of the current stream: Read may
+                    // legally return fewer bytes than requested while data is still pending
+                    // (network/gzip/pipe streams), so a partial read must not skip the stream
                     stream.Dispose()
                     streams <- streams |> Seq.skip 1
-                    let readFromRest = readFromStream buffer (offset + read) (count - read)
-                    read + readFromRest
+                    readFromStream buffer offset count
                 else
                     read
 
@@ -1615,9 +1611,12 @@ module internal HttpHelpers =
 
     let asyncCopy (source: Stream) (dest: Stream) =
         async {
-            do! source.CopyToAsync(dest) |> Async.AwaitIAsyncResult |> Async.Ignore
-
-            source.Dispose()
+            try
+                do! source.CopyToAsync(dest) |> Async.AwaitIAsyncResult |> Async.Ignore
+            finally
+                // dispose user-supplied body streams even when the copy faults
+                // (e.g. connection reset mid-upload)
+                source.Dispose()
         }
 
     let writeBody (req: HttpWebRequest) (data: Stream) =
@@ -1747,7 +1746,12 @@ module internal HttpHelpers =
                 if bytes.Length <> 2 then
                     failwithf "Invalid value for the Range header (%s)" value
 
-                req.AddRange(int64 bytes.[0], int64 bytes.[1])
+                // RFC 7233 also allows open-ended (bytes=N-) and suffix (bytes=-N) ranges
+                match bytes.[0], bytes.[1] with
+                | "", "" -> failwithf "Invalid value for the Range header (%s)" value
+                | rangeStart, "" -> req.AddRange(int64 rangeStart)
+                | "", suffixLength -> req.AddRange(-(int64 suffixLength))
+                | rangeStart, rangeEnd -> req.AddRange(int64 rangeStart, int64 rangeEnd)
             | "proxy-authorization" -> req.Headers.[HeaderEnum.ProxyAuthorization] <- value
             | "referer" -> req.Referer <- value
             | "te" -> req.Headers.[HeaderEnum.Te] <- value

--- a/src/FSharp.Data.Json.Core/JsonRuntime.fs
+++ b/src/FSharp.Data.Json.Core/JsonRuntime.fs
@@ -320,6 +320,17 @@ type JsonRuntime =
             | None -> JsonValue.Null
             | Some v -> f v
 
+        // NaN, infinities and values outside the decimal range cannot be converted
+        // to decimal; they must go through JsonValue.Float instead of crashing
+        let floatToJson (v: float) =
+            if Double.IsNaN v || Double.IsInfinity v then
+                JsonValue.Float v
+            else
+                try
+                    JsonValue.Number(decimal v)
+                with :? OverflowException ->
+                    JsonValue.Float v
+
         match value with
         | null -> JsonValue.Null
         | :? Array as v -> JsonValue.Array [| for elem in v -> JsonRuntime.ToJsonValue cultureInfo elem |]
@@ -330,7 +341,7 @@ type JsonRuntime =
         | :? TimeSpan as v -> v.ToString("g", cultureInfo) |> JsonValue.String
         | :? int as v -> JsonValue.Number(decimal v)
         | :? int64 as v -> JsonValue.Number(decimal v)
-        | :? float as v -> JsonValue.Number(decimal v)
+        | :? float as v -> floatToJson v
         | :? decimal as v -> JsonValue.Number v
         | :? bool as v -> JsonValue.Boolean v
         | :? Guid as v -> v.ToString() |> JsonValue.String
@@ -346,7 +357,7 @@ type JsonRuntime =
             optionToJson (fun (ts: TimeSpan) -> ts.ToString("g", cultureInfo) |> JsonValue.String) v
         | :? option<int> as v -> optionToJson (decimal >> JsonValue.Number) v
         | :? option<int64> as v -> optionToJson (decimal >> JsonValue.Number) v
-        | :? option<float> as v -> optionToJson (decimal >> JsonValue.Number) v
+        | :? option<float> as v -> optionToJson floatToJson v
         | :? option<decimal> as v -> optionToJson JsonValue.Number v
         | :? option<bool> as v -> optionToJson JsonValue.Boolean v
         | :? option<Guid> as v -> optionToJson (fun (g: Guid) -> g.ToString() |> JsonValue.String) v

--- a/src/FSharp.Data.Json.Core/JsonValue.fs
+++ b/src/FSharp.Data.Json.Core/JsonValue.fs
@@ -275,16 +275,15 @@ type private JsonParser(jsonText: string) =
             // Supported comment syntax:
             // - // ...{newLine}
             // - /* ... */
-            if i < s.Length && s.[i] = '/' then
-                i <- i + 1
-
-                if i < s.Length && s.[i] = '/' then
-                    i <- i + 1
+            // a lone '/' is not a comment and must be left for the parser to reject
+            if i + 1 < s.Length && s.[i] = '/' && (s.[i + 1] = '/' || s.[i + 1] = '*') then
+                if s.[i + 1] = '/' then
+                    i <- i + 2
 
                     while i < s.Length && (s.[i] <> '\r' && s.[i] <> '\n') do
                         i <- i + 1
-                else if i < s.Length && s.[i] = '*' then
-                    i <- i + 1
+                else
+                    i <- i + 2
 
                     while i + 1 < s.Length && (s.[i] <> '*' || s.[i + 1] <> '/') do
                         i <- i + 1

--- a/src/FSharp.Data.Runtime.Utilities/Caching.fs
+++ b/src/FSharp.Data.Runtime.Utilities/Caching.fs
@@ -3,6 +3,7 @@ module internal FSharp.Data.Runtime.Caching
 
 open System
 open System.Collections.Concurrent
+open System.Collections.Generic
 open System.Diagnostics
 open System.IO
 open System.Security.Cryptography
@@ -20,14 +21,17 @@ let createInMemoryCache (expiration: TimeSpan) =
 
     let rec invalidationFunction key =
         async {
-            do! Async.Sleep(int expiration.TotalMilliseconds)
+            // expirations over ~24.8 days overflow Int32 milliseconds; clamp and loop
+            // (the timestamp is re-checked after waking, so a short sleep just re-arms)
+            do! Async.Sleep(int (min expiration.TotalMilliseconds (float Int32.MaxValue)))
 
             match dict.TryGetValue(key) with
-            | true, (_, timestamp) ->
+            | true, ((_, timestamp) as entry) ->
                 if DateTime.UtcNow - timestamp >= expiration then
-                    match dict.TryRemove(key) with
-                    | true, _ -> log (sprintf "Cache expired: %O" key)
-                    | _ -> ()
+                    // conditional removal so a concurrent Set with a fresh timestamp
+                    // is not evicted between the check and the remove
+                    if (dict :> ICollection<KeyValuePair<_, _>>).Remove(KeyValuePair(key, entry)) then
+                        log (sprintf "Cache expired: %O" key)
                 else
                     do! invalidationFunction key
             | _ -> ()
@@ -99,14 +103,31 @@ let createInternetFileCache prefix expiration =
                 member _.Set(key, value) =
                     let cacheFile = cacheFile key
 
+                    // write to a temp file and move it into place so that concurrent readers
+                    // (other threads or processes sharing the cache folder) never observe a
+                    // partially written cache entry
+                    let tempFile = cacheFile + "." + Guid.NewGuid().ToString("N") + ".tmp"
+
                     try
-                        File.WriteAllText(cacheFile, value)
-                    with e ->
-                        Debug.WriteLine(
-                            "Caching: Failed to write file {0} with an exception: {1}",
-                            cacheFile,
-                            e.Message
-                        )
+                        try
+                            File.WriteAllText(tempFile, value)
+
+                            if File.Exists cacheFile then
+                                File.Delete cacheFile
+
+                            File.Move(tempFile, cacheFile)
+                        with e ->
+                            Debug.WriteLine(
+                                "Caching: Failed to write file {0} with an exception: {1}",
+                                cacheFile,
+                                e.Message
+                            )
+                    finally
+                        if File.Exists tempFile then
+                            try
+                                File.Delete tempFile
+                            with _ ->
+                                ()
 
                 member _.TryRetrieve(key, ?extendCacheExpiration) =
                     if extendCacheExpiration = Some true then

--- a/src/FSharp.Data.Runtime.Utilities/IO.fs
+++ b/src/FSharp.Data.Runtime.Utilities/IO.fs
@@ -153,8 +153,10 @@ type private FileWatcher(path: string) =
         if lastWrite <> curr then
             log (sprintf "File %s: %s" action path)
             lastWrite <- curr
-            // creating a copy since the handler can be unsubscribed during the iteration
-            let handlers = subscriptions.Values |> Seq.toArray
+            // snapshot under lock: this runs on FileSystemWatcher callback threads while
+            // Subscribe/Unsubscribe mutate the dictionary from other threads, and handlers
+            // can also unsubscribe during the iteration
+            let handlers = lock subscriptions (fun () -> subscriptions.Values |> Seq.toArray)
 
             for handler in handlers do
                 handler ()
@@ -164,20 +166,22 @@ type private FileWatcher(path: string) =
         watcher.Renamed.Add(checkForChanges "renamed")
         watcher.Deleted.Add(checkForChanges "deleted")
 
-    member _.Subscribe(name, action) = subscriptions.Add(name, action)
+    member _.Subscribe(name, action) =
+        lock subscriptions (fun () -> subscriptions.Add(name, action))
 
     member _.Unsubscribe(name) =
-        if subscriptions.Remove(name) then
-            log (sprintf "Unsubscribed %s from %s watcher" name path)
+        lock subscriptions (fun () ->
+            if subscriptions.Remove(name) then
+                log (sprintf "Unsubscribed %s from %s watcher" name path)
 
-            if subscriptions.Count = 0 then
-                log (sprintf "Disposing %s watcher" path)
-                watcher.Dispose()
-                true
+                if subscriptions.Count = 0 then
+                    log (sprintf "Disposing %s watcher" path)
+                    watcher.Dispose()
+                    true
+                else
+                    false
             else
-                false
-        else
-            false
+                false)
 
 let private watchers = Dictionary<string, FileWatcher>()
 

--- a/src/FSharp.Data.WorldBank.Core/WorldBankRuntime.fs
+++ b/src/FSharp.Data.WorldBank.Core/WorldBankRuntime.fs
@@ -44,13 +44,29 @@ module Implementation =
     type internal ServiceConnection(restCache: ICache<_, _>, serviceUrl: string, sources) =
 
         let worldBankUrl (functions: string list) (props: (string * string) list) =
+            // each function is a single path segment: EscapeDataString escapes '/', '?', '#'
+            // and '&' so runtime-supplied codes cannot rewrite the request path or query
             let url =
-                serviceUrl :: (List.map Uri.EscapeUriString functions) |> String.concat "/"
+                serviceUrl :: (List.map Uri.EscapeDataString functions) |> String.concat "/"
 
             let query = [ "per_page", "1000"; "format", "json" ] @ props
             Http.AppendQueryToUrl(url, query)
 
         // The WorldBank data changes very slowly indeed (monthly updates to values, rare updates to schema), hence caching it is ok.
+
+        // the API returns HTTP 200 with an error body (e.g. [{"message":[...]}]) for
+        // throttled/invalid requests; caching such a body would poison the cache for its
+        // whole expiration, so only valid paged documents may be cached or returned
+        let isValidPagedResponse (doc: string) =
+            try
+                match JsonValue.Parse doc with
+                | JsonValue.Array items when items.Length > 0 ->
+                    match items.[0] with
+                    | JsonValue.Record fields -> fields |> Array.exists (fun (k, _) -> k = "pages")
+                    | _ -> false
+                | _ -> false
+            with _ ->
+                false
 
         let rec worldBankRequest attempt funcs args : Async<string> =
             async {
@@ -78,10 +94,19 @@ module Implementation =
                                  else doc)
                         )
 
-                        if not (String.IsNullOrEmpty doc) then
+                        if isValidPagedResponse doc then
                             restCache.Set(url, doc)
-
-                        return doc
+                            return doc
+                        else
+                            // raising here routes error bodies through the retry logic below,
+                            // which handles transient throttling
+                            return
+                                failwithf
+                                    "Invalid response from '%s': %s"
+                                    url
+                                    (if isNull doc then "null"
+                                     elif doc.Length > 200 then doc.[0..199] + "..."
+                                     else doc)
                     with e ->
                         Debug.WriteLine(sprintf "[WorldBank] error: %s" (e.ToString()))
 
@@ -369,8 +394,12 @@ type IIndicatorsDescriptions =
 type IndicatorsDescriptions internal (connection: ServiceConnection, topicCode) =
     let indicatorsDescriptions =
         seq {
-            for indicatorId in connection.IndicatorsByTopic.[topicCode] ->
-                IndicatorDescription(connection, topicCode, indicatorId)
+            // a topic property is generated for every topic, but indicators may all have
+            // been filtered out by the Sources parameter — yield an empty sequence then
+            match connection.IndicatorsByTopic.TryGetValue topicCode with
+            | true, indicatorIds ->
+                for indicatorId in indicatorIds -> IndicatorDescription(connection, topicCode, indicatorId)
+            | false, _ -> ()
         }
 
     interface IIndicatorsDescriptions with

--- a/src/FSharp.Data.Xml.Core/XmlRuntime.fs
+++ b/src/FSharp.Data.Xml.Core/XmlRuntime.fs
@@ -287,19 +287,19 @@ type XmlRuntime =
 
         let createElement (parent: XElement) (nameWithNS: string) =
             let namesWithNS = nameWithNS.Split '|'
+            let lastIndex = namesWithNS.Length - 1
 
-            (parent, namesWithNS)
-            ||> Array.fold (fun parent nameWithNS ->
+            (parent, Array.indexed namesWithNS)
+            ||> Array.fold (fun parent (i, nameWithNS) ->
                 let xname = XName.Get nameWithNS
 
                 if isNull parent then
                     XElement xname
                 else
-                    let element =
-                        if nameWithNS = Seq.last namesWithNS then
-                            null
-                        else
-                            parent.Element(xname)
+                    // the final segment always creates a fresh element; intermediate
+                    // segments are detected by position, not by name, so a path like
+                    // "item|item" reuses the existing wrapper element
+                    let element = if i = lastIndex then null else parent.Element(xname)
 
                     if isNull element then
                         let element = XElement xname

--- a/tests/FSharp.Data.Core.Tests/Caching.fs
+++ b/tests/FSharp.Data.Core.Tests/Caching.fs
@@ -247,3 +247,11 @@ let ``ICache interface consistency between implementations``() =
     
     testOperations memoryCache "memory"
     testOperations fileCache "file"
+
+[<Test>]
+let ``InMemoryCache handles expirations longer than Int32 milliseconds``() =
+    // 30 days is ~2.6e9 ms, which overflows Int32; Set must not schedule a
+    // negative sleep (which would throw on a thread-pool thread)
+    let cache = createInMemoryCache (TimeSpan.FromDays 30.0)
+    cache.Set("longLived", "value")
+    cache.TryRetrieve("longLived") |> should equal (Some "value")

--- a/tests/FSharp.Data.Core.Tests/CsvFile.fs
+++ b/tests/FSharp.Data.Core.Tests/CsvFile.fs
@@ -71,11 +71,27 @@ Name,Age
 John,25
 Jane,30"""
     let csv = CsvFile.Parse(csvData, skipRows=2)
-    
+
     csv.Headers |> should equal (Some [| "Name"; "Age" |])
     let rows = csv.Rows |> Array.ofSeq
     rows.Length |> should equal 2
     rows.[0].Columns |> should equal [| "John"; "25" |]
+
+[<Test>]
+let ``CsvFile.Parse with skipRows supports repeated enumeration`` () =
+    let csvData = """Comment line 1
+Comment line 2
+Name,Age
+John,25
+Jane,30"""
+    let csv = CsvFile.Parse(csvData, skipRows=2)
+
+    // the second enumeration re-reads the source and must skip the same prologue rows
+    let firstPass = csv.Rows |> Array.ofSeq
+    let secondPass = csv.Rows |> Array.ofSeq
+    firstPass.Length |> should equal 2
+    secondPass.Length |> should equal 2
+    secondPass.[0].Columns |> should equal [| "John"; "25" |]
 
 [<Test>]
 let ``CsvFile.Parse handles ignoreErrors`` () =

--- a/tests/FSharp.Data.Core.Tests/CsvRuntimeOperations.fs
+++ b/tests/FSharp.Data.Core.Tests/CsvRuntimeOperations.fs
@@ -259,3 +259,43 @@ let ``Chaining Skip and Truncate works correctly`` () =
     let rows = result.Rows |> Seq.toArray
     rows |> should haveLength 2
     rows.[0].["Name"] |> should equal "Bob"
+
+// ============================================================
+// Save round-trip fidelity
+// ============================================================
+
+[<Test>]
+let ``SaveToString quotes headers containing the separator`` () =
+    let csv = CsvFile.Parse("\"Name, First\",Age\r\nJohn,25")
+    let saved = csv.SaveToString()
+    saved |> should startWith "\"Name, First\",Age"
+    let reloaded = CsvFile.Parse(saved)
+    reloaded.Headers |> should equal (Some [| "Name, First"; "Age" |])
+
+[<Test>]
+let ``SaveToString quotes fields containing a lone carriage return`` () =
+    // a bare CR terminates a row when re-parsing, so it must be quoted like LF
+    let csv = CsvFile.Parse("A,B\r\n\"x\ry\",2")
+    let saved = csv.SaveToString()
+    let reloaded = CsvFile.Parse(saved)
+    let rows = reloaded.Rows |> Seq.toArray
+    rows |> should haveLength 1
+    rows.[0].Columns |> should equal [| "x\ry"; "2" |]
+
+[<Test>]
+let ``SaveToString quotes fields containing any of the document separators`` () =
+    let csv = CsvFile.Parse("A;B\r\n1;\"x,y\"", separators = ";,")
+    let saved = csv.SaveToString()
+    let reloaded = CsvFile.Parse(saved, separators = ";,")
+    let rows = reloaded.Rows |> Seq.toArray
+    rows |> should haveLength 1
+    rows.[0].Columns |> should equal [| "1"; "x,y" |]
+
+[<Test>]
+let ``Save does not dispose the caller-supplied writer`` () =
+    let csv = CsvFile.Parse(sampleCsv)
+    use sw = new StringWriter()
+    csv.Save(sw)
+    // writing after Save must work: the writer belongs to the caller
+    sw.Write("still-open")
+    sw.ToString() |> should contain "still-open"

--- a/tests/FSharp.Data.Core.Tests/HtmlCharRefs.fs
+++ b/tests/FSharp.Data.Core.Tests/HtmlCharRefs.fs
@@ -36,7 +36,20 @@ let ``Should substitute char references in attribute``() =
 
 [<Test>]
 let ``Should handle indeterminate CharRefs``() =
-    HtmlCharRefs.substitute "&#xD;" |> should equal "&#xD;"
+    HtmlCharRefs.substitute "&#xG;" |> should equal "&#xG;"
+
+[<Test>]
+let ``Should decode hexadecimal numeric character references``() =
+    HtmlCharRefs.substitute "&#x41;" |> should equal "A"
+    HtmlCharRefs.substitute "&#X42;" |> should equal "B"
+    HtmlCharRefs.substitute "&#xD;" |> should equal "\r"
+    HtmlCharRefs.substitute "&#xff;" |> should equal "ÿ"
+    HtmlCharRefs.substitute "&#x1F600;" |> should equal "\U0001F600"
+
+[<Test>]
+let ``Should decode decimal numeric character references``() =
+    HtmlCharRefs.substitute "&#65;" |> should equal "A"
+    HtmlCharRefs.substitute "&#255;" |> should equal "ÿ"
 
 [<Test>]
 let ``Should handle Unicode characters above 655355``() =

--- a/tests/FSharp.Data.Core.Tests/HtmlNodeSerialization.fs
+++ b/tests/FSharp.Data.Core.Tests/HtmlNodeSerialization.fs
@@ -223,3 +223,16 @@ let ``HtmlNode constructed with NewElement round-trips to same string`` () =
     let lis = uls.[0].Descendants() |> Seq.filter (fun n -> n.Name() = "li") |> Seq.toList
     lis.Length |> should equal 2
 
+// ─────────────────────────────────────────────────────────────────────────────
+// HtmlNode.ToString() — deeply nested documents
+// ─────────────────────────────────────────────────────────────────────────────
+
+[<Test>]
+let ``Serialization of deeply nested elements does not overflow the stack`` () =
+    // the parser handles arbitrary nesting with an explicit stack, so ToString must too
+    let depth = 10000
+    let html = String.replicate depth "<div>" + "x" + String.replicate depth "</div>"
+    let doc = HtmlDocument.Parse html
+    let serialized = doc.ToString()
+    serialized.Contains "x" |> should equal true
+

--- a/tests/FSharp.Data.Core.Tests/HtmlParser.fs
+++ b/tests/FSharp.Data.Core.Tests/HtmlParser.fs
@@ -1019,3 +1019,24 @@ let ``Drops inter-block whitespace but keeps inline whitespace``() =
         |> Seq.map HtmlNode.innerText
         |> Seq.toList
     result |> should equal [ "A B"; "C" ]
+
+[<Test>]
+let ``Table with a huge colspan does not overflow or allocate huge arrays``() =
+    // spans are clamped to the HTML spec limits, so a malicious colspan can neither
+    // overflow the checked column-count sum nor allocate columns per claimed span
+    let html = """<html><body><table id="t">
+        <tr><th>A</th><th>B</th><th>C</th></tr>
+        <tr><td>1</td><td>2</td><td colspan="2147483647">BIG</td></tr>
+        </table></body></html>"""
+    let tables = HtmlDocument.Parse html |> getTables false
+    tables.Length |> should equal 1
+
+[<Test>]
+let ``Table with a huge rowspan terminates and stays bounded by the actual rows``() =
+    let html = """<html><body><table id="t">
+        <tr><th>A</th><th>B</th></tr>
+        <tr><td rowspan="2000000000">1</td><td>2</td></tr>
+        <tr><td>3</td></tr>
+        </table></body></html>"""
+    let tables = HtmlDocument.Parse html |> getTables false
+    tables.Length |> should equal 1

--- a/tests/FSharp.Data.Core.Tests/Http.fs
+++ b/tests/FSharp.Data.Core.Tests/Http.fs
@@ -385,6 +385,22 @@ let ``Seekable streams create Seekable CombinedStream`` () =
     let combinedStream = HttpHelpers.writeMultipart "-" multiparts Encoding.UTF8
     combinedStream.Length |> should equal result
     combinedStream.CanSeek |> should equal true
+
+[<Test>]
+let ``CombinedStream does not treat a partial read as end of stream`` () =
+    // Stream.Read may legally return fewer bytes than requested while more data is
+    // pending (network/gzip/pipe streams); the CombinedStream must not skip to the
+    // next stream (truncating multipart uploads) when that happens
+    let partialReadStream (data: byte[]) =
+        { new MemoryStream(data) with
+            override x.Read(buffer, offset, count) = base.Read(buffer, offset, min count 3) } :> Stream
+
+    let s1 = partialReadStream [| 1uy .. 10uy |]
+    let s2 = partialReadStream [| 11uy .. 20uy |]
+    use combined = new HttpHelpers.CombinedStream(Some 20L, [ s1; s2 ])
+    use result = new MemoryStream()
+    combined.CopyTo(result)
+    result.ToArray() |> should equal [| 1uy .. 20uy |]
     
 #nowarn "44" // Use of deprecated HttpWebRequest
 

--- a/tests/FSharp.Data.Core.Tests/JsonRuntime.fs
+++ b/tests/FSharp.Data.Core.Tests/JsonRuntime.fs
@@ -351,9 +351,20 @@ let ``JsonDocument.CreateList should handle multiple JSON objects`` () =
 {"b": 2}
 {"c": 3}"""
     use reader = new StringReader(jsonText)
-    
+
     let docType = typeof<JsonDocument>
     let createListMethod = docType.GetMethod("CreateList", [| typeof<TextReader> |])
     let docs = createListMethod.Invoke(null, [| reader |]) :?> IJsonDocument[]
-    
+
     docs.Length |> should equal 3
+
+[<Test>]
+let ``CreateValue handles floats not representable as decimal`` () =
+    // NaN, infinities and out-of-decimal-range floats must not crash with OverflowException;
+    // non-finite floats serialize as null per JSON
+    JsonRuntime.CreateValue(box Double.NaN, "").JsonValue.ToString() |> should equal "null"
+    JsonRuntime.CreateValue(box Double.PositiveInfinity, "").JsonValue.ToString() |> should equal "null"
+    JsonRuntime.CreateValue(box 1e300, "").JsonValue |> should equal (JsonValue.Float 1e300)
+    JsonRuntime.CreateValue(box (Some 1e300), "").JsonValue |> should equal (JsonValue.Float 1e300)
+    // ordinary floats keep their decimal-backed representation
+    JsonRuntime.CreateValue(box 1.5, "").JsonValue |> should equal (JsonValue.Number 1.5m)

--- a/tests/FSharp.Data.Core.Tests/JsonValue.fs
+++ b/tests/FSharp.Data.Core.Tests/JsonValue.fs
@@ -617,6 +617,14 @@ let ``JsonValue parsing with multi-line comment containing slash`` () =
     result?x.AsInteger() |> should equal 2
 
 [<Test>]
+let ``JsonValue parsing rejects a stray slash`` () =
+    // Bug: a lone '/' (not starting // or /*) was silently consumed as whitespace,
+    // so invalid documents like [1, /2] parsed as [1, 2]
+    (fun () -> JsonValue.Parse "[1, /2]" |> ignore) |> should throw typeof<Exception>
+    (fun () -> JsonValue.Parse "1 /" |> ignore) |> should throw typeof<Exception>
+    (fun () -> JsonValue.Parse """{"a" / : 1}""" |> ignore) |> should throw typeof<Exception>
+
+[<Test>]
 let ``JsonValue parsing with multi-line comment containing both asterisk and slash`` () =
     let json = "{ /* a/b * c */ \"x\": 3 }"
     let result = JsonValue.Parse json

--- a/tests/FSharp.Data.Core.Tests/TextConversions.fs
+++ b/tests/FSharp.Data.Core.Tests/TextConversions.fs
@@ -189,7 +189,7 @@ let ``DateTimeOffset conversions`` () =
 [<Test>]
 let ``DateTimeOffset conversions with additional formats``() =
   let culture = CultureInfo.InvariantCulture
-  
+
   // More timezone formats
   TextConversions.AsDateTimeOffset culture "2020-01-01T12:00:00+05:30" |> Option.isSome |> should equal true
   TextConversions.AsDateTimeOffset culture "2020-01-01T12:00:00-08:00" |> Option.isSome |> should equal true


### PR DESCRIPTION
- HTML: decode hex charrefs (&#x41;) correctly; clamp table colspan/rowspan to spec limits (was OverflowException/OOM/hang on malicious spans); stack-safe HtmlNode.ToString (was uncatchable StackOverflow at ~5k nesting depth)
- HTTP: CombinedStream no longer treats partial reads as EOF (silent multipart truncation) and drops the 2GB int overflow; Range supports bytes=N-/-N; body streams disposed even when an upload faults
- CSV: skipRows survives re-enumeration of Rows; Save quotes headers, lone CR, and all document separators (round-trip corruption); Save(TextWriter) no longer disposes the caller-owned writer; reentrant enumeration synchronized
- JSON: NaN/inf/1e300 floats route through JsonValue.Float instead of throwing OverflowException; stray '/' no longer swallowed as whitespace
- Caching/IO: no Int32 overflow for >24.8-day expirations (could crash host); atomic temp-file-then-rename cache writes; conditional expiry removal; file-watcher subscriptions locked (IDE crash risk)
- WorldBank: HTTP-200 error bodies validated before caching (30-day cache poisoning); empty topics no longer throw KeyNotFoundException; URL segments escaped with EscapeDataString (path injection)
- XML: CreateRecord no longer corrupts structure for same-named nested paths
- DesignTime: Interlocked instance ids, locked dispose-action set, web cache key includes Encoding/row-limit parameters